### PR TITLE
fix(core): stabilize passkey username suffixes

### DIFF
--- a/core/internal/auth/passkeys.go
+++ b/core/internal/auth/passkeys.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"regexp"
@@ -414,7 +415,7 @@ func generatePasskeyUsername(displayName string) (string, error) {
 		return "", fmt.Errorf("generate passkey username suffix: %w", err)
 	}
 	username, err := normalizeUsername(
-		fmt.Sprintf("passkey.%s.%s", base, base64.RawURLEncoding.EncodeToString(suffix)),
+		fmt.Sprintf("passkey.%s.%s", base, hex.EncodeToString(suffix)),
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- replace the random passkey username suffix encoding with lowercase hex
- remove the intermittent underscore emission that was breaking the passkey username test in CI
- keep generated usernames within the existing normalized username contract

## Validation
- go test ./internal/auth -run TestGeneratePasskeyUsername -count=200
- make -C core check