### PR TITLE
CLI: add first-class threads recommendations review workflow

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,6 +12,7 @@ go run ./cmd/oar --json version
 go run ./cmd/oar --json auth register --username agent.example --base-url http://127.0.0.1:8000 --agent agent-example
 go run ./cmd/oar --agent agent-example auth whoami
 printf '{"thread":{"title":"Incident #42"}}' | go run ./cmd/oar --agent agent-example threads create
+go run ./cmd/oar --agent agent-example threads recommendations --thread-id thread_123 --full-id
 go run ./cmd/oar --agent agent-example events stream --last-event-id event_123
 go run ./cmd/oar --json --agent agent-example provenance walk --from event:event_123 --depth 2
 printf '{"thread":{"title":"Incident #43"}}' | go run ./cmd/oar --agent agent-example draft create --command threads.create

--- a/cli/docs/runbook.md
+++ b/cli/docs/runbook.md
@@ -117,6 +117,7 @@ oar --agent agent-a events list --thread-id thread_123 --thread-id thread_456 --
 oar --json --agent agent-a provenance walk --from event:event_123 --depth 2
 oar --agent agent-a threads context --thread-id thread_123 --max-events 50
 oar --agent agent-a threads context --status active --tag pilot-rescue --type initiative --full-id
+oar --agent agent-a threads recommendations --thread-id thread_123 --full-id
 oar --agent agent-a docs content --document-id product-constitution
 oar --agent agent-a commitments inspect --commitment-id commitment_123
 oar --agent agent-a artifacts inspect --artifact-id artifact_123
@@ -139,7 +140,7 @@ oar --json --base-url http://127.0.0.1:8000 --agent agent-a api call --path /met
 
 Machine-facing notes for the targeted automation commands:
 
-- `events list`, `events get`, `events stream`, `inbox stream`, and `threads context` include a stable `command_id` alongside `command`.
+- `events list`, `events get`, `events stream`, `inbox stream`, `threads context`, and `threads recommendations` include a stable `command_id` alongside `command`.
 - `events tail` and `inbox tail` resolve to canonical machine command identity (`events stream` / `inbox stream`) in JSON success/error envelopes.
 - Stream frames expose a normalized payload contract:
   - `id`, `type`

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -84,6 +84,28 @@ var localHelperTopics = []localHelperTopic{
 			{Name: "--full-id", Description: "Render full event and inbox ids in human output."},
 		},
 	},
+	{
+		Path:        "threads recommendations",
+		Summary:     "Review recommendations/decision signals for one thread with author/time provenance and event follow-up commands.",
+		JSONShape:   "`thread`, `recommendations`, `decision_requests`, `decisions`, `pending_decision_requests`, `follow_up`",
+		Composition: "Resolves one thread by id or discovery filters, loads `threads context`, then derives a recommendation-focused review with pending decision inbox entries.",
+		Examples: []string{
+			"oar threads recommendations --thread-id <thread-id> --full-id",
+			"oar threads recommendations --status active --type initiative",
+		},
+		Flags: []localHelperFlag{
+			{Name: "--thread-id <thread-id>", Description: "Thread id to inspect."},
+			{Name: "--status <status>", Description: "Discover one thread by status."},
+			{Name: "--priority <priority>", Description: "Discover one thread by priority."},
+			{Name: "--stale <bool>", Description: "Discover one thread by stale state."},
+			{Name: "--tag <tag>", Description: "Repeatable discovery tag filter."},
+			{Name: "--cadence <cadence>", Description: "Repeatable discovery cadence filter."},
+			{Name: "--type <thread-type>", Description: "Local discovery filter after `threads list`."},
+			{Name: "--max-events <n>", Description: "Maximum recent context events to include."},
+			{Name: "--include-artifact-content", Description: "Include artifact content previews from `threads context`."},
+			{Name: "--full-id", Description: "Render full event and inbox ids in human output."},
+		},
+	},
 }
 
 func isHelpToken(value string) bool {
@@ -251,6 +273,7 @@ func localGroupHelpSupplement(topic string) string {
 	switch strings.TrimSpace(topic) {
 	case "threads":
 		return strings.TrimSpace(`Coordination helper:
+  threads recommendations     Review recommendation/decision inputs for one thread with provenance + follow-up commands.
   threads inspect             Compose one thread coordination view from context + inbox in one command.
   Tip: use ` + "`--status/--tag/--type initiative`" + ` to discover one initiative view; use ` + "`oar threads context`" + ` for cross-thread aggregates and add ` + "`--full-id`" + ` for copy/paste ids.`)
 	case "events":

--- a/cli/internal/app/human_output.go
+++ b/cli/internal/app/human_output.go
@@ -60,6 +60,8 @@ func formatCommandSummary(commandID string, body any) string {
 		return formatThreadContext(body)
 	case "threads.inspect":
 		return formatThreadInspect(body)
+	case "threads.recommendations":
+		return formatThreadRecommendations(body)
 	case "threads.timeline":
 		return formatThreadTimeline(body)
 	case "commitments.get", "commitments.create", "commitments.patch":
@@ -208,6 +210,29 @@ func formatThreadInspect(body any) string {
 	}
 	inbox := extractNestedMap(root, "inbox")
 	lines = appendInboxListSection(lines, "inbox_items", asSlice(inbox["items"]), fullID)
+	return strings.Join(lines, "\n")
+}
+
+func formatThreadRecommendations(body any) string {
+	root := asMap(body)
+	lines := make([]string, 0, 32)
+	lines = append(lines, formatThreadRecord(extractNestedMap(root, "thread")))
+	fullID := asBool(root["full_id"])
+	lines = appendRecommendationEventListSection(lines, "recommendations", asSlice(root["recommendations"]), fullID)
+	lines = appendRecommendationEventListSection(lines, "decision_requests", asSlice(root["decision_requests"]), fullID)
+	lines = appendRecommendationEventListSection(lines, "decisions", asSlice(root["decisions"]), fullID)
+	pending := extractNestedMap(root, "pending_decision_requests")
+	lines = appendInboxListSection(lines, "pending_decision_requests", asSlice(pending["items"]), fullID)
+	if followUp := extractNestedMap(root, "follow_up"); followUp != nil {
+		lines = append(lines, "follow_up:")
+		for _, key := range []string{"event", "context", "inbox"} {
+			command := strings.TrimSpace(anyString(followUp[key]))
+			if command == "" {
+				continue
+			}
+			lines = append(lines, "- "+command)
+		}
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -453,6 +478,18 @@ func appendEventListSection(lines []string, label string, items []any, fullID bo
 	return lines
 }
 
+func appendRecommendationEventListSection(lines []string, label string, items []any, fullID bool) []string {
+	lines = append(lines, fmt.Sprintf("%s (%d):", label, len(items)))
+	for _, raw := range items {
+		item := asMap(raw)
+		if item == nil {
+			continue
+		}
+		lines = append(lines, "- "+renderRecommendationEventListItemWithMode(item, fullID))
+	}
+	return lines
+}
+
 func appendInboxListSection(lines []string, label string, items []any, fullID bool) []string {
 	lines = append(lines, fmt.Sprintf("%s (%d):", label, len(items)))
 	for _, raw := range items {
@@ -597,6 +634,32 @@ func displayIDWithMode(item map[string]any, fullID bool) string {
 func renderEventListItemWithMode(item map[string]any, fullID bool) string {
 	summary := firstNonEmpty(anyString(item["summary_preview"]), anyString(item["summary"]), anyString(item["created_at"]))
 	return compactSummary(displayEventID(item, fullID), anyString(item["type"]), summary)
+}
+
+func renderRecommendationEventListItemWithMode(item map[string]any, fullID bool) string {
+	summary := strings.Join(strings.Fields(strings.TrimSpace(firstNonEmpty(
+		anyString(item["summary_full"]),
+		anyString(item["summary"]),
+		anyString(item["summary_preview"]),
+		anyString(item["created_at"]),
+	))), " ")
+	parts := []string{displayEventID(item, fullID), anyString(item["type"])}
+	if actorID := strings.TrimSpace(anyString(item["actor_id"])); actorID != "" {
+		parts = append(parts, "actor="+actorID)
+	}
+	if createdAt := strings.TrimSpace(anyString(item["created_at"])); createdAt != "" {
+		parts = append(parts, "at="+createdAt)
+	}
+	if provenanceSources := stringList(item["provenance_sources"]); len(provenanceSources) > 0 {
+		parts = append(parts, "sources="+strings.Join(provenanceSources, ","))
+	}
+	if summary != "" {
+		parts = append(parts, summary)
+	}
+	if inspectCommand := strings.TrimSpace(anyString(item["inspect_command"])); inspectCommand != "" {
+		parts = append(parts, "inspect="+inspectCommand)
+	}
+	return compactSummary(parts...)
 }
 
 func displayEventID(item map[string]any, fullID bool) string {

--- a/cli/internal/app/machine_identity.go
+++ b/cli/internal/app/machine_identity.go
@@ -8,14 +8,15 @@ type machineCommandIdentity struct {
 }
 
 var machineCommandIdentityByPath = map[string]machineCommandIdentity{
-	"events list":     {Command: "events list", CommandID: "threads.timeline"},
-	"events get":      {Command: "events get", CommandID: "events.get"},
-	"events stream":   {Command: "events stream", CommandID: "events.stream"},
-	"events tail":     {Command: "events stream", CommandID: "events.stream"},
-	"inbox stream":    {Command: "inbox stream", CommandID: "inbox.stream"},
-	"inbox tail":      {Command: "inbox stream", CommandID: "inbox.stream"},
-	"threads context": {Command: "threads context", CommandID: "threads.context"},
-	"threads inspect": {Command: "threads inspect", CommandID: "threads.inspect"},
+	"events list":             {Command: "events list", CommandID: "threads.timeline"},
+	"events get":              {Command: "events get", CommandID: "events.get"},
+	"events stream":           {Command: "events stream", CommandID: "events.stream"},
+	"events tail":             {Command: "events stream", CommandID: "events.stream"},
+	"inbox stream":            {Command: "inbox stream", CommandID: "inbox.stream"},
+	"inbox tail":              {Command: "inbox stream", CommandID: "inbox.stream"},
+	"threads context":         {Command: "threads context", CommandID: "threads.context"},
+	"threads inspect":         {Command: "threads inspect", CommandID: "threads.inspect"},
+	"threads recommendations": {Command: "threads recommendations", CommandID: "threads.recommendations"},
 }
 
 func resolveMachineCommandIdentity(command string) machineCommandIdentity {

--- a/cli/internal/app/meta_help_test.go
+++ b/cli/internal/app/meta_help_test.go
@@ -117,6 +117,9 @@ func TestRunGeneratedHelpTopic(t *testing.T) {
 	if !strings.Contains(output, "threads inspect") {
 		t.Fatalf("expected local threads inspect helper in generated help output=%s", output)
 	}
+	if !strings.Contains(output, "threads recommendations") {
+		t.Fatalf("expected local threads recommendations helper in generated help output=%s", output)
+	}
 	if strings.Contains(output, "threads update") {
 		t.Fatalf("unexpected legacy update subcommand in generated help output=%s", output)
 	}
@@ -234,6 +237,8 @@ func TestRunLocalHelperHelpTopicsResolveAcrossEntryPoints(t *testing.T) {
 	eventsFromFlag := run([]string{"events", "list", "--help"})
 	threadsFromTopic := run([]string{"help", "threads", "inspect"})
 	threadsFromFlag := run([]string{"threads", "inspect", "--help"})
+	threadsRecommendationsFromTopic := run([]string{"help", "threads", "recommendations"})
+	threadsRecommendationsFromFlag := run([]string{"threads", "recommendations", "--help"})
 
 	for _, output := range []string{eventsFromTopic, eventsFromFlag} {
 		if !strings.Contains(output, "Local Help: events list") {
@@ -251,11 +256,22 @@ func TestRunLocalHelperHelpTopicsResolveAcrossEntryPoints(t *testing.T) {
 			t.Fatalf("expected composed-helper details output=%s", output)
 		}
 	}
+	for _, output := range []string{threadsRecommendationsFromTopic, threadsRecommendationsFromFlag} {
+		if !strings.Contains(output, "Local Help: threads recommendations") {
+			t.Fatalf("expected local threads recommendations help header output=%s", output)
+		}
+		if !strings.Contains(output, "decision signals") || !strings.Contains(output, "threads context") {
+			t.Fatalf("expected recommendation-helper details output=%s", output)
+		}
+	}
 	if eventsFromTopic != eventsFromFlag {
 		t.Fatalf("expected same events list help via topic and --help\nhelp output:\n%s\nflag output:\n%s", eventsFromTopic, eventsFromFlag)
 	}
 	if threadsFromTopic != threadsFromFlag {
 		t.Fatalf("expected same threads inspect help via topic and --help\nhelp output:\n%s\nflag output:\n%s", threadsFromTopic, threadsFromFlag)
+	}
+	if threadsRecommendationsFromTopic != threadsRecommendationsFromFlag {
+		t.Fatalf("expected same threads recommendations help via topic and --help\nhelp output:\n%s\nflag output:\n%s", threadsRecommendationsFromTopic, threadsRecommendationsFromFlag)
 	}
 }
 

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -469,6 +469,9 @@ func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.R
 	case "inspect":
 		result, err := a.runThreadsInspectCommand(ctx, args[1:], cfg)
 		return result, "threads inspect", err
+	case "recommendations":
+		result, err := a.runThreadsRecommendationsCommand(ctx, args[1:], cfg)
+		return result, "threads recommendations", err
 	default:
 		return nil, "threads", threadsSubcommandSpec.unknownError(args[0])
 	}
@@ -722,6 +725,95 @@ func (a *App) runThreadsInspectCommand(ctx context.Context, args []string, cfg c
 		intValue(data["status_code"]),
 		headerValues(data["headers"]),
 		inspectBody,
+		cfg.Verbose,
+		cfg.Headers,
+	)
+	return contextResult, nil
+}
+
+func (a *App) runThreadsRecommendationsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
+	selection, err := parseThreadContextSelectionArgs(args, "threads recommendations")
+	if err != nil {
+		return nil, err
+	}
+	threadIDs, err := a.resolveThreadContextSelection(ctx, cfg, "threads recommendations", selection, false)
+	if err != nil {
+		return nil, err
+	}
+
+	contextResult, callErr := a.invokeTypedJSONWithIDResolution(
+		ctx,
+		cfg,
+		"threads context",
+		"threads.context",
+		"thread_id",
+		threadIDs[0],
+		threadIDLookupSpec,
+		threadContextQuery(selection),
+		nil,
+	)
+	if callErr != nil {
+		return nil, callErr
+	}
+
+	data := asMap(contextResult.Data)
+	body := asMap(data["body"])
+	if body == nil {
+		return contextResult, nil
+	}
+	addThreadContextCollaborationSummary(body)
+
+	thread := extractNestedMap(body, "thread")
+	resolvedThreadID := firstNonEmpty(strings.TrimSpace(anyString(body["thread_id"])), strings.TrimSpace(anyString(thread["id"])), strings.TrimSpace(threadIDs[0]))
+	collaboration := asMap(body["collaboration_summary"])
+
+	recommendations := decorateRecommendationReviewEvents(asSlice(collaboration["recommendations"]))
+	decisionRequests := decorateRecommendationReviewEvents(asSlice(collaboration["decision_requests"]))
+	decisions := decorateRecommendationReviewEvents(asSlice(collaboration["decisions"]))
+
+	inboxResult, err := a.invokeTypedJSON(ctx, cfg, "inbox list", "inbox.list", nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	inboxData := asMap(inboxResult.Data)
+	inboxBody := extractNestedMap(inboxData, "body")
+	pendingDecisionRequests := filteredInboxItems(asSlice(inboxBody["items"]), []string{resolvedThreadID}, []string{"decision_needed"})
+
+	reviewBody := map[string]any{
+		"thread_id":         resolvedThreadID,
+		"full_id":           selection.fullID,
+		"thread":            thread,
+		"recommendations":   recommendations,
+		"decision_requests": decisionRequests,
+		"decisions":         decisions,
+		"pending_decision_requests": map[string]any{
+			"thread_id": resolvedThreadID,
+			"items":     pendingDecisionRequests,
+			"count":     len(pendingDecisionRequests),
+			"full_id":   selection.fullID,
+			"source":    "inbox.list",
+		},
+		"counts": map[string]any{
+			"recommendations":           len(recommendations),
+			"decision_requests":         len(decisionRequests),
+			"decisions":                 len(decisions),
+			"pending_decision_requests": len(pendingDecisionRequests),
+		},
+		"context_source": "threads.context",
+		"follow_up": map[string]any{
+			"event":   "oar events get --event-id <event-id> --json",
+			"context": "oar threads context --thread-id <thread-id> --include-artifact-content --full-id --json",
+			"inbox":   "oar inbox get --id <inbox-id-or-alias> --json",
+		},
+	}
+
+	data["body"] = reviewBody
+	contextResult.Data = data
+	contextResult.Text = formatTypedCommandText(
+		"threads.recommendations",
+		intValue(data["status_code"]),
+		headerValues(data["headers"]),
+		reviewBody,
 		cfg.Verbose,
 		cfg.Headers,
 	)
@@ -2977,6 +3069,73 @@ func eventSummaryPreview(event map[string]any) string {
 		return truncatePreview(strings.Join(refs, ", "))
 	}
 	return truncatePreview(strings.TrimSpace(anyString(event["created_at"])))
+}
+
+func decorateRecommendationReviewEvents(events []any) []any {
+	if len(events) == 0 {
+		return []any{}
+	}
+	out := make([]any, 0, len(events))
+	for _, raw := range events {
+		event := asMap(raw)
+		if event == nil {
+			continue
+		}
+		enriched := cloneMap(event)
+		id := strings.TrimSpace(anyString(enriched["id"]))
+		if id != "" && strings.TrimSpace(anyString(enriched["short_id"])) == "" {
+			enriched["short_id"] = shortID(id)
+		}
+		if summary := recommendationEventSummary(enriched); summary != "" {
+			enriched["summary_full"] = summary
+		}
+		if id != "" {
+			enriched["inspect_command"] = fmt.Sprintf("oar events get --event-id %s --json", id)
+		}
+		if sources := recommendationEventProvenanceSources(enriched); len(sources) > 0 {
+			enriched["provenance_sources"] = sources
+		}
+		out = append(out, enriched)
+	}
+	sortEventsByCreatedAt(out)
+	return out
+}
+
+func recommendationEventSummary(event map[string]any) string {
+	if event == nil {
+		return ""
+	}
+	if summary := strings.TrimSpace(anyString(event["summary"])); summary != "" {
+		return strings.Join(strings.Fields(summary), " ")
+	}
+	payload := asMap(event["payload"])
+	if payload != nil {
+		for _, key := range []string{"recommendation", "decision", "summary", "statement", "message", "title", "content", "text"} {
+			if value := compactPreviewValue(payload[key]); value != "" {
+				return strings.Join(strings.Fields(value), " ")
+			}
+		}
+		if encoded, err := json.Marshal(payload); err == nil {
+			if value := strings.TrimSpace(string(encoded)); value != "" && value != "{}" {
+				return value
+			}
+		}
+	}
+	if refs := stringList(event["refs"]); len(refs) > 0 {
+		return strings.Join(refs, ", ")
+	}
+	return strings.TrimSpace(anyString(event["created_at"]))
+}
+
+func recommendationEventProvenanceSources(event map[string]any) []string {
+	if event == nil {
+		return nil
+	}
+	provenance := asMap(event["provenance"])
+	if provenance == nil {
+		return nil
+	}
+	return stringList(provenance["sources"])
 }
 
 func compactPreviewValue(raw any) string {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -1754,6 +1754,273 @@ func TestThreadsInspectRejectsMixedSelectionModes(t *testing.T) {
 	}
 }
 
+func TestThreadsRecommendationsBuildsFocusedReview(t *testing.T) {
+	t.Parallel()
+
+	const recommendationEventID = "event_rec_1234567890abcdef"
+	const decisionInboxID = "inbox:decision_needed:thread_1:none:event_need_1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/thread_1/context":
+			_, _ = w.Write([]byte(`{
+				"thread":{"id":"thread_1","title":"Pilot Rescue","status":"active","type":"initiative"},
+				"recent_events":[
+					{"id":"` + recommendationEventID + `","thread_id":"thread_1","type":"actor_statement","actor_id":"pm-1","created_at":"2026-03-07T00:00:00Z","summary":"recommend launching rescue scope once docs are signed","provenance":{"sources":["event:event_seed_1"]}},
+					{"id":"event_need_1","thread_id":"thread_1","type":"decision_needed","actor_id":"lead-1","created_at":"2026-03-07T00:01:00Z","summary":"confirm launch date"},
+					{"id":"event_done_1","thread_id":"thread_1","type":"decision_made","actor_id":"director-1","created_at":"2026-03-07T00:02:00Z","summary":"launch Friday"}
+				],
+				"key_artifacts":[],
+				"open_commitments":[]
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
+			_, _ = w.Write([]byte(`{"items":[
+				{"id":"` + decisionInboxID + `","thread_id":"thread_1","type":"decision_needed","summary":"launch date still needs acknowledgement"},
+				{"id":"inbox:decision_needed:thread_2:none:event_other","thread_id":"thread_2","type":"decision_needed","summary":"ignore other thread"}
+			]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", "thread_1",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	if got := anyStringValue(payload["command"]); got != "threads recommendations" {
+		t.Fatalf("expected threads recommendations command, got %#v", payload)
+	}
+	if got := anyStringValue(payload["command_id"]); got != "threads.recommendations" {
+		t.Fatalf("expected threads.recommendations command_id, got %#v", payload)
+	}
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	recommendations, _ := body["recommendations"].([]any)
+	if len(recommendations) != 1 {
+		t.Fatalf("expected 1 recommendation, got %#v", body)
+	}
+	recommendation, _ := recommendations[0].(map[string]any)
+	if got := anyStringValue(recommendation["inspect_command"]); got != "oar events get --event-id "+recommendationEventID+" --json" {
+		t.Fatalf("expected inspect_command for recommendation event, got %#v", recommendation)
+	}
+	if got := anyStringValue(recommendation["summary_full"]); got != "recommend launching rescue scope once docs are signed" {
+		t.Fatalf("expected non-truncated recommendation summary, got %#v", recommendation)
+	}
+	if got := anyStringValue(recommendation["actor_id"]); got != "pm-1" {
+		t.Fatalf("expected recommendation actor_id pm-1, got %#v", recommendation)
+	}
+	provenanceSources := stringList(recommendation["provenance_sources"])
+	if len(provenanceSources) != 1 || provenanceSources[0] != "event:event_seed_1" {
+		t.Fatalf("expected provenance source in recommendation, got %#v", recommendation)
+	}
+	pendingDecisionRequests, _ := body["pending_decision_requests"].(map[string]any)
+	pendingCount, _ := pendingDecisionRequests["count"].(float64)
+	if got := int(pendingCount); got != 1 {
+		t.Fatalf("expected pending decision request count=1, got %#v", pendingDecisionRequests)
+	}
+	followUp, _ := body["follow_up"].(map[string]any)
+	if !strings.Contains(anyStringValue(followUp["event"]), "oar events get --event-id <event-id> --json") {
+		t.Fatalf("expected follow-up event guidance, got %#v", followUp)
+	}
+}
+
+func TestThreadsRecommendationsHumanOutputShowsProvenanceAndFollowUp(t *testing.T) {
+	t.Parallel()
+
+	const recommendationEventID = "event_rec_human_1"
+	const longSummary = "recommend rolling out in staged phases after support readiness review and launch-ops signoff with full comms checklist coverage for final decision alignment"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/thread_1/context":
+			_, _ = w.Write([]byte(`{
+				"thread":{"id":"thread_1","title":"Pilot Rescue","status":"active"},
+				"recent_events":[
+					{"id":"` + recommendationEventID + `","thread_id":"thread_1","type":"actor_statement","actor_id":"pm-2","created_at":"2026-03-07T01:00:00Z","summary":"` + longSummary + `","provenance":{"sources":["event:event_seed_human_1"]}}
+				],
+				"key_artifacts":[],
+				"open_commitments":[]
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
+			_, _ = w.Write([]byte(`{"items":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	human := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", "thread_1",
+		"--full-id",
+	})
+	if !strings.Contains(human, "recommendations (1):") || !strings.Contains(human, "actor=pm-2") || !strings.Contains(human, "at=2026-03-07T01:00:00Z") {
+		t.Fatalf("expected recommendation provenance details in human output, got:\n%s", human)
+	}
+	if !strings.Contains(human, longSummary) {
+		t.Fatalf("expected non-truncated summary in human output, got:\n%s", human)
+	}
+	if !strings.Contains(human, "inspect=oar events get --event-id "+recommendationEventID+" --json") {
+		t.Fatalf("expected event inspect follow-up in human output, got:\n%s", human)
+	}
+	if !strings.Contains(human, "follow_up:") || !strings.Contains(human, "oar inbox get --id <inbox-id-or-alias> --json") {
+		t.Fatalf("expected follow_up section in human output, got:\n%s", human)
+	}
+}
+
+func TestThreadsRecommendationsDiscoveryRequiresSingleThread(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"threads":[
+				{"id":"thread_init_1","type":"initiative","status":"active"},
+				{"id":"thread_init_2","type":"initiative","status":"active"}
+			]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--status", "active",
+		"--type", "initiative",
+	})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj == nil || anyStringValue(errObj["code"]) != "invalid_request" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	if !strings.Contains(anyStringValue(errObj["message"]), "exactly one thread") || !strings.Contains(anyStringValue(errObj["message"]), "oar threads context") {
+		t.Fatalf("expected single-thread guidance, got %#v", payload)
+	}
+}
+
+func TestThreadsRecommendationsPropagatesContextQueryFlags(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/thread_1/context":
+			if got := r.URL.Query().Get("max_events"); got != "3" {
+				t.Fatalf("expected max_events=3, got %q", got)
+			}
+			if got := r.URL.Query().Get("include_artifact_content"); got != "true" {
+				t.Fatalf("expected include_artifact_content=true, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"thread":{"id":"thread_1"},"recent_events":[],"key_artifacts":[],"open_commitments":[]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
+			_, _ = w.Write([]byte(`{"items":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", "thread_1",
+		"--max-events", "3",
+		"--include-artifact-content",
+	}))
+	if got := anyStringValue(payload["command"]); got != "threads recommendations" {
+		t.Fatalf("expected threads recommendations command, got %#v", payload)
+	}
+}
+
+func TestThreadsRecommendationsInboxFailurePreservesMachineIdentity(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/thread_1/context":
+			_, _ = w.Write([]byte(`{"thread":{"id":"thread_1"},"recent_events":[],"key_artifacts":[],"open_commitments":[]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"code":"inbox_unavailable","message":"inbox list unavailable"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	errPayload := assertEnvelopeError(t, runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", "thread_1",
+	}))
+	if got := anyStringValue(errPayload["command"]); got != "threads recommendations" {
+		t.Fatalf("expected threads recommendations error command, got %#v", errPayload)
+	}
+	if got := anyStringValue(errPayload["command_id"]); got != "threads.recommendations" {
+		t.Fatalf("expected threads.recommendations command_id, got %#v", errPayload)
+	}
+}
+
+func TestThreadsRecommendationsResolvesShortThreadID(t *testing.T) {
+	t.Parallel()
+
+	const canonicalThreadID = "fff63e25-084b-4598-af8f-b6d0a4fbf001"
+	const shortPrefix = "fff63e25-084b-4598-af8f"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/"+shortPrefix+"/context":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"thread not found"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/threads":
+			_, _ = w.Write([]byte(`{"threads":[{"id":"` + canonicalThreadID + `"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/threads/"+canonicalThreadID+"/context":
+			_, _ = w.Write([]byte(`{"thread":{"id":"` + canonicalThreadID + `","title":"Pilot Rescue"},"recent_events":[],"key_artifacts":[],"open_commitments":[]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
+			_, _ = w.Write([]byte(`{"items":[{"id":"inbox:decision_needed:` + canonicalThreadID + `:none:event_1","thread_id":"` + canonicalThreadID + `","type":"decision_needed"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", shortPrefix,
+	}))
+	data, _ := payload["data"].(map[string]any)
+	body, _ := data["body"].(map[string]any)
+	if got := anyStringValue(body["thread_id"]); got != canonicalThreadID {
+		t.Fatalf("expected canonical thread_id %q, got %#v", canonicalThreadID, body)
+	}
+	pending, _ := body["pending_decision_requests"].(map[string]any)
+	if got := anyStringValue(pending["thread_id"]); got != canonicalThreadID {
+		t.Fatalf("expected pending_decision_requests.thread_id=%q, got %#v", canonicalThreadID, body)
+	}
+}
+
 func TestThreadsContextHumanOutputIsPayloadFirst(t *testing.T) {
 	t.Parallel()
 
@@ -2575,6 +2842,31 @@ func TestMachineFacingTargetedCommandGoldens(t *testing.T) {
 		t.Fatalf("expected inbox section in inspect payload, got %#v", threadsInspectBody)
 	}
 
+	threadsRecommendationsOut := runCLIForTest(t, home, env, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"threads", "recommendations",
+		"--thread-id", "thread_123",
+	})
+	threadsRecommendationsPayload := assertEnvelopeOK(t, threadsRecommendationsOut)
+	if got := anyStringValue(threadsRecommendationsPayload["command"]); got != "threads recommendations" {
+		t.Fatalf("expected threads recommendations command label, got %#v", threadsRecommendationsPayload)
+	}
+	if got := anyStringValue(threadsRecommendationsPayload["command_id"]); got != "threads.recommendations" {
+		t.Fatalf("expected threads.recommendations command_id, got %#v", threadsRecommendationsPayload)
+	}
+	threadsRecommendationsData, _ := threadsRecommendationsPayload["data"].(map[string]any)
+	threadsRecommendationsBody, _ := threadsRecommendationsData["body"].(map[string]any)
+	if _, ok := threadsRecommendationsBody["recommendations"].([]any); !ok {
+		t.Fatalf("expected recommendations section in payload, got %#v", threadsRecommendationsBody)
+	}
+	if _, ok := threadsRecommendationsBody["pending_decision_requests"].(map[string]any); !ok {
+		t.Fatalf("expected pending_decision_requests section in payload, got %#v", threadsRecommendationsBody)
+	}
+	if _, ok := threadsRecommendationsBody["follow_up"].(map[string]any); !ok {
+		t.Fatalf("expected follow_up section in payload, got %#v", threadsRecommendationsBody)
+	}
+
 	eventsStreamOut := runCLIForTest(t, home, env, nil, []string{
 		"--json",
 		"--base-url", server.URL,
@@ -2716,6 +3008,17 @@ func TestMachineFacingNonStreamErrorsIncludeCommandIdentity(t *testing.T) {
 	}
 	if got := anyStringValue(threadsContextErr["command_id"]); got != "threads.context" {
 		t.Fatalf("expected threads.context command_id, got %q payload=%#v", got, threadsContextErr)
+	}
+
+	threadsRecommendationsErr := assertEnvelopeError(t, runCLIForTest(t, home, env, nil, []string{
+		"--json",
+		"threads", "recommendations",
+	}))
+	if got := anyStringValue(threadsRecommendationsErr["command"]); got != "threads recommendations" {
+		t.Fatalf("expected threads recommendations error command, got %q payload=%#v", got, threadsRecommendationsErr)
+	}
+	if got := anyStringValue(threadsRecommendationsErr["command_id"]); got != "threads.recommendations" {
+		t.Fatalf("expected threads.recommendations command_id, got %q payload=%#v", got, threadsRecommendationsErr)
 	}
 }
 

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -50,8 +50,8 @@ var provenanceSubcommandSpec = subcommandSpec{
 
 var threadsSubcommandSpec = subcommandSpec{
 	command:  "threads",
-	valid:    []string{"list", "get", "create", "patch", "timeline", "context", "inspect"},
-	examples: []string{"oar threads list --status active", "oar threads inspect --status active --type initiative --full-id"},
+	valid:    []string{"list", "get", "create", "patch", "timeline", "context", "inspect", "recommendations"},
+	examples: []string{"oar threads list --status active", "oar threads recommendations --thread-id <thread-id> --full-id"},
 	aliases: map[string]string{
 		"ls":     "list",
 		"update": "patch",


### PR DESCRIPTION
## Summary
- add a first-class `threads recommendations` CLI helper for single-thread recommendation/decision review
- include actor/timestamp/provenance and explicit follow-up commands to inspect full event payloads (`oar events get`)
- surface pending decision requests from inbox for the same thread
- wire helper into command guidance/help, machine `command_id`, and CLI docs

## Tests
- `cd cli && go test ./...`
- `make cli-check`

Closes #53
