### PR TITLE
CLI: improve collaborative event inspection for coordinating roles

### DIFF
--- a/cli/docs/runbook.md
+++ b/cli/docs/runbook.md
@@ -113,7 +113,8 @@ oar --agent agent-a threads list --status active
 oar --agent agent-a events stream --max-events 1
 oar --agent agent-a inbox stream --max-events 1
 oar --agent agent-a events stream --follow
-oar --agent agent-a events list --thread-id thread_123 --type actor_statement --max-events 20
+oar --agent agent-a events list --thread-id thread_123 --thread-id thread_456 --type actor_statement --mine --full-id --max-events 20
+oar --agent agent-a threads context --thread-id thread_123 --max-events 50
 oar --agent agent-a docs content --document-id product-constitution
 oar --agent agent-a commitments inspect --commitment-id commitment_123
 oar --agent agent-a artifacts inspect --artifact-id artifact_123

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -179,9 +179,10 @@ func localGroupHelpSupplement(topic string) string {
 	switch strings.TrimSpace(topic) {
 	case "events":
 		return strings.TrimSpace(`Local inspection helpers:
-  events list              List thread timeline events with optional type filters and max window.
+  events list              List timeline events with thread/type/actor filters, id mode, and preview summaries.
   events explain           Explain known event-type conventions and local validation constraints.
   events validate          Validate an events.create payload from stdin/--from-file without sending a request.
+  Tip: use ` + "`--mine`" + ` or ` + "`--actor-id <id>`" + ` to audit one actor; add ` + "`--full-id`" + ` for copy/paste IDs.
   For details: ` + "`oar events explain <event-type>`")
 	case "artifacts":
 		return strings.TrimSpace(`Local inspection helper:

--- a/cli/internal/app/human_output.go
+++ b/cli/internal/app/human_output.go
@@ -84,6 +84,12 @@ func formatThreadContext(body any) string {
 	thread := extractNestedMap(root, "thread")
 	lines := make([]string, 0, 24)
 	lines = append(lines, formatThreadRecord(thread))
+	collaboration := extractNestedMap(root, "collaboration_summary")
+	if collaboration != nil {
+		lines = appendListSection(lines, "recommendations", asSlice(collaboration["recommendations"]), renderEventListItem)
+		lines = appendListSection(lines, "decision_requests", asSlice(collaboration["decision_requests"]), renderEventListItem)
+		lines = appendListSection(lines, "decisions", asSlice(collaboration["decisions"]), renderEventListItem)
+	}
 	lines = appendListSection(lines, "recent_events", asSlice(root["recent_events"]), renderEventListItem)
 	lines = appendListSection(lines, "key_artifacts", asSlice(root["key_artifacts"]), renderArtifactListItem)
 	lines = appendListSection(lines, "open_commitments", asSlice(root["open_commitments"]), renderCommitmentListItem)
@@ -107,10 +113,17 @@ func formatEventsList(body any) string {
 	if threadID := strings.TrimSpace(anyString(root["thread_id"])); threadID != "" {
 		lines = append(lines, "Thread "+threadID)
 	}
+	threadIDs := stringList(root["thread_ids"])
+	if len(threadIDs) > 1 {
+		lines = appendStringList(lines, "thread_ids", threadIDs)
+	}
 	lines = appendScalar(lines, "total_events", root, "total_events")
 	lines = appendScalar(lines, "returned_events", root, "returned_events")
 	lines = appendStringList(lines, "types", stringList(root["types"]))
-	lines = appendListSection(lines, "events", asSlice(root["events"]), renderEventListItem)
+	if actorID := strings.TrimSpace(anyString(root["actor_id"])); actorID != "" {
+		lines = append(lines, "actor_id: "+actorID)
+	}
+	lines = appendEventListSection(lines, "events", asSlice(root["events"]), asBool(root["full_id"]))
 	return strings.Join(lines, "\n")
 }
 
@@ -268,11 +281,23 @@ func renderCommitmentListItem(item map[string]any) string {
 }
 
 func renderArtifactListItem(item map[string]any) string {
-	return compactSummary(displayID(item), anyString(item["kind"]), firstNonEmpty(anyString(item["summary"]), anyString(item["title"])))
+	artifact := item
+	if nested := asMap(item["artifact"]); nested != nil {
+		artifact = nested
+	}
+	summary := firstNonEmpty(anyString(artifact["summary"]), anyString(artifact["title"]))
+	if summary == "" {
+		summary = anyString(item["content_preview"])
+	}
+	ref := strings.TrimSpace(anyString(item["ref"]))
+	if ref != "" {
+		summary = firstNonEmpty(summary, "ref="+ref)
+	}
+	return compactSummary(displayID(artifact), anyString(artifact["kind"]), summary)
 }
 
 func renderEventListItem(item map[string]any) string {
-	return compactSummary(displayID(item), anyString(item["type"]), firstNonEmpty(anyString(item["summary"]), anyString(item["created_at"])))
+	return renderEventListItemWithMode(item, false)
 }
 
 func renderInboxItem(item map[string]any) string {
@@ -310,6 +335,18 @@ func appendListSection(lines []string, label string, items []any, render func(ma
 			continue
 		}
 		lines = append(lines, "- "+render(item))
+	}
+	return lines
+}
+
+func appendEventListSection(lines []string, label string, items []any, fullID bool) []string {
+	lines = append(lines, fmt.Sprintf("%s (%d):", label, len(items)))
+	for _, raw := range items {
+		item := asMap(raw)
+		if item == nil {
+			continue
+		}
+		lines = append(lines, "- "+renderEventListItemWithMode(item, fullID))
 	}
 	return lines
 }
@@ -410,6 +447,41 @@ func displayID(item map[string]any) string {
 		return short + " (id=" + id + ")"
 	}
 	return firstNonEmpty(id, short)
+}
+
+func renderEventListItemWithMode(item map[string]any, fullID bool) string {
+	summary := firstNonEmpty(anyString(item["summary_preview"]), anyString(item["summary"]), anyString(item["created_at"]))
+	return compactSummary(displayEventID(item, fullID), anyString(item["type"]), summary)
+}
+
+func displayEventID(item map[string]any, fullID bool) string {
+	if item == nil {
+		return ""
+	}
+	id := strings.TrimSpace(anyString(item["id"]))
+	short := strings.TrimSpace(anyString(item["short_id"]))
+	if short == "" && id != "" {
+		short = shortID(id)
+	}
+	if fullID && id != "" {
+		return id
+	}
+	if short != "" {
+		return short
+	}
+	return displayID(item)
+}
+
+func asBool(raw any) bool {
+	switch typed := raw.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, err := strconvParseBool(typed)
+		return err == nil && parsed
+	default:
+		return false
+	}
 }
 
 func extractNestedMap(body any, key string) map[string]any {

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -357,6 +357,24 @@ func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.R
 			query,
 			nil,
 		)
+		if callErr != nil {
+			return result, "threads context", callErr
+		}
+		data := asMap(result.Data)
+		body := asMap(data["body"])
+		if body != nil {
+			addThreadContextCollaborationSummary(body)
+			data["body"] = body
+			result.Data = data
+			result.Text = formatTypedCommandText(
+				"threads.context",
+				intValue(data["status_code"]),
+				headerValues(data["headers"]),
+				body,
+				cfg.Verbose,
+				cfg.Headers,
+			)
+		}
 		return result, "threads context", callErr
 	default:
 		return nil, "threads", threadsSubcommandSpec.unknownError(args[0])
@@ -787,82 +805,141 @@ func (a *App) runDocsContentCommand(ctx context.Context, args []string, cfg conf
 
 func (a *App) runEventsListCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
 	fs := newSilentFlagSet("events list")
-	var threadIDFlag trackedString
+	var threadIDFlags trackedStrings
 	var typesCSVFlag trackedString
+	var actorIDFlag trackedString
 	var maxEventsFlag trackedInt
+	var mineFlag trackedBool
+	var fullIDFlag trackedBool
 	var typeFlags trackedStrings
-	fs.Var(&threadIDFlag, "thread-id", "Thread id")
+	fs.Var(&threadIDFlags, "thread-id", "Thread id (repeatable)")
 	fs.Var(&typeFlags, "type", "Filter by event type (repeatable)")
 	fs.Var(&typesCSVFlag, "types", "Comma-separated event types")
+	fs.Var(&actorIDFlag, "actor-id", "Filter by actor id")
+	fs.Var(&mineFlag, "mine", "Filter to events authored by active profile actor_id")
+	fs.Var(&fullIDFlag, "full-id", "Render full IDs in human output")
 	fs.Var(&maxEventsFlag, "max-events", "Return at most N most-recent matching events (0 means unlimited)")
 	if err := fs.Parse(args); err != nil {
 		return nil, errnorm.Usage("invalid_flags", err.Error())
 	}
 
-	positionals := fs.Args()
-	threadID := strings.TrimSpace(threadIDFlag.value)
-	if threadID == "" && len(positionals) > 0 {
-		threadID = strings.TrimSpace(positionals[0])
-		positionals = positionals[1:]
+	positionals := append([]string(nil), fs.Args()...)
+	threadIDs := make([]string, 0, len(threadIDFlags.values)+len(positionals))
+	threadIDs = append(threadIDs, threadIDFlags.values...)
+	threadIDs = append(threadIDs, positionals...)
+	threadIDs = normalizeIDFilters(threadIDs)
+	if len(threadIDs) == 0 {
+		return nil, errnorm.Usage("invalid_request", "thread id is required (provide --thread-id <thread-id>)")
 	}
-	if err := validateID(threadID, "thread id"); err != nil {
-		return nil, err
-	}
-	if len(positionals) > 0 {
-		return nil, errnorm.Usage("invalid_args", "unexpected positional arguments for `oar events list`")
+	for _, threadID := range threadIDs {
+		if err := validateID(threadID, "thread id"); err != nil {
+			return nil, err
+		}
 	}
 	if maxEventsFlag.set && maxEventsFlag.value < 0 {
 		return nil, errnorm.Usage("invalid_request", "--max-events must be >= 0")
 	}
-
-	typeFilters := normalizeEventTypeFilters(typeFlags.values, typesCSVFlag.value)
-	timelineResult, callErr := a.invokeTypedJSONWithIDResolution(
-		ctx,
-		cfg,
-		"events list",
-		"threads.timeline",
-		"thread_id",
-		threadID,
-		threadIDLookupSpec,
-		nil,
-		nil,
-	)
-	if callErr != nil {
-		return nil, callErr
+	if mineFlag.set && mineFlag.value && strings.TrimSpace(actorIDFlag.value) != "" && strings.TrimSpace(actorIDFlag.value) != "me" {
+		return nil, errnorm.Usage("invalid_request", "--mine cannot be combined with --actor-id unless --actor-id=me")
 	}
 
-	data := asMap(timelineResult.Data)
-	body := asMap(data["body"])
-	allEvents := asSlice(body["events"])
-	matching := filterEventsByType(allEvents, typeFilters)
+	typeFilters := normalizeEventTypeFilters(typeFlags.values, typesCSVFlag.value)
+	actorFilter := strings.TrimSpace(actorIDFlag.value)
+	if mineFlag.set && mineFlag.value {
+		actorFilter = "me"
+	}
+	resolvedActorID, err := resolveActorIDAlias(actorFilter, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedThreadIDs := make([]string, 0, len(threadIDs))
+	allEvents := make([]any, 0, 32)
+	matching := make([]any, 0, 32)
+	statusCode := http.StatusOK
+	headers := map[string][]string{"Content-Type": {"application/json"}}
+	capturedResponse := false
+	for _, threadID := range threadIDs {
+		timelineResult, callErr := a.invokeTypedJSONWithIDResolution(
+			ctx,
+			cfg,
+			"events list",
+			"threads.timeline",
+			"thread_id",
+			threadID,
+			threadIDLookupSpec,
+			nil,
+			nil,
+		)
+		if callErr != nil {
+			return nil, callErr
+		}
+		data := asMap(timelineResult.Data)
+		body := asMap(data["body"])
+		if !capturedResponse {
+			capturedResponse = true
+			if code := intValue(data["status_code"]); code > 0 {
+				statusCode = code
+			}
+			if responseHeaders := headerValues(data["headers"]); len(responseHeaders) > 0 {
+				headers = responseHeaders
+			}
+		}
+		threadEvents := asSlice(body["events"])
+		allEvents = append(allEvents, threadEvents...)
+		filtered := filterEventsByType(threadEvents, typeFilters)
+		filtered = filterEventsByActorID(filtered, resolvedActorID)
+		matching = append(matching, filtered...)
+		resolvedThreadID := firstNonEmpty(anyString(body["thread_id"]), eventThreadIDFromList(threadEvents), threadID)
+		if resolvedThreadID != "" {
+			resolvedThreadIDs = append(resolvedThreadIDs, resolvedThreadID)
+		}
+	}
+	resolvedThreadIDs = normalizeIDFilters(resolvedThreadIDs)
+	if len(resolvedThreadIDs) > 1 {
+		sortEventsByCreatedAt(matching)
+	}
 	if maxEventsFlag.set && maxEventsFlag.value > 0 && len(matching) > maxEventsFlag.value {
 		matching = matching[len(matching)-maxEventsFlag.value:]
 	}
+	matching = enrichEventsForList(matching)
 
 	listBody := map[string]any{
-		"thread_id":       firstNonEmpty(anyString(body["thread_id"]), eventThreadIDFromList(matching), eventThreadIDFromList(allEvents), threadID),
+		"thread_id":       firstNonEmpty(eventThreadIDFromList(matching), eventThreadIDFromList(allEvents)),
+		"thread_ids":      resolvedThreadIDs,
+		"full_id":         fullIDFlag.set && fullIDFlag.value,
 		"events":          matching,
 		"total_events":    len(allEvents),
 		"returned_events": len(matching),
 	}
+	if len(resolvedThreadIDs) == 1 {
+		listBody["thread_id"] = resolvedThreadIDs[0]
+	}
 	if len(typeFilters) > 0 {
 		listBody["types"] = typeFilters
+	}
+	if resolvedActorID != "" {
+		listBody["actor_id"] = resolvedActorID
 	}
 	if maxEventsFlag.set {
 		listBody["max_events"] = maxEventsFlag.value
 	}
 
-	data["body"] = listBody
-	timelineResult.Data = data
-	timelineResult.Text = formatTypedCommandText(
+	resultData := map[string]any{
+		"status_code": statusCode,
+		"headers":     headers,
+		"body":        listBody,
+	}
+	result := &commandResult{Data: resultData}
+	result.Text = formatTypedCommandText(
 		"events.list",
-		intValue(data["status_code"]),
-		headerValues(data["headers"]),
+		intValue(resultData["status_code"]),
+		headerValues(resultData["headers"]),
 		listBody,
 		cfg.Verbose,
 		cfg.Headers,
 	)
-	return timelineResult, nil
+	return result, nil
 }
 
 func (a *App) runEventsExplainCommand(args []string) (*commandResult, error) {
@@ -2233,7 +2310,7 @@ func normalizeEventTypeFilters(explicit []string, csv string) []string {
 
 func filterEventsByType(events []any, types []string) []any {
 	if len(events) == 0 {
-		return nil
+		return []any{}
 	}
 	if len(types) == 0 {
 		return append([]any(nil), events...)
@@ -2276,6 +2353,211 @@ func eventThreadIDFromList(events []any) string {
 		}
 	}
 	return ""
+}
+
+func normalizeIDFilters(rawIDs []string) []string {
+	if len(rawIDs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(rawIDs))
+	seen := make(map[string]struct{}, len(rawIDs))
+	for _, raw := range rawIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func filterEventsByActorID(events []any, actorID string) []any {
+	actorID = strings.TrimSpace(actorID)
+	if len(events) == 0 {
+		return []any{}
+	}
+	if actorID == "" {
+		return append([]any(nil), events...)
+	}
+	filtered := make([]any, 0, len(events))
+	for _, raw := range events {
+		event := asMap(raw)
+		if event == nil {
+			continue
+		}
+		if strings.TrimSpace(anyString(event["actor_id"])) != actorID {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	return filtered
+}
+
+func sortEventsByCreatedAt(events []any) {
+	if len(events) <= 1 {
+		return
+	}
+	sort.SliceStable(events, func(i int, j int) bool {
+		left := asMap(events[i])
+		right := asMap(events[j])
+		if left == nil || right == nil {
+			return false
+		}
+		leftTS, leftOK := eventCreatedAt(left)
+		rightTS, rightOK := eventCreatedAt(right)
+		if leftOK && rightOK {
+			return leftTS.Before(rightTS)
+		}
+		if leftOK != rightOK {
+			return !leftOK
+		}
+		return false
+	})
+}
+
+func eventCreatedAt(event map[string]any) (time.Time, bool) {
+	raw := strings.TrimSpace(anyString(event["created_at"]))
+	if raw == "" {
+		return time.Time{}, false
+	}
+	if ts, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return ts, true
+	}
+	if ts, err := time.Parse(time.RFC3339, raw); err == nil {
+		return ts, true
+	}
+	return time.Time{}, false
+}
+
+func enrichEventsForList(events []any) []any {
+	if len(events) == 0 {
+		return []any{}
+	}
+	out := make([]any, 0, len(events))
+	for _, raw := range events {
+		event := asMap(raw)
+		if event == nil {
+			continue
+		}
+		copy := cloneMap(event)
+		id := strings.TrimSpace(anyString(copy["id"]))
+		if id != "" && strings.TrimSpace(anyString(copy["short_id"])) == "" {
+			copy["short_id"] = shortID(id)
+		}
+		if preview := eventSummaryPreview(copy); preview != "" {
+			copy["summary_preview"] = preview
+		}
+		out = append(out, copy)
+	}
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func eventSummaryPreview(event map[string]any) string {
+	preview := strings.TrimSpace(anyString(event["summary"]))
+	if preview != "" {
+		return truncatePreview(preview)
+	}
+	payload := asMap(event["payload"])
+	if payload != nil {
+		for _, key := range []string{"recommendation", "decision", "summary", "statement", "message", "title", "content", "text"} {
+			if value := compactPreviewValue(payload[key]); value != "" {
+				return truncatePreview(value)
+			}
+		}
+		if encoded, err := json.Marshal(payload); err == nil {
+			if value := strings.TrimSpace(string(encoded)); value != "" && value != "{}" {
+				return truncatePreview(value)
+			}
+		}
+	}
+	refs := stringList(event["refs"])
+	if len(refs) > 0 {
+		return truncatePreview(strings.Join(refs, ", "))
+	}
+	return truncatePreview(strings.TrimSpace(anyString(event["created_at"])))
+}
+
+func compactPreviewValue(raw any) string {
+	switch typed := raw.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []string:
+		return strings.TrimSpace(strings.Join(typed, "; "))
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			text := strings.TrimSpace(anyString(item))
+			if text == "" {
+				continue
+			}
+			parts = append(parts, text)
+			if len(parts) >= 3 {
+				break
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, "; "))
+	default:
+		if raw == nil {
+			return ""
+		}
+		encoded, err := json.Marshal(raw)
+		if err != nil {
+			return strings.TrimSpace(fmt.Sprintf("%v", raw))
+		}
+		return strings.TrimSpace(string(encoded))
+	}
+}
+
+func truncatePreview(raw string) string {
+	const maxRunes = 120
+	normalized := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	if normalized == "" {
+		return ""
+	}
+	runes := []rune(normalized)
+	if len(runes) <= maxRunes {
+		return normalized
+	}
+	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
+}
+
+func addThreadContextCollaborationSummary(body map[string]any) bool {
+	if body == nil {
+		return false
+	}
+	recentEvents := enrichEventsForList(asSlice(body["recent_events"]))
+	body["recent_events"] = recentEvents
+
+	collaboration := map[string]any{
+		"recommendations":   filterEventsByType(recentEvents, []string{"actor_statement"}),
+		"decision_requests": filterEventsByType(recentEvents, []string{"decision_needed"}),
+		"decisions":         filterEventsByType(recentEvents, []string{"decision_made"}),
+		"key_artifacts":     asSlice(body["key_artifacts"]),
+		"open_commitments":  asSlice(body["open_commitments"]),
+	}
+	collaboration["recommendation_count"] = len(asSlice(collaboration["recommendations"]))
+	collaboration["decision_request_count"] = len(asSlice(collaboration["decision_requests"]))
+	collaboration["decision_count"] = len(asSlice(collaboration["decisions"]))
+	collaboration["artifact_count"] = len(asSlice(collaboration["key_artifacts"]))
+	collaboration["open_commitment_count"] = len(asSlice(collaboration["open_commitments"]))
+
+	body["collaboration_summary"] = collaboration
+	return true
 }
 
 func (a *App) applyContentFileOverride(body any, contentFile string, commandName string) (any, error) {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -314,7 +314,7 @@ func TestEventsUnknownSubcommandGuidance(t *testing.T) {
 	if !strings.Contains(message, "did you mean `oar events stream`?") {
 		t.Fatalf("expected stream correction, got %q", message)
 	}
-	if !strings.Contains(message, "`oar events list --thread-id <thread-id> --type actor_statement`") || !strings.Contains(message, "`oar events tail --max-events 20`") {
+	if !strings.Contains(message, "`oar events list --thread-id <thread-id> --type actor_statement --mine --full-id`") || !strings.Contains(message, "`oar events tail --max-events 20`") {
 		t.Fatalf("expected list/tail examples, got %q", message)
 	}
 }
@@ -385,6 +385,162 @@ func TestEventsListCommandFiltersAndLimits(t *testing.T) {
 	})
 	if !strings.Contains(human, "types:") || !strings.Contains(human, "- actor_statement") {
 		t.Fatalf("expected human output to include selected filter types, got:\n%s", human)
+	}
+}
+
+func TestEventsListCommandSupportsMineActorFilterAndFullID(t *testing.T) {
+	t.Parallel()
+
+	const mineEventID = "event_1234567890abcdef"
+	const mineActorID = "actor-profile-1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/threads/thread_1/timeline" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"events":[
+				{"id":"` + mineEventID + `","thread_id":"thread_1","type":"actor_statement","actor_id":"` + mineActorID + `","payload":{"recommendation":"Ship Friday rescue scope"}},
+				{"id":"event_other_actor","thread_id":"thread_1","type":"actor_statement","actor_id":"actor-other","summary":"other recommendation"}
+			],
+			"snapshots":{},
+			"artifacts":{}
+		}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-a", `{"agent":"agent-a","actor_id":"`+mineActorID+`","access_token":"token-a","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"--agent", "agent-a",
+		"events", "list",
+		"--thread-id", "thread_1",
+		"--type", "actor_statement",
+		"--mine",
+		"--full-id",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	if got := anyStringValue(body["actor_id"]); got != mineActorID {
+		t.Fatalf("expected actor_id filter %q, got %#v", mineActorID, body)
+	}
+	if fullID, _ := body["full_id"].(bool); !fullID {
+		t.Fatalf("expected full_id=true, got %#v", body)
+	}
+	events, _ := body["events"].([]any)
+	if len(events) != 1 {
+		t.Fatalf("expected one filtered event, got %#v", body)
+	}
+	event, _ := events[0].(map[string]any)
+	if got := anyStringValue(event["id"]); got != mineEventID {
+		t.Fatalf("unexpected event id after mine filter: %#v", body)
+	}
+	if got := anyStringValue(event["summary_preview"]); !strings.Contains(got, "Ship Friday rescue scope") {
+		t.Fatalf("expected payload preview summary, got %#v", event)
+	}
+
+	humanFull := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--base-url", server.URL,
+		"--agent", "agent-a",
+		"events", "list",
+		"--thread-id", "thread_1",
+		"--type", "actor_statement",
+		"--mine",
+		"--full-id",
+	})
+	if !strings.Contains(humanFull, mineEventID) || !strings.Contains(humanFull, "Ship Friday rescue scope") {
+		t.Fatalf("expected full id + preview in human output, got:\n%s", humanFull)
+	}
+
+	humanShort := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--base-url", server.URL,
+		"--agent", "agent-a",
+		"events", "list",
+		"--thread-id", "thread_1",
+		"--type", "actor_statement",
+		"--mine",
+	})
+	if strings.Contains(humanShort, mineEventID) {
+		t.Fatalf("expected default short-id rendering without --full-id, got:\n%s", humanShort)
+	}
+	if !strings.Contains(humanShort, mineEventID[:12]) {
+		t.Fatalf("expected short id rendering by default, got:\n%s", humanShort)
+	}
+}
+
+func TestEventsListCommandSupportsMultipleThreadIDs(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	requested := make([]string, 0, 2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/timeline") {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		requested = append(requested, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/threads/thread_1/timeline":
+			_, _ = w.Write([]byte(`{"thread_id":"thread_1","events":[
+				{"id":"event_1","thread_id":"thread_1","type":"actor_statement","summary":"first","created_at":"2026-03-06T12:00:00Z"},
+				{"id":"event_2","thread_id":"thread_1","type":"actor_statement","summary":"second","created_at":"2026-03-06T12:05:00Z"}
+			],"snapshots":{},"artifacts":{}}`))
+		case "/threads/thread_2/timeline":
+			_, _ = w.Write([]byte(`{"thread_id":"thread_2","events":[
+				{"id":"event_3","thread_id":"thread_2","type":"actor_statement","summary":"third","created_at":"2026-03-06T12:06:00Z"},
+				{"id":"event_4","thread_id":"thread_2","type":"actor_statement","summary":"fourth","created_at":"2026-03-06T12:07:00Z"}
+			],"snapshots":{},"artifacts":{}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"events", "list",
+		"--thread-id", "thread_1",
+		"--thread-id", "thread_2",
+		"--type", "actor_statement",
+		"--max-events", "2",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	totalEvents, _ := body["total_events"].(float64)
+	if int(totalEvents) != 4 {
+		t.Fatalf("expected total_events=4, got %#v", body)
+	}
+	threadIDs := stringList(body["thread_ids"])
+	if len(threadIDs) != 2 || threadIDs[0] != "thread_1" || threadIDs[1] != "thread_2" {
+		t.Fatalf("expected thread_ids [thread_1 thread_2], got %#v", body)
+	}
+	events, _ := body["events"].([]any)
+	if len(events) != 2 {
+		t.Fatalf("expected max_events to cap result set, got %#v", body)
+	}
+	first, _ := events[0].(map[string]any)
+	second, _ := events[1].(map[string]any)
+	if anyStringValue(first["id"]) != "event_3" || anyStringValue(second["id"]) != "event_4" {
+		t.Fatalf("expected most recent cross-thread events, got %#v", body)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requested) != 2 {
+		t.Fatalf("expected one timeline request per thread id, got %d (%v)", len(requested), requested)
 	}
 }
 
@@ -926,6 +1082,75 @@ func TestThreadsContextCommand(t *testing.T) {
 	payload := assertEnvelopeOK(t, raw)
 	if got := anyStringValue(payload["command"]); got != "threads context" {
 		t.Fatalf("unexpected command label: %#v", payload)
+	}
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	collaboration, _ := body["collaboration_summary"].(map[string]any)
+	if collaboration == nil {
+		t.Fatalf("expected collaboration_summary in context payload, got %#v", body)
+	}
+}
+
+func TestThreadsContextIncludesCollaborationSummarySections(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/threads/thread_1/context" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"thread":{"id":"thread_1","title":"Pilot Rescue"},
+			"recent_events":[
+				{"id":"event_actor_1","type":"actor_statement","summary":"support recommends Friday launch"},
+				{"id":"event_need_1","type":"decision_needed","summary":"pick launch day"},
+				{"id":"event_done_1","type":"decision_made","summary":"launch Friday"}
+			],
+			"key_artifacts":[
+				{"ref":"artifact:brief_1","artifact":{"id":"artifact_1","kind":"gtm-brief","summary":"Pilot rescue brief"}}
+			],
+			"open_commitments":[
+				{"id":"commitment_1","status":"open","title":"Publish launch brief"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "context",
+		"--thread-id", "thread_1",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	collaboration, _ := body["collaboration_summary"].(map[string]any)
+	if collaboration == nil {
+		t.Fatalf("expected collaboration_summary, got %#v", body)
+	}
+	recommendationCount, _ := collaboration["recommendation_count"].(float64)
+	if got := int(recommendationCount); got != 1 {
+		t.Fatalf("expected recommendation_count=1, got %#v", collaboration)
+	}
+	decisionRequestCount, _ := collaboration["decision_request_count"].(float64)
+	if got := int(decisionRequestCount); got != 1 {
+		t.Fatalf("expected decision_request_count=1, got %#v", collaboration)
+	}
+	decisionCount, _ := collaboration["decision_count"].(float64)
+	if got := int(decisionCount); got != 1 {
+		t.Fatalf("expected decision_count=1, got %#v", collaboration)
+	}
+
+	human := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--base-url", server.URL,
+		"threads", "context",
+		"--thread-id", "thread_1",
+	})
+	if !strings.Contains(human, "recommendations (1):") || !strings.Contains(human, "decision_requests (1):") || !strings.Contains(human, "decisions (1):") {
+		t.Fatalf("expected collaboration sections in human output, got:\n%s", human)
 	}
 }
 

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -92,7 +92,7 @@ var docsRevisionSubcommandSpec = subcommandSpec{
 var eventsSubcommandSpec = subcommandSpec{
 	command:  "events",
 	valid:    []string{"list", "get", "create", "validate", "stream", "tail", "explain"},
-	examples: []string{"oar events list --thread-id <thread-id> --type actor_statement", "oar events tail --max-events 20"},
+	examples: []string{"oar events list --thread-id <thread-id> --type actor_statement --mine --full-id", "oar events tail --max-events 20"},
 	aliases: map[string]string{
 		"watch": "stream",
 		"ls":    "list",


### PR DESCRIPTION
## Summary
- extend `oar events list` with repeatable `--thread-id`, actor filters (`--actor-id`/`--mine`), and optional full-id display (`--full-id`)
- add list-time event enrichment (`short_id`, `summary_preview`) so operators can inspect payload intent without repetitive `events get`
- add derived `collaboration_summary` to `threads context` and render recommendation/decision sections in human output
- update help/runbook guidance for the new collaborative inspection flow

## Validation
- `make cli-check`

Closes #34
