### PR TITLE
CLI: resolve 'me' actor-id alias from active profile

### DIFF
--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -279,7 +279,7 @@ func (a *App) runInboxCommand(ctx context.Context, args []string, cfg config.Res
 		result, err := a.invokeTypedJSON(ctx, cfg, "inbox list", "inbox.list", nil, nil, nil)
 		return result, "inbox list", err
 	case "ack":
-		body, err := a.parseAckBodyInput(args[1:])
+		body, err := a.parseAckBodyInput(args[1:], cfg)
 		if err != nil {
 			return nil, "inbox ack", err
 		}
@@ -318,7 +318,7 @@ func (a *App) runDerivedCommand(ctx context.Context, args []string, cfg config.R
 	if strings.TrimSpace(args[0]) != "rebuild" {
 		return nil, "derived", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown derived subcommand %q", strings.TrimSpace(args[0])))
 	}
-	body, err := a.parseJSONBodyInput(args[1:], "derived rebuild")
+	body, err := a.parseDerivedRebuildBodyInput(args[1:], cfg)
 	if err != nil {
 		return nil, "derived rebuild", err
 	}
@@ -762,7 +762,49 @@ func validateID(id string, label string) error {
 	return nil
 }
 
-func (a *App) parseAckBodyInput(args []string) (any, error) {
+func (a *App) parseDerivedRebuildBodyInput(args []string, cfg config.Resolved) (any, error) {
+	fs := newSilentFlagSet("derived rebuild")
+	var fromFileFlag, actorIDFlag trackedString
+	fs.Var(&fromFileFlag, "from-file", "Load JSON body from file path")
+	fs.Var(&actorIDFlag, "actor-id", "Actor id")
+	if err := fs.Parse(args); err != nil {
+		return nil, errnorm.Usage("invalid_flags", err.Error())
+	}
+	if len(fs.Args()) > 0 {
+		return nil, errnorm.Usage("invalid_args", "unexpected positional arguments for `oar derived rebuild`")
+	}
+
+	payload, err := a.readBodyInput(strings.TrimSpace(fromFileFlag.value))
+	if err != nil {
+		return nil, err
+	}
+
+	var body map[string]any
+	if len(payload) == 0 {
+		body = map[string]any{}
+	} else {
+		decoded, decodeErr := decodeJSONPayload(payload)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		parsed, ok := decoded.(map[string]any)
+		if !ok {
+			return nil, errnorm.Usage("invalid_request", "JSON body for `oar derived rebuild` must be an object")
+		}
+		body = parsed
+	}
+
+	actorID, err := resolveActorIDAlias(actorIDFlag.value, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if actorID != "" {
+		body["actor_id"] = actorID
+	}
+	return body, nil
+}
+
+func (a *App) parseAckBodyInput(args []string, cfg config.Resolved) (any, error) {
 	fs := newSilentFlagSet("inbox ack")
 	var fromFileFlag, threadIDFlag, inboxItemIDFlag, actorIDFlag trackedString
 	fs.Var(&fromFileFlag, "from-file", "Load JSON body from file path")
@@ -790,14 +832,36 @@ func (a *App) parseAckBodyInput(args []string) (any, error) {
 	if err := validateID(inboxItemIDFlag.value, "inbox item id"); err != nil {
 		return nil, err
 	}
+	actorID, err := resolveActorIDAlias(actorIDFlag.value, cfg)
+	if err != nil {
+		return nil, err
+	}
 	body := map[string]any{
 		"thread_id":     strings.TrimSpace(threadIDFlag.value),
 		"inbox_item_id": strings.TrimSpace(inboxItemIDFlag.value),
 	}
-	if strings.TrimSpace(actorIDFlag.value) != "" {
-		body["actor_id"] = strings.TrimSpace(actorIDFlag.value)
+	if actorID != "" {
+		body["actor_id"] = actorID
 	}
 	return body, nil
+}
+
+func resolveActorIDAlias(raw string, cfg config.Resolved) (string, error) {
+	actorID := strings.TrimSpace(raw)
+	if actorID == "" {
+		return "", nil
+	}
+	if actorID != "me" {
+		return actorID, nil
+	}
+	resolved := strings.TrimSpace(cfg.ActorID)
+	if resolved != "" {
+		return resolved, nil
+	}
+	return "", errnorm.Usage(
+		"invalid_request",
+		fmt.Sprintf("--actor-id me requires actor_id in active profile (%s)", strings.TrimSpace(cfg.ProfilePath)),
+	)
 }
 
 func (a *App) readBodyInput(fromFile string) ([]byte, error) {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -112,6 +112,123 @@ func TestTypedWorkflowCommands(t *testing.T) {
 	assertEnvelopeOK(t, runCLIForTest(t, home, env, nil, []string{"--json", "--base-url", server.URL, "inbox", "ack", "--thread-id", "thread_flow_1", "--inbox-item-id", "inbox:1"}))
 }
 
+func TestInboxAckActorIDMeAliasFromProfile(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/inbox/ack" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode inbox ack body: %v body=%s", err, string(body))
+		}
+		if got := strings.TrimSpace(anyStringValue(payload["actor_id"])); got != "actor-profile-1" {
+			t.Fatalf("expected actor_id from profile, got %q body=%s", got, string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"event":{"id":"event_ack_profile"}}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-a", `{"agent":"agent-a","actor_id":"actor-profile-1","access_token":"token-a","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"--agent", "agent-a",
+		"inbox", "ack",
+		"--thread-id", "thread_1",
+		"--inbox-item-id", "inbox:1",
+		"--actor-id", "me",
+	})
+	assertEnvelopeOK(t, raw)
+}
+
+func TestInboxAckActorIDMeRequiresProfileActorID(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-a", `{}`)
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--agent", "agent-a",
+		"inbox", "ack",
+		"--thread-id", "thread_1",
+		"--inbox-item-id", "inbox:1",
+		"--actor-id", "me",
+	})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "invalid_request" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	if !strings.Contains(anyStringValue(errObj["message"]), "requires actor_id") {
+		t.Fatalf("expected actor_id guidance, payload=%#v", payload)
+	}
+}
+
+func TestDerivedRebuildActorIDMeAliasFromProfile(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/derived/rebuild" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode derived rebuild body: %v body=%s", err, string(body))
+		}
+		if got := strings.TrimSpace(anyStringValue(payload["actor_id"])); got != "actor-profile-2" {
+			t.Fatalf("expected actor_id from profile, got %q body=%s", got, string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-b", `{"agent":"agent-b","actor_id":"actor-profile-2","access_token":"token-b","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"--agent", "agent-b",
+		"derived", "rebuild",
+		"--actor-id", "me",
+	})
+	assertEnvelopeOK(t, raw)
+}
+
+func TestDerivedRebuildActorIDMeRequiresProfileActorID(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-b", `{}`)
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--agent", "agent-b",
+		"derived", "rebuild",
+		"--actor-id", "me",
+	})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "invalid_request" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	if !strings.Contains(anyStringValue(errObj["message"]), "requires actor_id") {
+		t.Fatalf("expected actor_id guidance, payload=%#v", payload)
+	}
+}
+
 func TestArtifactContentRaw(t *testing.T) {
 	t.Parallel()
 
@@ -281,4 +398,16 @@ func TestTypedCommandUsageFailures(t *testing.T) {
 func Example_oarThreadsList() {
 	fmt.Println("oar --json threads list --status active")
 	// Output: oar --json threads list --status active
+}
+
+func writeAgentProfile(t *testing.T, home string, agent string, profileJSON string) {
+	t.Helper()
+	profilesDir := filepath.Join(home, ".config", "oar", "profiles")
+	if err := os.MkdirAll(profilesDir, 0o700); err != nil {
+		t.Fatalf("mkdir profiles dir: %v", err)
+	}
+	profilePath := filepath.Join(profilesDir, agent+".json")
+	if err := os.WriteFile(profilePath, []byte(profileJSON), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- resolve the literal token `me` for `--actor-id` flags using the active profile's `actor_id`
- return a clear `invalid_request` usage error when `--actor-id me` is used but the profile has no `actor_id`
- add `derived rebuild --actor-id` parsing so actor-id aliasing works there and matches existing command examples

## Validation
- make cli-check
- make check
- make e2e-smoke

Closes #7
