### PR TITLE
Support mounting oar-ui under a path prefix

### DIFF
--- a/web-ui/.env.example
+++ b/web-ui/.env.example
@@ -1,3 +1,6 @@
 # Base URL for oar-core API.
 # Leave unset for same-origin.
 PUBLIC_OAR_CORE_BASE_URL=http://127.0.0.1:8000
+
+# Optional external mount prefix for the UI, for example /oar.
+OAR_UI_BASE_PATH=

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -27,6 +27,10 @@ This package contains the SvelteKit web UI for Organization Autorunner.
   - `/` redirects to the default project.
   - Legacy root page routes (`/threads`, `/inbox`, etc.) redirect to the default
     project for convenience.
+- Optional external mount prefix: `OAR_UI_BASE_PATH=/oar`
+  - External routes become `/oar/:project/...`
+  - Build/dev the UI with the same base path you plan to serve
+  - Reverse proxies should preserve the prefix instead of stripping it
 
 - The SvelteKit server resolves proxied API traffic from the active project
   context and forwards requests to the matching `oar-core`.

--- a/web-ui/docs/runbook.md
+++ b/web-ui/docs/runbook.md
@@ -29,6 +29,10 @@ Route model:
 - `/` redirects to `/${OAR_DEFAULT_PROJECT}`.
 - Root page routes such as `/threads` and `/inbox` redirect to the default
   project to ease local use and old bookmarks.
+- Optional mount prefix: set `OAR_UI_BASE_PATH=/oar`
+  - External routes become `/oar/:project/...`
+  - `OAR_UI_BASE_PATH` is applied by SvelteKit at dev/build startup, so use the
+    intended value when running `./scripts/dev` or `./scripts/build`
 
 Single-core fallback:
 
@@ -91,6 +95,16 @@ OAR_DEFAULT_PROJECT=local \
 ./scripts/dev
 ```
 
+With an external mount prefix:
+
+```bash
+cd ../web-ui
+OAR_PROJECTS='[{"slug":"local","label":"Local","coreBaseUrl":"http://127.0.0.1:8000"}]' \
+OAR_DEFAULT_PROJECT=local \
+OAR_UI_BASE_PATH=/oar \
+./scripts/dev
+```
+
 Two cores:
 
 ```bash
@@ -142,15 +156,17 @@ Example Caddy config for external URLs like
 
 ```caddy
 m2-internal.scalingforever.com {
-  handle_path /oar/* {
+  handle /oar* {
     reverse_proxy 127.0.0.1:4173
   }
 }
 ```
 
-`handle_path` strips `/oar`, so the UI receives `/:project/...` as expected.
-The UI server then proxies API traffic to the matching `oar-core` from
-`OAR_PROJECTS`. Core instances do not need to be internet-exposed.
+Configure the UI with `OAR_UI_BASE_PATH=/oar` when building or running the dev
+server. The reverse proxy must preserve `/oar` so SvelteKit can route and
+generate links under the configured base path. The UI server then proxies API
+traffic to the matching `oar-core` from `OAR_PROJECTS`. Core instances do not
+need to be internet-exposed.
 
 ## WebAuthn and hostname/origin limits
 

--- a/web-ui/playwright.config.js
+++ b/web-ui/playwright.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
 const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+const basePathPort = Number(process.env.PLAYWRIGHT_BASE_PATH_PORT ?? 4174);
+const appBasePath = process.env.PLAYWRIGHT_APP_BASE_PATH ?? "/oar";
 
 export default defineConfig({
   testDir: "tests/e2e",
@@ -10,14 +12,41 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "list",
   use: {
-    baseURL: `http://127.0.0.1:${port}`,
     headless: true,
     trace: "on-first-retry",
   },
-  webServer: {
-    command: `pnpm exec vite dev --host 127.0.0.1 --port ${port}`,
-    port,
-    timeout: 120000,
-    reuseExistingServer: !process.env.CI,
-  },
+  projects: [
+    {
+      name: "default",
+      testIgnore: /base-path\.spec\.js/,
+      use: {
+        baseURL: `http://127.0.0.1:${port}`,
+      },
+    },
+    {
+      name: "base-path",
+      testMatch: /base-path\.spec\.js/,
+      use: {
+        baseURL: `http://127.0.0.1:${basePathPort}`,
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: `pnpm exec vite dev --host 127.0.0.1 --port ${port}`,
+      port,
+      timeout: 120000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: `pnpm exec vite dev --host 127.0.0.1 --port ${basePathPort}`,
+      env: {
+        ...process.env,
+        OAR_UI_BASE_PATH: appBasePath,
+      },
+      port: basePathPort,
+      timeout: 120000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });

--- a/web-ui/src/hooks.server.js
+++ b/web-ui/src/hooks.server.js
@@ -1,6 +1,6 @@
 import { env } from "$env/dynamic/private";
 import { isProxyableCommand } from "$lib/coreRouteCatalog";
-import { PROJECT_HEADER } from "$lib/projectPaths";
+import { PROJECT_HEADER, stripBasePath } from "$lib/projectPaths";
 import { loadProjectCatalog } from "$lib/server/projectCatalog";
 import { buildProxyRequestInit } from "$lib/server/coreProxy";
 import { resolveProxyProjectTarget } from "$lib/server/proxyProjectTarget";
@@ -33,8 +33,9 @@ function resolveProjectTarget(event) {
 }
 
 async function proxyToCore(event, coreBaseUrl) {
+  const corePathname = stripBasePath(event.url.pathname);
   const targetUrl = new URL(
-    `${event.url.pathname}${event.url.search}`,
+    `${corePathname}${event.url.search}`,
     `${coreBaseUrl}/`,
   ).toString();
   const requestInit = buildProxyRequestInit(event);
@@ -72,7 +73,7 @@ async function proxyToCore(event, coreBaseUrl) {
 }
 
 export async function handle({ event, resolve }) {
-  const pathname = event.url.pathname;
+  const pathname = stripBasePath(event.url.pathname);
   const method = event.request.method;
   const documentNavigation = isDocumentNavigationRequest(event.request);
   const proxyableRequest =

--- a/web-ui/src/lib/authSession.js
+++ b/web-ui/src/lib/authSession.js
@@ -5,6 +5,7 @@ import { normalizeBaseUrl } from "./config.js";
 import { getCurrentProjectSlug, currentProjectSlug } from "./projectContext.js";
 import {
   DEFAULT_PROJECT_SLUG,
+  appPath,
   buildProjectStorageKey,
   projectPath,
 } from "./projectPaths.js";
@@ -62,7 +63,7 @@ function resolveFetch(fetchFn) {
 function buildUrl(pathname, baseUrl = "") {
   const resolvedBaseUrl = resolveBaseUrl(baseUrl);
   if (!resolvedBaseUrl) {
-    return pathname;
+    return appPath(pathname);
   }
 
   return new URL(pathname, `${resolvedBaseUrl}/`).toString();

--- a/web-ui/src/lib/oarCoreClient.js
+++ b/web-ui/src/lib/oarCoreClient.js
@@ -4,6 +4,7 @@ import {
 } from "../../../contracts/gen/ts/dist/client.js";
 
 import { EXPECTED_SCHEMA_VERSION, normalizeBaseUrl } from "./config.js";
+import { appPath } from "./projectPaths.js";
 
 const commandRegistryByID = new Map(
   commandRegistry.map((command) => [command.command_id, command]),
@@ -165,7 +166,9 @@ export function createOarCoreClient(options = {}) {
       ? baseFetchFn
       : (input, init) => {
           const parsedUrl = new URL(String(input), sameOriginProxyBaseUrl);
-          const relativeUrl = `${parsedUrl.pathname}${parsedUrl.search}`;
+          const relativeUrl = appPath(
+            `${parsedUrl.pathname}${parsedUrl.search}`,
+          );
           return baseFetchFn(relativeUrl, init);
         };
 

--- a/web-ui/src/lib/projectPaths.js
+++ b/web-ui/src/lib/projectPaths.js
@@ -1,3 +1,5 @@
+import { base } from "$app/paths";
+
 export const DEFAULT_PROJECT_SLUG = "local";
 export const PROJECT_HEADER = "x-oar-project-slug";
 
@@ -20,19 +22,64 @@ export function normalizeAppPath(pathname = "/") {
   return normalized;
 }
 
-export function projectPath(projectSlug, pathname = "/") {
+export function normalizeBasePath(pathname = "") {
+  const normalized = normalizeAppPath(pathname);
+  return normalized === "/" ? "" : normalized;
+}
+
+export const APP_BASE_PATH = normalizeBasePath(base);
+
+export function appPath(pathname = "/", basePath = APP_BASE_PATH) {
+  const normalizedPathname = normalizeAppPath(pathname);
+  if (!basePath) {
+    return normalizedPathname;
+  }
+
+  return normalizedPathname === "/"
+    ? basePath
+    : `${basePath}${normalizedPathname}`;
+}
+
+export function stripBasePath(pathname = "/", basePath = APP_BASE_PATH) {
+  const normalizedPathname = normalizeAppPath(pathname);
+  if (!basePath) {
+    return normalizedPathname;
+  }
+
+  if (normalizedPathname === basePath) {
+    return "/";
+  }
+
+  if (normalizedPathname.startsWith(`${basePath}/`)) {
+    return normalizedPathname.slice(basePath.length);
+  }
+
+  return normalizedPathname;
+}
+
+export function projectPath(
+  projectSlug,
+  pathname = "/",
+  basePath = APP_BASE_PATH,
+) {
   const slug = normalizeProjectSlug(projectSlug);
   if (!slug) {
     throw new Error("project slug is required");
   }
 
-  const appPath = normalizeAppPath(pathname);
-  return appPath === "/" ? `/${slug}` : `/${slug}${appPath}`;
+  const normalizedPathname = normalizeAppPath(pathname);
+  return normalizedPathname === "/"
+    ? appPath(`/${slug}`, basePath)
+    : appPath(`/${slug}${normalizedPathname}`, basePath);
 }
 
-export function stripProjectPath(pathname, projectSlug) {
+export function stripProjectPath(
+  pathname,
+  projectSlug,
+  basePath = APP_BASE_PATH,
+) {
   const slug = normalizeProjectSlug(projectSlug);
-  const normalizedPathname = normalizeAppPath(pathname);
+  const normalizedPathname = stripBasePath(pathname, basePath);
   if (!slug) {
     return normalizedPathname;
   }

--- a/web-ui/src/lib/refLinkModel.js
+++ b/web-ui/src/lib/refLinkModel.js
@@ -1,5 +1,5 @@
 import { parseRef, renderRef } from "./typedRefs.js";
-import { projectPath } from "./projectPaths.js";
+import { appPath, projectPath } from "./projectPaths.js";
 
 function asPathSegment(value) {
   return encodeURIComponent(String(value));
@@ -59,7 +59,7 @@ function resolveRefLabels(raw, prefix, value, options = {}) {
 }
 
 function toProjectHref(projectSlug, pathname) {
-  return projectSlug ? projectPath(projectSlug, pathname) : pathname;
+  return projectSlug ? projectPath(projectSlug, pathname) : appPath(pathname);
 }
 
 export function resolveRefLink(refValue, options = {}) {

--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -25,7 +25,11 @@
   import { coreClient } from "$lib/coreClient";
   import { getShellContentConfig, navigationItems } from "$lib/navigation";
   import { setCurrentProjectSlug } from "$lib/projectContext";
-  import { projectPath, stripProjectPath } from "$lib/projectPaths";
+  import {
+    projectPath,
+    stripBasePath,
+    stripProjectPath,
+  } from "$lib/projectPaths";
 
   let { children, data } = $props();
 
@@ -52,7 +56,7 @@
   let currentAppPath = $derived(
     activeProjectSlug
       ? stripProjectPath($page.url.pathname, activeProjectSlug)
-      : $page.url.pathname,
+      : stripBasePath($page.url.pathname),
   );
   let identityReady = $derived($actorSessionReady && $authSessionReady);
   let principalActorId = $derived($authenticatedAgent?.actor_id ?? "");
@@ -384,16 +388,32 @@
               {projectInitials(activeProject?.label)}
             </span>
             <span class="project-switcher-label">
-              <span class="project-switcher-name">{activeProject?.label || activeProjectSlug}</span>
+              <span class="project-switcher-name"
+                >{activeProject?.label || activeProjectSlug}</span
+              >
               <span class="project-switcher-sub">OAR Control Surface</span>
             </span>
-            <svg class="project-switcher-chevron" class:project-switcher-chevron--open={projectPickerOpen} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            <svg
+              class="project-switcher-chevron"
+              class:project-switcher-chevron--open={projectPickerOpen}
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                clip-rule="evenodd"
+              />
             </svg>
           </button>
 
           {#if projectPickerOpen}
-            <div class="project-switcher-dropdown" role="listbox" aria-label="Switch project">
+            <div
+              class="project-switcher-dropdown"
+              role="listbox"
+              aria-label="Switch project"
+            >
               {#each data.projects ?? [] as project}
                 {@const isCurrent = project.slug === activeProjectSlug}
                 <button
@@ -410,12 +430,23 @@
                   <span class="project-switcher-option-label">
                     <span>{project.label}</span>
                     {#if project.description}
-                      <span class="project-switcher-option-desc">{project.description}</span>
+                      <span class="project-switcher-option-desc"
+                        >{project.description}</span
+                      >
                     {/if}
                   </span>
                   {#if isCurrent}
-                    <svg class="project-switcher-check" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+                    <svg
+                      class="project-switcher-check"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                        clip-rule="evenodd"
+                      />
                     </svg>
                   {/if}
                 </button>
@@ -548,18 +579,33 @@
                     <button
                       class="project-switcher-option"
                       class:project-switcher-option--active={isCurrent}
-                      onclick={() => { pickProject(project.slug); closeMobileNav(); }}
+                      onclick={() => {
+                        pickProject(project.slug);
+                        closeMobileNav();
+                      }}
                       type="button"
                     >
-                      <span class="project-switcher-option-icon" aria-hidden="true">
+                      <span
+                        class="project-switcher-option-icon"
+                        aria-hidden="true"
+                      >
                         {projectInitials(project.label)}
                       </span>
                       <span class="project-switcher-option-label">
                         <span>{project.label}</span>
                       </span>
                       {#if isCurrent}
-                        <svg class="project-switcher-check" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                          <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+                        <svg
+                          class="project-switcher-check"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                            clip-rule="evenodd"
+                          />
                         </svg>
                       {/if}
                     </button>

--- a/web-ui/svelte.config.js
+++ b/web-ui/svelte.config.js
@@ -3,11 +3,25 @@ import adapterNode from "@sveltejs/adapter-node";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 const useNodeAdapter = process.env.ADAPTER === "node";
+const basePath = normalizeBasePath(process.env.OAR_UI_BASE_PATH);
+
+function normalizeBasePath(value = "") {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed || trimmed === "/") {
+    return "";
+  }
+
+  const normalized = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return normalized.replace(/\/+$/, "");
+}
 
 const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: useNodeAdapter ? adapterNode({ out: "build" }) : adapterAuto(),
+    paths: {
+      base: basePath,
+    },
   },
 };
 

--- a/web-ui/tests/e2e/base-path.spec.js
+++ b/web-ui/tests/e2e/base-path.spec.js
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const APP_BASE_PATH = normalizeBasePath(
+  process.env.PLAYWRIGHT_APP_BASE_PATH ?? "/oar",
+);
+
+function normalizeBasePath(value = "") {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed || trimmed === "/") {
+    return "";
+  }
+
+  const normalized = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return normalized.replace(/\/+$/, "");
+}
+
+function appPath(pathname = "/") {
+  const normalizedPathname =
+    pathname === "/"
+      ? "/"
+      : pathname.startsWith("/")
+        ? pathname
+        : `/${pathname}`;
+  if (!APP_BASE_PATH) {
+    return normalizedPathname;
+  }
+
+  return normalizedPathname === "/"
+    ? APP_BASE_PATH
+    : `${APP_BASE_PATH}${normalizedPathname}`;
+}
+
+test("preserves a configured mount prefix in redirects and generated links", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("oar_ui_actor_id", "actor-ops-ai");
+    window.localStorage.setItem("oar_ui_actor_id:local", "actor-ops-ai");
+  });
+
+  await page.goto(appPath("/"));
+
+  await expect(page).toHaveURL(new RegExp(`${APP_BASE_PATH}/local/?$`));
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+
+  await expect(
+    page.locator(`a[href="${appPath("/local/inbox")}"]`).first(),
+  ).toBeVisible();
+  await expect(
+    page.locator(`a[href="${appPath("/local/threads")}"]`).first(),
+  ).toBeVisible();
+  await expect(
+    page.locator(`a[href="${appPath("/local/artifacts")}"]`).first(),
+  ).toBeVisible();
+
+  await page
+    .locator(`a[href="${appPath("/local/threads")}"]`)
+    .first()
+    .click();
+  await expect(page).toHaveURL(new RegExp(`${APP_BASE_PATH}/local/threads/?$`));
+  await expect(page.getByRole("heading", { name: "Threads" })).toBeVisible();
+});

--- a/web-ui/tests/mocks/app-paths.js
+++ b/web-ui/tests/mocks/app-paths.js
@@ -1,0 +1,1 @@
+export const base = "";

--- a/web-ui/tests/unit/projectPaths.test.js
+++ b/web-ui/tests/unit/projectPaths.test.js
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadProjectPaths(base = "") {
+  vi.resetModules();
+  vi.doMock("$app/paths", () => ({ base }));
+  return import("../../src/lib/projectPaths.js");
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("$app/paths");
+});
+
+describe("project paths", () => {
+  it("prefixes app and project routes with the configured base path", async () => {
+    const { appPath, projectPath } = await loadProjectPaths("/oar");
+
+    expect(appPath("/")).toBe("/oar");
+    expect(appPath("/threads")).toBe("/oar/threads");
+    expect(projectPath("local")).toBe("/oar/local");
+    expect(projectPath("local", "/threads")).toBe("/oar/local/threads");
+  });
+
+  it("strips the configured base path before resolving project-relative paths", async () => {
+    const { stripBasePath, stripProjectPath } = await loadProjectPaths("/oar");
+
+    expect(stripBasePath("/oar/local/inbox")).toBe("/local/inbox");
+    expect(stripProjectPath("/oar/local/inbox", "local")).toBe("/inbox");
+    expect(stripProjectPath("/local/inbox", "local")).toBe("/inbox");
+  });
+
+  it("keeps root-mounted behavior unchanged when no base path is configured", async () => {
+    const { appPath, projectPath, stripProjectPath } = await loadProjectPaths();
+
+    expect(appPath("/threads")).toBe("/threads");
+    expect(projectPath("local", "/threads")).toBe("/local/threads");
+    expect(stripProjectPath("/local/threads", "local")).toBe("/threads");
+  });
+});

--- a/web-ui/vitest.config.js
+++ b/web-ui/vitest.config.js
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "$app/paths": fileURLToPath(
+        new URL("./tests/mocks/app-paths.js", import.meta.url),
+      ),
+    },
+  },
   test: {
     include: ["tests/unit/**/*.test.js"],
     environment: "node",


### PR DESCRIPTION
## Summary
- add first-class `OAR_UI_BASE_PATH` support in SvelteKit config and shared route helpers
- preserve the configured base path for redirects, generated links, same-origin client requests, and proxied core requests
- document the supported prefix-preserving reverse-proxy shape and add `/oar` Playwright coverage

## Validation
- `make -C web-ui check`
- `pnpm -C web-ui exec playwright test --project=default tests/e2e/shell.spec.js -g "renders a dashboard on / and routes into inbox"`
- `pnpm -C web-ui exec playwright test --project=base-path tests/e2e/base-path.spec.js`

Closes #66