### PR TITLE
Add work_order_claimed event type and payload convention docs

### DIFF
--- a/contracts/oar-openapi.yaml
+++ b/contracts/oar-openapi.yaml
@@ -1801,6 +1801,10 @@ components:
         actor_id: { type: string }
         event:
           $ref: '#/components/schemas/AnyObject'
+      description: >
+        Conventional event payloads are additive guidance for orchestrators.
+        For `event.type="work_order_claimed"`, `event.payload` should include:
+        `{ "work_order_id": "<artifact_id>", "actor_id": "<claiming_actor_id>" }`.
       required: [event]
 
     EventResponse:

--- a/contracts/oar-schema.yaml
+++ b/contracts/oar-schema.yaml
@@ -58,6 +58,7 @@ enums:
     values:
       - message_posted
       - work_order_created
+      - work_order_claimed
       - receipt_added
       - review_completed
       - decision_needed


### PR DESCRIPTION
## Summary
- add `work_order_claimed` to the canonical `event_type` open enum in `contracts/oar-schema.yaml`
- document the conventional payload shape for `event.type=work_order_claimed` in `contracts/oar-openapi.yaml`
- keep behavior non-enforcing: this remains orchestrator guidance only

## Testing
- `make contract-gen`
- `make contract-check`
- `make check`

Closes #6
