### PR TITLE
CLI: make threads inspect canonical thread coordination workflow

### DIFF
--- a/cli/docs/generated/commands.md
+++ b/cli/docs/generated/commands.md
@@ -574,11 +574,11 @@ Generated from `contracts/oar-openapi.yaml`.
 - HTTP: `GET /threads/{thread_id}/context`
 - Stability: `beta`
 - Input mode: `none`
-- Why: Load thread state, recent events, key artifacts, and open commitments in a single round-trip.
+- Why: Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.
 - Concepts: `threads`, `events`, `artifacts`, `commitments`
 - Error codes: `invalid_request`, `not_found`
 - Output: Returns `{ thread, recent_events, key_artifacts, open_commitments }`.
-- Agent notes: Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.
+- Agent notes: Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.
 - Examples:
   - Context with defaults: `oar threads context --thread-id thread_123 --json`
   - Context with artifact previews: `oar threads context --thread-id thread_123 --include-artifact-content --max-events 50 --json`
@@ -603,11 +603,11 @@ Generated from `contracts/oar-openapi.yaml`.
 - HTTP: `GET /threads/{thread_id}`
 - Stability: `stable`
 - Input mode: `none`
-- Why: Resolve authoritative thread state before patching or composing packets.
+- Why: Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.
 - Concepts: `threads`
 - Error codes: `not_found`
 - Output: Returns `{ thread }`.
-- Agent notes: Safe and idempotent.
+- Agent notes: Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.
 - Examples:
   - Read thread: `oar threads get --thread-id thread_123 --json`
 

--- a/cli/docs/runbook.md
+++ b/cli/docs/runbook.md
@@ -115,7 +115,7 @@ oar --agent agent-a inbox stream --max-events 1
 oar --agent agent-a events stream --follow
 oar --agent agent-a events list --thread-id thread_123 --thread-id thread_456 --type actor_statement --mine --full-id --max-events 20
 oar --json --agent agent-a provenance walk --from event:event_123 --depth 2
-oar --agent agent-a threads context --thread-id thread_123 --max-events 50
+oar --agent agent-a threads inspect --thread-id thread_123 --max-events 50 --full-id
 oar --agent agent-a threads context --status active --tag pilot-rescue --type initiative --full-id
 oar --agent agent-a docs content --document-id product-constitution
 oar --agent agent-a commitments inspect --commitment-id commitment_123
@@ -139,7 +139,7 @@ oar --json --base-url http://127.0.0.1:8000 --agent agent-a api call --path /met
 
 Machine-facing notes for the targeted automation commands:
 
-- `events list`, `events get`, `events stream`, `inbox stream`, and `threads context` include a stable `command_id` alongside `command`.
+- `events list`, `events get`, `events stream`, `inbox stream`, `threads inspect`, and `threads context` include a stable `command_id` alongside `command`.
 - `events tail` and `inbox tail` resolve to canonical machine command identity (`events stream` / `inbox stream`) in JSON success/error envelopes.
 - Stream frames expose a normalized payload contract:
   - `id`, `type`

--- a/cli/dogfood/pi/run.mjs
+++ b/cli/dogfood/pi/run.mjs
@@ -227,8 +227,9 @@ Auth:
 
 Read workflow state:
 - List threads: \`oar threads list\`
-- Read thread: \`oar threads get --thread-id <thread-id>\`
-- Read thread context: \`oar threads context --thread-id <thread-id>\`
+- Canonical thread coordination read: \`oar threads inspect --thread-id <thread-id>\`
+- Cross-thread aggregate context (optional): \`oar threads context --status active --type initiative --full-id\`
+- Raw thread snapshot only (optional): \`oar threads get --thread-id <thread-id>\`
 - List inbox items: \`oar inbox list\`
 - List artifacts: \`oar artifacts list --thread-id <thread-id>\`
 - Read artifact metadata: \`oar artifacts get --artifact-id <artifact-id>\`
@@ -416,10 +417,10 @@ function targetsGuide(role, targets) {
     `Shared goal title: ${targets.mainThread.title}`,
     `Primary thread for your role: ${targets.primaryThread.id}`,
     `Primary thread title: ${targets.primaryThread.title}`,
-    `Read shared goal thread: oar threads get --thread-id ${targets.mainThread.id}`,
-    `Read shared goal context: oar threads context --thread-id ${targets.mainThread.id}`,
-    `Read your primary thread: oar threads get --thread-id ${targets.primaryThread.id}`,
-    `Read your primary thread context: oar threads context --thread-id ${targets.primaryThread.id}`,
+    `Canonical read shared goal thread: oar threads inspect --thread-id ${targets.mainThread.id}`,
+    `Canonical read your primary thread: oar threads inspect --thread-id ${targets.primaryThread.id}`,
+    `Optional raw snapshot shared goal thread: oar threads get --thread-id ${targets.mainThread.id}`,
+    `Optional raw snapshot your primary thread: oar threads get --thread-id ${targets.primaryThread.id}`,
   ];
 
   if (targets.relatedThreads.length > 0) {

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -64,9 +64,9 @@ var localHelperTopics = []localHelperTopic{
 	},
 	{
 		Path:        "threads inspect",
-		Summary:     "Compose one coordination view from `threads context` and related `inbox list` items for the same thread.",
+		Summary:     "Canonical thread coordination read path: compose one view from `threads context` and related `inbox list` items.",
 		JSONShape:   "`thread`, `context`, `collaboration`, `inbox`",
-		Composition: "Resolves one thread by id or discovery filters, loads `threads context`, then filters inbox items client-side by `thread_id`.",
+		Composition: "Resolves one thread by id or discovery filters, loads `threads context`, then filters inbox items client-side by `thread_id` for one operator-focused coordination view.",
 		Examples: []string{
 			"oar threads inspect --thread-id <thread-id>",
 			"oar threads inspect --status active --type initiative --full-id",
@@ -250,9 +250,9 @@ func formatGeneratedGroupHelp(topic string, commands []registry.Command) string 
 func localGroupHelpSupplement(topic string) string {
 	switch strings.TrimSpace(topic) {
 	case "threads":
-		return strings.TrimSpace(`Coordination helper:
+		return strings.TrimSpace(`Canonical coordination read path:
   threads inspect             Compose one thread coordination view from context + inbox in one command.
-  Tip: use ` + "`--status/--tag/--type initiative`" + ` to discover one initiative view; use ` + "`oar threads context`" + ` for cross-thread aggregates and add ` + "`--full-id`" + ` for copy/paste ids.`)
+  Tip: start with ` + "`oar threads inspect`" + ` for one initiative/thread; use ` + "`oar threads context`" + ` for cross-thread aggregates and ` + "`oar threads get`" + ` for raw snapshot-only reads. Add ` + "`--full-id`" + ` for copy/paste ids.`)
 	case "events":
 		return strings.TrimSpace(`Local inspection helpers:
   events list              List timeline events with thread/type/actor filters, id mode, and preview summaries.
@@ -532,7 +532,8 @@ func onboardingHelpText() string {
 Work-order loop
 
 1. Inspect inbound work and context: ` + "`oar inbox list`" + ` or ` + "`oar inbox stream --max-events 1`" + `.
-2. Read current state before mutating it: ` + "`oar threads get <thread-id>`" + ` and related list/get commands.
+2. Read current state before mutating it: ` + "`oar threads inspect --thread-id <thread-id>`" + `.
+   Use ` + "`oar threads context`" + ` for cross-thread aggregates and ` + "`oar threads get`" + ` for raw snapshot-only reads.
 3. Stage a mutation as a draft when you need reviewable intent: ` + "`oar draft create --command <command-id>`" + `.
 4. Commit the draft (or send a direct typed create/patch command) and capture returned IDs.
 5. Confirm outcomes in timeline/events and ack inbox items to close the loop.

--- a/cli/internal/app/meta_help_test.go
+++ b/cli/internal/app/meta_help_test.go
@@ -117,6 +117,12 @@ func TestRunGeneratedHelpTopic(t *testing.T) {
 	if !strings.Contains(output, "threads inspect") {
 		t.Fatalf("expected local threads inspect helper in generated help output=%s", output)
 	}
+	if !strings.Contains(output, "Canonical coordination read path:") {
+		t.Fatalf("expected canonical coordination guidance in threads group help output=%s", output)
+	}
+	if !strings.Contains(output, "oar threads inspect") {
+		t.Fatalf("expected canonical threads inspect command hint in threads group help output=%s", output)
+	}
 	if strings.Contains(output, "threads update") {
 		t.Fatalf("unexpected legacy update subcommand in generated help output=%s", output)
 	}
@@ -400,6 +406,9 @@ func TestRunOnboardingHelpTopic(t *testing.T) {
 	}
 	if !strings.Contains(output, "5. The fastest way to stay aligned") {
 		t.Fatalf("expected fifth mental model sentence output=%s", output)
+	}
+	if !strings.Contains(output, "oar threads inspect --thread-id <thread-id>") {
+		t.Fatalf("expected canonical thread inspect workflow guidance output=%s", output)
 	}
 }
 

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -51,7 +51,7 @@ var provenanceSubcommandSpec = subcommandSpec{
 var threadsSubcommandSpec = subcommandSpec{
 	command:  "threads",
 	valid:    []string{"list", "get", "create", "patch", "timeline", "context", "inspect"},
-	examples: []string{"oar threads list --status active", "oar threads inspect --status active --type initiative --full-id"},
+	examples: []string{"oar threads inspect --status active --type initiative --full-id", "oar threads list --status active"},
 	aliases: map[string]string{
 		"ls":     "list",
 		"update": "patch",

--- a/cli/internal/registry/commands.json
+++ b/cli/internal/registry/commands.json
@@ -2089,7 +2089,7 @@
       "path": "/threads/{thread_id}/context",
       "operation_id": "getThreadContext",
       "summary": "Get bundled thread context for agent callers",
-      "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+      "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2106,7 +2106,7 @@
         "commitments"
       ],
       "stability": "beta",
-      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
       "examples": [
         {
           "title": "Context with defaults",
@@ -2263,7 +2263,7 @@
       "path": "/threads/{thread_id}",
       "operation_id": "getThread",
       "summary": "Get thread snapshot by id",
-      "why": "Resolve authoritative thread state before patching or composing packets.",
+      "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2276,7 +2276,7 @@
         "threads"
       ],
       "stability": "stable",
-      "agent_notes": "Safe and idempotent.",
+      "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
       "examples": [
         {
           "title": "Read thread",

--- a/cli/internal/registry/concepts.json
+++ b/cli/internal/registry/concepts.json
@@ -308,7 +308,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -325,7 +325,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -956,7 +956,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -973,7 +973,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -2050,7 +2050,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -2067,7 +2067,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -4849,7 +4849,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -4866,7 +4866,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -5023,7 +5023,7 @@
           "path": "/threads/{thread_id}",
           "operation_id": "getThread",
           "summary": "Get thread snapshot by id",
-          "why": "Resolve authoritative thread state before patching or composing packets.",
+          "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -5036,7 +5036,7 @@
             "threads"
           ],
           "stability": "stable",
-          "agent_notes": "Safe and idempotent.",
+          "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
           "examples": [
             {
               "title": "Read thread",

--- a/cli/internal/registry/help.json
+++ b/cli/internal/registry/help.json
@@ -2215,7 +2215,7 @@
       "path": "/threads/{thread_id}/context",
       "operation_id": "getThreadContext",
       "summary": "Get bundled thread context for agent callers",
-      "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+      "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2232,7 +2232,7 @@
         "commitments"
       ],
       "stability": "beta",
-      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
       "examples": [
         {
           "title": "Context with defaults",
@@ -2389,7 +2389,7 @@
       "path": "/threads/{thread_id}",
       "operation_id": "getThread",
       "summary": "Get thread snapshot by id",
-      "why": "Resolve authoritative thread state before patching or composing packets.",
+      "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2402,7 +2402,7 @@
         "threads"
       ],
       "stability": "stable",
-      "agent_notes": "Safe and idempotent.",
+      "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
       "examples": [
         {
           "title": "Read thread",

--- a/contracts/gen/docs/commands.md
+++ b/contracts/gen/docs/commands.md
@@ -574,11 +574,11 @@ Generated from `contracts/oar-openapi.yaml`.
 - HTTP: `GET /threads/{thread_id}/context`
 - Stability: `beta`
 - Input mode: `none`
-- Why: Load thread state, recent events, key artifacts, and open commitments in a single round-trip.
+- Why: Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.
 - Concepts: `threads`, `events`, `artifacts`, `commitments`
 - Error codes: `invalid_request`, `not_found`
 - Output: Returns `{ thread, recent_events, key_artifacts, open_commitments }`.
-- Agent notes: Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.
+- Agent notes: Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.
 - Examples:
   - Context with defaults: `oar threads context --thread-id thread_123 --json`
   - Context with artifact previews: `oar threads context --thread-id thread_123 --include-artifact-content --max-events 50 --json`
@@ -603,11 +603,11 @@ Generated from `contracts/oar-openapi.yaml`.
 - HTTP: `GET /threads/{thread_id}`
 - Stability: `stable`
 - Input mode: `none`
-- Why: Resolve authoritative thread state before patching or composing packets.
+- Why: Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.
 - Concepts: `threads`
 - Error codes: `not_found`
 - Output: Returns `{ thread }`.
-- Agent notes: Safe and idempotent.
+- Agent notes: Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.
 - Examples:
   - Read thread: `oar threads get --thread-id thread_123 --json`
 

--- a/contracts/gen/meta/commands.json
+++ b/contracts/gen/meta/commands.json
@@ -2089,7 +2089,7 @@
       "path": "/threads/{thread_id}/context",
       "operation_id": "getThreadContext",
       "summary": "Get bundled thread context for agent callers",
-      "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+      "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2106,7 +2106,7 @@
         "commitments"
       ],
       "stability": "beta",
-      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
       "examples": [
         {
           "title": "Context with defaults",
@@ -2263,7 +2263,7 @@
       "path": "/threads/{thread_id}",
       "operation_id": "getThread",
       "summary": "Get thread snapshot by id",
-      "why": "Resolve authoritative thread state before patching or composing packets.",
+      "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2276,7 +2276,7 @@
         "threads"
       ],
       "stability": "stable",
-      "agent_notes": "Safe and idempotent.",
+      "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
       "examples": [
         {
           "title": "Read thread",

--- a/contracts/gen/meta/concepts.json
+++ b/contracts/gen/meta/concepts.json
@@ -308,7 +308,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -325,7 +325,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -956,7 +956,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -973,7 +973,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -2050,7 +2050,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -2067,7 +2067,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -4849,7 +4849,7 @@
           "path": "/threads/{thread_id}/context",
           "operation_id": "getThreadContext",
           "summary": "Get bundled thread context for agent callers",
-          "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+          "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -4866,7 +4866,7 @@
             "commitments"
           ],
           "stability": "beta",
-          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+          "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
           "examples": [
             {
               "title": "Context with defaults",
@@ -5023,7 +5023,7 @@
           "path": "/threads/{thread_id}",
           "operation_id": "getThread",
           "summary": "Get thread snapshot by id",
-          "why": "Resolve authoritative thread state before patching or composing packets.",
+          "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
@@ -5036,7 +5036,7 @@
             "threads"
           ],
           "stability": "stable",
-          "agent_notes": "Safe and idempotent.",
+          "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
           "examples": [
             {
               "title": "Read thread",

--- a/contracts/gen/meta/help.json
+++ b/contracts/gen/meta/help.json
@@ -2215,7 +2215,7 @@
       "path": "/threads/{thread_id}/context",
       "operation_id": "getThreadContext",
       "summary": "Get bundled thread context for agent callers",
-      "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+      "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2232,7 +2232,7 @@
         "commitments"
       ],
       "stability": "beta",
-      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+      "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
       "examples": [
         {
           "title": "Context with defaults",
@@ -2389,7 +2389,7 @@
       "path": "/threads/{thread_id}",
       "operation_id": "getThread",
       "summary": "Get thread snapshot by id",
-      "why": "Resolve authoritative thread state before patching or composing packets.",
+      "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
@@ -2402,7 +2402,7 @@
         "threads"
       ],
       "stability": "stable",
-      "agent_notes": "Safe and idempotent.",
+      "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
       "examples": [
         {
           "title": "Read thread",

--- a/contracts/gen/ts/client.ts
+++ b/contracts/gen/ts/client.ts
@@ -2127,7 +2127,7 @@ export const commandRegistry: CommandSpec[] = [
     "path": "/threads/{thread_id}/context",
     "operation_id": "getThreadContext",
     "summary": "Get bundled thread context for agent callers",
-    "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+    "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
     "input_mode": "none",
     "streaming": {
       "mode": "none"
@@ -2144,7 +2144,7 @@ export const commandRegistry: CommandSpec[] = [
       "commitments"
     ],
     "stability": "beta",
-    "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+    "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
     "examples": [
       {
         "title": "Context with defaults",
@@ -2301,7 +2301,7 @@ export const commandRegistry: CommandSpec[] = [
     "path": "/threads/{thread_id}",
     "operation_id": "getThread",
     "summary": "Get thread snapshot by id",
-    "why": "Resolve authoritative thread state before patching or composing packets.",
+    "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
     "input_mode": "none",
     "streaming": {
       "mode": "none"
@@ -2314,7 +2314,7 @@ export const commandRegistry: CommandSpec[] = [
       "threads"
     ],
     "stability": "stable",
-    "agent_notes": "Safe and idempotent.",
+    "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
     "examples": [
       {
         "title": "Read thread",

--- a/contracts/gen/ts/dist/client.js
+++ b/contracts/gen/ts/dist/client.js
@@ -2083,7 +2083,7 @@ export const commandRegistry = [
         "path": "/threads/{thread_id}/context",
         "operation_id": "getThreadContext",
         "summary": "Get bundled thread context for agent callers",
-        "why": "Load thread state, recent events, key artifacts, and open commitments in a single round-trip.",
+        "why": "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls.",
         "input_mode": "none",
         "streaming": {
             "mode": "none"
@@ -2100,7 +2100,7 @@ export const commandRegistry = [
             "commitments"
         ],
         "stability": "beta",
-        "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter.",
+        "agent_notes": "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read.",
         "examples": [
             {
                 "title": "Context with defaults",
@@ -2257,7 +2257,7 @@ export const commandRegistry = [
         "path": "/threads/{thread_id}",
         "operation_id": "getThread",
         "summary": "Get thread snapshot by id",
-        "why": "Resolve authoritative thread state before patching or composing packets.",
+        "why": "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets.",
         "input_mode": "none",
         "streaming": {
             "mode": "none"
@@ -2270,7 +2270,7 @@ export const commandRegistry = [
             "threads"
         ],
         "stability": "stable",
-        "agent_notes": "Safe and idempotent.",
+        "agent_notes": "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads.",
         "examples": [
             {
                 "title": "Read thread",

--- a/contracts/oar-openapi.yaml
+++ b/contracts/oar-openapi.yaml
@@ -587,7 +587,7 @@ paths:
       tags: [threads]
       x-oar-command-id: "threads.get"
       x-oar-cli-path: "threads get"
-      x-oar-why: "Resolve authoritative thread state before patching or composing packets."
+      x-oar-why: "Resolve a raw authoritative thread snapshot for low-level reads before patching or composing packets."
       x-oar-examples:
         - title: Read thread
           command: oar threads get --thread-id thread_123 --json
@@ -597,7 +597,7 @@ paths:
       x-oar-error-codes: [not_found]
       x-oar-concepts: [threads]
       x-oar-stability: "stable"
-      x-oar-agent-notes: "Safe and idempotent."
+      x-oar-agent-notes: "Safe and idempotent. Prefer `oar threads inspect` for operator coordination reads."
       parameters:
         - $ref: '#/components/parameters/ThreadID'
       responses:
@@ -685,7 +685,7 @@ paths:
       tags: [threads]
       x-oar-command-id: "threads.context"
       x-oar-cli-path: "threads context"
-      x-oar-why: "Load thread state, recent events, key artifacts, and open commitments in a single round-trip."
+      x-oar-why: "Load one thread's state, recent events, key artifacts, and open commitments in a single round-trip; CLI `oar threads context` can aggregate across threads by composing multiple calls."
       x-oar-examples:
         - title: Context with defaults
           command: oar threads context --thread-id thread_123 --json
@@ -697,7 +697,7 @@ paths:
       x-oar-error-codes: [invalid_request, not_found]
       x-oar-concepts: [threads, events, artifacts, commitments]
       x-oar-stability: "beta"
-      x-oar-agent-notes: "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter."
+      x-oar-agent-notes: "Use include_artifact_content for prompt-ready previews; default mode keeps payloads lighter. Prefer `oar threads inspect` as the first single-thread coordination read."
       parameters:
         - $ref: '#/components/parameters/ThreadID'
         - in: query


### PR DESCRIPTION
## Summary
- promote `threads inspect` as the canonical thread coordination read path in CLI help/onboarding text
- de-emphasize overlap by clarifying `threads get` as raw snapshot-only and `threads context` as context API + CLI aggregate composition
- update Pi dogfood command guidance to steer agents to `threads inspect` first
- regenerate contract-derived CLI/docs metadata and add help tests for canonical guidance

## Validation
- `make check`

## Subagent review
- Ran a dedicated subagent diff review for bugs/regressions/test gaps/CLI consistency.
- Finding fixed: contract wording for `/threads/{thread_id}/context` briefly over-promised one-or-many behavior at API level.
- Fix: rewrote metadata to preserve single-thread endpoint semantics and explicitly describe CLI-level aggregation composition; regenerated artifacts and reran checks.

Closes #52
