### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .pnpm-store/
 .tmp/
 .codex-autorunner/
+.DS_Store
 
 _src_core/
 _src_ui/


### PR DESCRIPTION
## Summary
- ignore macOS .DS_Store files at the repo root level
- keep the PR scoped to repo hygiene only

## Review context
- the older local branch handshake/contract changes were reviewed separately and are already superseded upstream, so they are intentionally excluded from this PR

## Validation
- verified with     .gitignore:6:.DS_Store	.DS_Store