### PR TITLE
fix(cli): corrective subcommand guidance for subcommand errors

### DIFF
--- a/cli/internal/app/auth_commands.go
+++ b/cli/internal/app/auth_commands.go
@@ -12,10 +12,10 @@ import (
 
 func (a *App) runAuth(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "auth", errnorm.Usage("subcommand_required", "expected one of: register, whoami, update-username, rotate, revoke, token-status")
+		return nil, "auth", authSubcommandSpec.requiredError()
 	}
 	service := authcli.New(cfg)
-	subcommand := strings.TrimSpace(args[0])
+	subcommand := authSubcommandSpec.normalize(args[0])
 	switch subcommand {
 	case "register":
 		result, err := a.runAuthRegister(ctx, service, args[1:])
@@ -36,7 +36,7 @@ func (a *App) runAuth(ctx context.Context, args []string, cfg config.Resolved) (
 		result, err := a.runAuthTokenStatus(ctx, service)
 		return result, "auth token-status", err
 	default:
-		return nil, "auth", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown auth subcommand %q", subcommand))
+		return nil, "auth", authSubcommandSpec.unknownError(args[0])
 	}
 }
 

--- a/cli/internal/app/commands.go
+++ b/cli/internal/app/commands.go
@@ -54,10 +54,10 @@ func (a *App) runCommand(ctx context.Context, args []string, cfg config.Resolved
 		return name, result, err
 	case "api":
 		if len(args) < 2 {
-			return "api", nil, errnorm.Usage("subcommand_required", "expected `oar api call`")
+			return "api", nil, apiSubcommandSpec.requiredError()
 		}
-		if args[1] != "call" {
-			return "api", nil, errnorm.Usage("unknown_subcommand", "expected `oar api call`")
+		if apiSubcommandSpec.normalize(args[1]) != "call" {
+			return "api", nil, apiSubcommandSpec.unknownError(args[1])
 		}
 		result, err := a.runAPICall(ctx, args[2:], cfg)
 		return "api call", result, err

--- a/cli/internal/app/draft_commands.go
+++ b/cli/internal/app/draft_commands.go
@@ -37,7 +37,7 @@ func (a *App) runDraft(ctx context.Context, args []string, cfg config.Resolved) 
 	if len(args) == 0 || isHelpToken(args[0]) {
 		return &commandResult{Text: draftUsageText()}, "draft", nil
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := draftSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "create":
 		result, err := a.runDraftCreate(args[1:], cfg)
@@ -55,7 +55,7 @@ func (a *App) runDraft(ctx context.Context, args []string, cfg config.Resolved) 
 		result, err := a.runDraftDiscard(args[1:], cfg)
 		return result, "draft discard", err
 	default:
-		return nil, "draft", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown draft subcommand %q", sub))
+		return nil, "draft", draftSubcommandSpec.unknownError(args[0])
 	}
 }
 

--- a/cli/internal/app/meta_commands.go
+++ b/cli/internal/app/meta_commands.go
@@ -15,9 +15,9 @@ func (a *App) runMeta(_ context.Context, args []string, _ config.Resolved) (*com
 		if text, ok := generatedHelpText("meta"); ok {
 			return &commandResult{Text: text}, "meta", nil
 		}
-		return nil, "meta", errnorm.Usage("subcommand_required", "expected one of: commands, command, concepts, concept")
+		return nil, "meta", metaSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := metaSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "commands":
 		result, err := a.runMetaCommands(args[1:])
@@ -32,7 +32,7 @@ func (a *App) runMeta(_ context.Context, args []string, _ config.Resolved) (*com
 		result, err := a.runMetaConcept(args[1:])
 		return result, "meta concept", err
 	default:
-		return nil, "meta", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown meta subcommand %q", sub))
+		return nil, "meta", metaSubcommandSpec.unknownError(args[0])
 	}
 }
 

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -181,9 +181,9 @@ func (a *App) runTypedResource(ctx context.Context, resource string, args []stri
 
 func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "threads", errnorm.Usage("subcommand_required", "expected one of: list, get, create, patch, timeline, context")
+		return nil, "threads", threadsSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := threadsSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "list":
 		fs := newSilentFlagSet("threads list")
@@ -222,7 +222,7 @@ func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.R
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "threads create", "threads.create", nil, nil, body)
 		return result, "threads create", callErr
-	case "patch", "update":
+	case "patch":
 		id, body, err := a.parseIDAndBodyInput(args[1:], "thread-id", "thread id", "threads patch")
 		if err != nil {
 			return nil, "threads patch", err
@@ -274,15 +274,15 @@ func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.R
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "threads context", "threads.context", map[string]string{"thread_id": threadID}, query, nil)
 		return result, "threads context", callErr
 	default:
-		return nil, "threads", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown threads subcommand %q", sub))
+		return nil, "threads", threadsSubcommandSpec.unknownError(args[0])
 	}
 }
 
 func (a *App) runCommitmentsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "commitments", errnorm.Usage("subcommand_required", "expected one of: list, get, create, update")
+		return nil, "commitments", commitmentsSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := commitmentsSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "list":
 		fs := newSilentFlagSet("commitments list")
@@ -328,15 +328,15 @@ func (a *App) runCommitmentsCommand(ctx context.Context, args []string, cfg conf
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "commitments update", "commitments.patch", map[string]string{"commitment_id": id}, nil, body)
 		return result, "commitments update", callErr
 	default:
-		return nil, "commitments", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown commitments subcommand %q", sub))
+		return nil, "commitments", commitmentsSubcommandSpec.unknownError(args[0])
 	}
 }
 
 func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "artifacts", errnorm.Usage("subcommand_required", "expected one of: list, get, create, content")
+		return nil, "artifacts", artifactsSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := artifactsSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "list":
 		fs := newSilentFlagSet("artifacts list")
@@ -380,15 +380,15 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 		result, callErr := a.invokeArtifactContent(ctx, cfg, "artifacts content", map[string]string{"artifact_id": id})
 		return result, "artifacts content", callErr
 	default:
-		return nil, "artifacts", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown artifacts subcommand %q", sub))
+		return nil, "artifacts", artifactsSubcommandSpec.unknownError(args[0])
 	}
 }
 
 func (a *App) runDocsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "docs", errnorm.Usage("subcommand_required", "expected one of: create, get, update, history, revision")
+		return nil, "docs", docsSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := docsSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "create":
 		body, err := a.parseJSONBodyInput(args[1:], "docs create")
@@ -420,10 +420,10 @@ func (a *App) runDocsCommand(ctx context.Context, args []string, cfg config.Reso
 		return result, "docs history", callErr
 	case "revision":
 		if len(args) < 2 {
-			return nil, "docs revision", errnorm.Usage("subcommand_required", "expected `oar docs revision get`")
+			return nil, "docs revision", docsRevisionSubcommandSpec.requiredError()
 		}
-		if strings.TrimSpace(args[1]) != "get" {
-			return nil, "docs revision", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown docs revision subcommand %q", strings.TrimSpace(args[1])))
+		if docsRevisionSubcommandSpec.normalize(args[1]) != "get" {
+			return nil, "docs revision", docsRevisionSubcommandSpec.unknownError(args[1])
 		}
 		fs := newSilentFlagSet("docs revision get")
 		var documentIDFlag trackedString
@@ -466,15 +466,15 @@ func (a *App) runDocsCommand(ctx context.Context, args []string, cfg config.Reso
 		)
 		return result, "docs revision get", callErr
 	default:
-		return nil, "docs", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown docs subcommand %q", sub))
+		return nil, "docs", docsSubcommandSpec.unknownError(args[0])
 	}
 }
 
 func (a *App) runEventsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "events", errnorm.Usage("subcommand_required", "expected one of: get, create, stream, tail, explain")
+		return nil, "events", eventsSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := eventsSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "get":
 		id, err := parseIDArg(args[1:], "event-id", "event id")
@@ -503,7 +503,7 @@ func (a *App) runEventsCommand(ctx context.Context, args []string, cfg config.Re
 		result, err := a.runEventsExplainCommand(args[1:])
 		return result, "events explain", err
 	default:
-		return nil, "events", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown events subcommand %q", sub))
+		return nil, "events", eventsSubcommandSpec.unknownError(args[0])
 	}
 }
 
@@ -569,9 +569,9 @@ func (a *App) runEventsExplainCommand(args []string) (*commandResult, error) {
 
 func (a *App) runInboxCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "inbox", errnorm.Usage("subcommand_required", "expected one of: list, ack, stream")
+		return nil, "inbox", inboxSubcommandSpec.requiredError()
 	}
-	sub := strings.TrimSpace(args[0])
+	sub := inboxSubcommandSpec.normalize(args[0])
 	switch sub {
 	case "list":
 		result, err := a.invokeTypedJSON(ctx, cfg, "inbox list", "inbox.list", nil, nil, nil)
@@ -590,16 +590,17 @@ func (a *App) runInboxCommand(ctx context.Context, args []string, cfg config.Res
 		result, err := a.runInboxStream(ctx, args[1:], cfg, "inbox tail", true)
 		return result, "inbox tail", err
 	default:
-		return nil, "inbox", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown inbox subcommand %q", sub))
+		return nil, "inbox", inboxSubcommandSpec.unknownError(args[0])
 	}
 }
 
 func (a *App) runPacketsCreateCommand(ctx context.Context, resource string, commandID string, args []string, cfg config.Resolved) (*commandResult, string, error) {
+	spec := packetCreateSubcommandSpec(resource)
 	if len(args) == 0 {
-		return nil, resource, errnorm.Usage("subcommand_required", fmt.Sprintf("expected `%s create`", resource))
+		return nil, resource, spec.requiredError()
 	}
-	if strings.TrimSpace(args[0]) != "create" {
-		return nil, resource, errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown %s subcommand %q", resource, strings.TrimSpace(args[0])))
+	if spec.normalize(args[0]) != "create" {
+		return nil, resource, spec.unknownError(args[0])
 	}
 	body, err := a.parseJSONBodyInput(args[1:], resource+" create")
 	if err != nil {
@@ -611,10 +612,10 @@ func (a *App) runPacketsCreateCommand(ctx context.Context, resource string, comm
 
 func (a *App) runDerivedCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
 	if len(args) == 0 {
-		return nil, "derived", errnorm.Usage("subcommand_required", "expected `derived rebuild`")
+		return nil, "derived", derivedSubcommandSpec.requiredError()
 	}
-	if strings.TrimSpace(args[0]) != "rebuild" {
-		return nil, "derived", errnorm.Usage("unknown_subcommand", fmt.Sprintf("unknown derived subcommand %q", strings.TrimSpace(args[0])))
+	if derivedSubcommandSpec.normalize(args[0]) != "rebuild" {
+		return nil, "derived", derivedSubcommandSpec.unknownError(args[0])
 	}
 	body, err := a.parseDerivedRebuildBodyInput(args[1:], cfg)
 	if err != nil {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -112,6 +112,71 @@ func TestTypedWorkflowCommands(t *testing.T) {
 	assertEnvelopeOK(t, runCLIForTest(t, home, env, nil, []string{"--json", "--base-url", server.URL, "inbox", "ack", "--thread-id", "thread_flow_1", "--inbox-item-id", "inbox:1"}))
 }
 
+func TestInboxUnknownSubcommandGuidance(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "inbox", "10"})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "unknown_subcommand" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	message := anyStringValue(errObj["message"])
+	if !strings.Contains(message, "valid subcommands: list, ack, stream, tail") {
+		t.Fatalf("expected valid-subcommands guidance, got %q", message)
+	}
+	if !strings.Contains(message, "`oar inbox list`") || !strings.Contains(message, "`oar inbox ack --thread-id <thread-id> --inbox-item-id <inbox-item-id>`") {
+		t.Fatalf("expected concrete inbox examples, got %q", message)
+	}
+	if !strings.Contains(message, "did you mean `oar inbox ack --thread-id <thread-id> --inbox-item-id <inbox-item-id>`?") {
+		t.Fatalf("expected corrective suggestion, got %q", message)
+	}
+}
+
+func TestInboxGetAliasMapsToList(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/inbox" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"inbox:1","thread_id":"thread_1"}]}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "--base-url", server.URL, "inbox", "get"})
+	payload := assertEnvelopeOK(t, raw)
+	if got := anyStringValue(payload["command"]); got != "inbox list" {
+		t.Fatalf("expected alias to resolve to inbox list, got %q payload=%#v", got, payload)
+	}
+}
+
+func TestEventsUnknownSubcommandGuidance(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "events", "streem"})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "unknown_subcommand" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	message := anyStringValue(errObj["message"])
+	if !strings.Contains(message, "valid subcommands: get, create, stream, tail, explain") {
+		t.Fatalf("expected valid subcommands in message, got %q", message)
+	}
+	if !strings.Contains(message, "did you mean `oar events stream`?") {
+		t.Fatalf("expected stream correction, got %q", message)
+	}
+	if !strings.Contains(message, "`oar events stream --thread-id <thread-id> --follow`") || !strings.Contains(message, "`oar events tail --max-events 20`") {
+		t.Fatalf("expected stream/tail examples, got %q", message)
+	}
+}
+
 func TestDocsCommands(t *testing.T) {
 	t.Parallel()
 
@@ -653,6 +718,25 @@ func TestTypedCommandUsageFailures(t *testing.T) {
 	exitCode := cli.Run([]string{"--json", "threads", "patch", "--thread-id", "thread_1"})
 	if exitCode != 2 {
 		t.Fatalf("expected exit code 2, got %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestDocsRevisionSubcommandRequiredGuidance(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "docs", "revision"})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "subcommand_required" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	message := anyStringValue(errObj["message"])
+	if !strings.Contains(message, "expected one of: get") {
+		t.Fatalf("expected valid subcommands in required message, got %q", message)
+	}
+	if !strings.Contains(message, "`oar docs revision get --document-id <document-id> --revision-id <revision-id>`") {
+		t.Fatalf("expected usage examples in required message, got %q", message)
 	}
 }
 

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -1,0 +1,283 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"organization-autorunner-cli/internal/errnorm"
+)
+
+type subcommandSpec struct {
+	command  string
+	valid    []string
+	examples []string
+	aliases  map[string]string
+}
+
+var apiSubcommandSpec = subcommandSpec{
+	command:  "api",
+	valid:    []string{"call"},
+	examples: []string{"oar api call --method GET --path /health"},
+}
+
+var authSubcommandSpec = subcommandSpec{
+	command:  "auth",
+	valid:    []string{"register", "whoami", "update-username", "rotate", "revoke", "token-status"},
+	examples: []string{"oar auth register --username <username>", "oar auth whoami"},
+	aliases: map[string]string{
+		"status": "token-status",
+	},
+}
+
+var metaSubcommandSpec = subcommandSpec{
+	command:  "meta",
+	valid:    []string{"commands", "command", "concepts", "concept"},
+	examples: []string{"oar meta commands", "oar meta command --command-id threads.list"},
+}
+
+var draftSubcommandSpec = subcommandSpec{
+	command:  "draft",
+	valid:    []string{"create", "list", "commit", "discard"},
+	examples: []string{"oar draft list", "oar draft commit --draft-id <draft-id>"},
+}
+
+var threadsSubcommandSpec = subcommandSpec{
+	command:  "threads",
+	valid:    []string{"list", "get", "create", "patch", "timeline", "context"},
+	examples: []string{"oar threads list --status active", "oar threads patch --thread-id <thread-id>"},
+	aliases: map[string]string{
+		"ls":     "list",
+		"update": "patch",
+	},
+}
+
+var commitmentsSubcommandSpec = subcommandSpec{
+	command:  "commitments",
+	valid:    []string{"list", "get", "create", "update"},
+	examples: []string{"oar commitments list --status open", "oar commitments update --commitment-id <commitment-id>"},
+	aliases: map[string]string{
+		"ls": "list",
+	},
+}
+
+var artifactsSubcommandSpec = subcommandSpec{
+	command:  "artifacts",
+	valid:    []string{"list", "get", "create", "content"},
+	examples: []string{"oar artifacts list --kind packet", "oar artifacts content --artifact-id <artifact-id>"},
+	aliases: map[string]string{
+		"ls": "list",
+	},
+}
+
+var docsSubcommandSpec = subcommandSpec{
+	command:  "docs",
+	valid:    []string{"create", "get", "update", "history", "revision"},
+	examples: []string{"oar docs get --document-id <document-id>", "oar docs revision get --document-id <document-id> --revision-id <revision-id>"},
+}
+
+var docsRevisionSubcommandSpec = subcommandSpec{
+	command:  "docs revision",
+	valid:    []string{"get"},
+	examples: []string{"oar docs revision get --document-id <document-id> --revision-id <revision-id>"},
+}
+
+var eventsSubcommandSpec = subcommandSpec{
+	command:  "events",
+	valid:    []string{"get", "create", "stream", "tail", "explain"},
+	examples: []string{"oar events stream --thread-id <thread-id> --follow", "oar events tail --max-events 20"},
+	aliases: map[string]string{
+		"watch": "stream",
+	},
+}
+
+var inboxSubcommandSpec = subcommandSpec{
+	command:  "inbox",
+	valid:    []string{"list", "ack", "stream", "tail"},
+	examples: []string{"oar inbox list", "oar inbox ack --thread-id <thread-id> --inbox-item-id <inbox-item-id>"},
+	aliases: map[string]string{
+		"get":   "list",
+		"ls":    "list",
+		"watch": "stream",
+	},
+}
+
+var derivedSubcommandSpec = subcommandSpec{
+	command:  "derived",
+	valid:    []string{"rebuild"},
+	examples: []string{"oar derived rebuild --actor-id <actor-id>"},
+}
+
+func packetCreateSubcommandSpec(resource string) subcommandSpec {
+	trimmed := strings.TrimSpace(resource)
+	return subcommandSpec{
+		command:  trimmed,
+		valid:    []string{"create"},
+		examples: []string{fmt.Sprintf("oar %s create", trimmed)},
+	}
+}
+
+func (s subcommandSpec) normalize(raw string) string {
+	token := strings.ToLower(strings.TrimSpace(raw))
+	if token == "" {
+		return ""
+	}
+	if canonical, ok := s.aliases[token]; ok {
+		return canonical
+	}
+	return token
+}
+
+func (s subcommandSpec) requiredError() *errnorm.Error {
+	message := fmt.Sprintf("expected one of: %s; examples: %s", strings.Join(s.valid, ", "), joinExamples(s.examples))
+	return errnorm.Usage("subcommand_required", message)
+}
+
+func (s subcommandSpec) unknownError(raw string) *errnorm.Error {
+	raw = strings.TrimSpace(raw)
+	parts := []string{
+		fmt.Sprintf("unknown %s subcommand %q", strings.TrimSpace(s.command), raw),
+		"valid subcommands: " + strings.Join(s.valid, ", "),
+	}
+	if suggestion := s.suggestion(raw); suggestion != "" {
+		parts = append(parts, "did you mean `"+suggestion+"`?")
+	}
+	parts = append(parts, "examples: "+joinExamples(s.examples))
+	return errnorm.Usage("unknown_subcommand", strings.Join(parts, "; "))
+}
+
+func (s subcommandSpec) suggestion(raw string) string {
+	token := strings.ToLower(strings.TrimSpace(raw))
+	if token == "" {
+		return ""
+	}
+	if canonical, ok := s.aliases[token]; ok {
+		return s.commandPath(canonical)
+	}
+	if strings.TrimSpace(s.command) == "inbox" && looksLikePositionalID(raw) {
+		return "oar inbox ack --thread-id <thread-id> --inbox-item-id <inbox-item-id>"
+	}
+	if closest := closestSubcommand(token, s.valid); closest != "" {
+		return s.commandPath(closest)
+	}
+	return ""
+}
+
+func (s subcommandSpec) commandPath(subcommand string) string {
+	return strings.Join(strings.Fields("oar "+strings.TrimSpace(s.command)+" "+strings.TrimSpace(subcommand)), " ")
+}
+
+func joinExamples(examples []string) string {
+	formatted := make([]string, 0, len(examples))
+	for _, example := range examples {
+		example = strings.TrimSpace(example)
+		if example == "" {
+			continue
+		}
+		formatted = append(formatted, "`"+example+"`")
+	}
+	if len(formatted) == 0 {
+		return "`oar help`"
+	}
+	return strings.Join(formatted, "; ")
+}
+
+func looksLikePositionalID(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.HasPrefix(raw, "-") {
+		return false
+	}
+	if strings.Contains(raw, ":") {
+		return true
+	}
+	hasLetter := false
+	for _, r := range raw {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			break
+		}
+	}
+	return !hasLetter
+}
+
+func closestSubcommand(token string, options []string) string {
+	token = strings.ToLower(strings.TrimSpace(token))
+	if token == "" {
+		return ""
+	}
+
+	best := ""
+	bestDistance := -1
+	for _, option := range options {
+		option = strings.ToLower(strings.TrimSpace(option))
+		if option == "" {
+			continue
+		}
+		if strings.HasPrefix(option, token) || strings.HasPrefix(token, option) {
+			return option
+		}
+		distance := levenshteinDistance(token, option)
+		if bestDistance == -1 || distance < bestDistance {
+			bestDistance = distance
+			best = option
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	maxDistance := 1
+	if len(token) >= 5 {
+		maxDistance = 2
+	}
+	if len(token) >= 10 {
+		maxDistance = 3
+	}
+	if bestDistance > maxDistance {
+		return ""
+	}
+	return best
+}
+
+func levenshteinDistance(a string, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := 0; j <= len(b); j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			curr[j] = minInt(del, ins, sub)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	best := values[0]
+	for _, v := range values[1:] {
+		if v < best {
+			best = v
+		}
+	}
+	return best
+}


### PR DESCRIPTION
## Summary
- add a shared subcommand-guidance helper that standardizes subcommand-required and unknown-subcommand usage errors
- make unknown-subcommand errors list valid subcommands, include exact command examples, and provide did-you-mean suggestions for likely typos
- improve agent-facing surfaces (especially `inbox`, `threads`, and streaming-related `events`/`inbox` subcommands) and add low-risk alias normalization (for example, `inbox get` -> `inbox list`)
- add regression tests for the dogfood failures and new guidance behavior

## Validation
- 
- cd cli && go test ./...
?   	organization-autorunner-cli/cmd/oar	[no test files]
?   	organization-autorunner-cli/cmd/oar-scenario	[no test files]
?   	organization-autorunner-cli/internal/authcli	[no test files]
ok  	organization-autorunner-cli/internal/app	(cached)
ok  	organization-autorunner-cli/internal/config	(cached)
ok  	organization-autorunner-cli/internal/errnorm	(cached)
ok  	organization-autorunner-cli/internal/httpclient	(cached)
ok  	organization-autorunner-cli/internal/output	(cached)
ok  	organization-autorunner-cli/internal/profile	(cached)
ok  	organization-autorunner-cli/internal/registry	(cached)
ok  	organization-autorunner-cli/internal/streaming	(cached)
ok  	organization-autorunner-cli/scenarios/harness	(cached)
- /Applications/Xcode.app/Contents/Developer/usr/bin/make contract-check
./scripts/contract-check
ok  	organization-autorunner-contracts-go-client/client	(cached)
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C core check
?   	organization-autorunner-core/cmd/contract-gen	[no test files]
?   	organization-autorunner-core/cmd/oar-core	[no test files]
?   	organization-autorunner-core/internal/auth	[no test files]
ok  	organization-autorunner-core/internal/actors	(cached)
ok  	organization-autorunner-core/internal/primitives	(cached)
ok  	organization-autorunner-core/internal/schedule	(cached)
ok  	organization-autorunner-core/internal/schema	(cached)
ok  	organization-autorunner-core/internal/server	(cached)
ok  	organization-autorunner-core/internal/storage	(cached)
/Applications/Xcode.app/Contents/Developer/usr/bin/make cli-check
cd cli && go test ./...
?   	organization-autorunner-cli/cmd/oar	[no test files]
?   	organization-autorunner-cli/cmd/oar-scenario	[no test files]
?   	organization-autorunner-cli/internal/authcli	[no test files]
ok  	organization-autorunner-cli/internal/app	(cached)
ok  	organization-autorunner-cli/internal/config	(cached)
ok  	organization-autorunner-cli/internal/errnorm	(cached)
ok  	organization-autorunner-cli/internal/httpclient	(cached)
ok  	organization-autorunner-cli/internal/output	(cached)
ok  	organization-autorunner-cli/internal/profile	(cached)
ok  	organization-autorunner-cli/internal/registry	(cached)
ok  	organization-autorunner-cli/internal/streaming	(cached)
ok  	organization-autorunner-cli/scenarios/harness	(cached)
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C web-ui check
pnpm run lint

> organization-autorunner-ui@0.1.0 lint /Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/web-ui
> eslint . && node scripts/check-svelte5-runes.js && prettier --check "src/**/*.{js,svelte,css}" "tests/**/*.js" "*.{json,js,cjs}" ".github/workflows/*.yml"

Checking formatting...
All matched files use Prettier code style!
pnpm run test:unit

> organization-autorunner-ui@0.1.0 test:unit /Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/web-ui
> vitest run


 RUN  v2.1.9 /Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/web-ui

 ✓ tests/unit/threadFilters.test.js (8 tests) 2ms
 ✓ tests/unit/reviewUtils.test.js (4 tests) 2ms
 ✓ tests/unit/artifactRefs.test.js (2 tests) 3ms
 ✓ tests/unit/commitmentUtils.test.js (6 tests) 4ms
 ✓ tests/unit/receiptUtils.test.js (4 tests) 5ms
 ✓ tests/unit/workOrderUtils.test.js (5 tests) 3ms
 ✓ tests/unit/inboxUtils.test.js (2 tests) 2ms
 ✓ tests/unit/oarCoreClient.test.js (4 tests) 16ms
 ✓ tests/unit/actorClient.integration.test.js (1 test) 13ms
 ✓ tests/unit/provenanceUtils.test.js (2 tests) 1ms
 ✓ tests/unit/refLinkModel.test.js (2 tests) 2ms
 ✓ tests/unit/typedRefs.test.js (2 tests) 2ms
 ✓ tests/unit/timelineUtils.test.js (2 tests) 2ms
 ✓ tests/unit/threadPatch.test.js (3 tests) 2ms
 ✓ tests/unit/navigation.test.js (2 tests) 1ms
 ✓ tests/unit/actorSession.test.js (3 tests) 2ms

 Test Files  16 passed (16)
      Tests  52 passed (52)
   Start at  17:10:47
   Duration  416ms (transform 149ms, setup 0ms, collect 432ms, tests 62ms, environment 1ms, prepare 1.01s)
- ./scripts/e2e-smoke
e2e smoke completed successfully
core_base_url=http://127.0.0.1:18080
ui_base_url=http://127.0.0.1:4179
thread_id=fc76001f-64c9-4281-afb1-f934a4b802bb
agent=smoke-agent
profile_path=/Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/.tmp/e2e-smoke/run.QA0lFF/home/.config/oar/profiles/smoke-agent.json
artifacts_dir=/Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/.tmp/e2e-smoke/run.QA0lFF
smoke artifacts: /Users/dazheng/car-workspace/worktrees/organization-autorunner--discord-2/.tmp/e2e-smoke/run.QA0lFF

Closes #19