### PR TITLE
core: separate auth audit and principal cursor internals

### DIFF
--- a/core/internal/auth/audit.go
+++ b/core/internal/auth/audit.go
@@ -3,13 +3,13 @@ package auth
 import (
 	"context"
 	"database/sql"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
+
+	"organization-autorunner-core/internal/authaudit"
 
 	"github.com/google/uuid"
 )
@@ -17,7 +17,6 @@ import (
 var ErrInvalidCursor = errors.New("invalid_cursor")
 
 const (
-	authAuditSortKeyLayout             = "2006-01-02T15:04:05.000000000Z07:00"
 	AuthAuditEventBootstrapConsumed    = "bootstrap_consumed"
 	AuthAuditEventInviteCreated        = "invite_created"
 	AuthAuditEventInviteRevoked        = "invite_revoked"
@@ -72,17 +71,12 @@ type AuthAuditEventInput struct {
 	Metadata       map[string]any
 }
 
-type authAuditCursor struct {
-	SortKey string `json:"sort_key"`
-	EventID string `json:"event_id"`
-}
-
 func (s *Store) ListPrincipals(ctx context.Context, filter AuthPrincipalListFilter) ([]AuthPrincipalSummary, string, error) {
 	if s == nil || s.db == nil {
 		return nil, "", fmt.Errorf("auth store database is not initialized")
 	}
 
-	offset, err := decodeAuthCursor(strings.TrimSpace(filter.Cursor))
+	offset, err := decodeAuthPrincipalCursor(strings.TrimSpace(filter.Cursor))
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: %v", ErrInvalidCursor, err)
 	}
@@ -152,7 +146,7 @@ func (s *Store) ListPrincipals(ctx context.Context, filter AuthPrincipalListFilt
 	var nextCursor string
 	if filter.Limit != nil && len(principals) > *filter.Limit {
 		principals = principals[:*filter.Limit]
-		nextCursor = encodeAuthCursor(offset + *filter.Limit)
+		nextCursor = encodeAuthPrincipalCursor(offset + *filter.Limit)
 	}
 
 	return principals, nextCursor, nil
@@ -163,7 +157,7 @@ func (s *Store) ListAuditEvents(ctx context.Context, filter AuthAuditListFilter)
 		return nil, "", fmt.Errorf("auth store database is not initialized")
 	}
 
-	keysetCursor, legacyOffset, err := decodeAuthAuditCursor(strings.TrimSpace(filter.Cursor))
+	keysetCursor, err := decodeAuthAuditCursor(strings.TrimSpace(filter.Cursor))
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: %v", ErrInvalidCursor, err)
 	}
@@ -183,13 +177,9 @@ func (s *Store) ListAuditEvents(ctx context.Context, filter AuthAuditListFilter)
 	`
 	args := make([]any, 0, 4)
 
-	switch {
-	case keysetCursor != nil:
+	if keysetCursor != nil {
 		query += ` WHERE (occurred_at_sort_key < ? OR (occurred_at_sort_key = ? AND id < ?))`
 		args = append(args, keysetCursor.SortKey, keysetCursor.SortKey, keysetCursor.EventID)
-	case legacyOffset > 0:
-		// Support in-flight legacy cursors from the pre-keyset implementation.
-	default:
 	}
 
 	query += ` ORDER BY occurred_at_sort_key DESC, id DESC`
@@ -197,10 +187,6 @@ func (s *Store) ListAuditEvents(ctx context.Context, filter AuthAuditListFilter)
 	if filter.Limit != nil && *filter.Limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, *filter.Limit+1)
-		if keysetCursor == nil && legacyOffset > 0 {
-			query += ` OFFSET ?`
-			args = append(args, legacyOffset)
-		}
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -313,7 +299,7 @@ func (s *Store) recordAuthAuditEventTx(ctx context.Context, tx *sql.Tx, input Au
 		"authevt_"+uuid.NewString(),
 		eventType,
 		occurredAt.Format(time.RFC3339Nano),
-		formatAuthAuditSortKey(occurredAt),
+		authaudit.FormatOccurredAtSortKey(occurredAt),
 		nullIfEmpty(input.ActorAgentID),
 		nullIfEmpty(input.ActorActorID),
 		nullIfEmpty(input.SubjectAgentID),
@@ -325,81 +311,6 @@ func (s *Store) recordAuthAuditEventTx(ctx context.Context, tx *sql.Tx, input Au
 		return fmt.Errorf("insert auth audit event: %w", err)
 	}
 	return nil
-}
-
-func formatAuthAuditSortKey(occurredAt time.Time) string {
-	return occurredAt.UTC().Format(authAuditSortKeyLayout)
-}
-
-func encodeAuthCursor(offset int) string {
-	if offset <= 0 {
-		return ""
-	}
-	cursor := fmt.Sprintf("offset:%d", offset)
-	return base64.StdEncoding.EncodeToString([]byte(cursor))
-}
-
-func decodeAuthCursor(cursor string) (int, error) {
-	if cursor == "" {
-		return 0, nil
-	}
-	decoded, err := base64.StdEncoding.DecodeString(cursor)
-	if err != nil {
-		return 0, fmt.Errorf("invalid cursor encoding: %w", err)
-	}
-	parts := strings.Split(string(decoded), ":")
-	if len(parts) != 2 || parts[0] != "offset" {
-		return 0, fmt.Errorf("invalid cursor format")
-	}
-	offset, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, fmt.Errorf("invalid cursor offset: %w", err)
-	}
-	if offset <= 0 {
-		return 0, fmt.Errorf("invalid cursor offset: must be greater than zero")
-	}
-	return offset, nil
-}
-
-func encodeAuthAuditCursor(sortKey string, eventID string) string {
-	cursor := authAuditCursor{
-		SortKey: strings.TrimSpace(sortKey),
-		EventID: strings.TrimSpace(eventID),
-	}
-	if cursor.SortKey == "" || cursor.EventID == "" {
-		return ""
-	}
-	encoded, err := json.Marshal(cursor)
-	if err != nil {
-		return ""
-	}
-	return base64.StdEncoding.EncodeToString(encoded)
-}
-
-func decodeAuthAuditCursor(cursor string) (*authAuditCursor, int, error) {
-	if cursor == "" {
-		return nil, 0, nil
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(cursor)
-	if err != nil {
-		return nil, 0, fmt.Errorf("invalid cursor encoding: %w", err)
-	}
-
-	var keyset authAuditCursor
-	if err := json.Unmarshal(decoded, &keyset); err == nil {
-		keyset.SortKey = strings.TrimSpace(keyset.SortKey)
-		keyset.EventID = strings.TrimSpace(keyset.EventID)
-		if keyset.SortKey != "" && keyset.EventID != "" {
-			return &keyset, 0, nil
-		}
-	}
-
-	offset, err := decodeAuthCursor(cursor)
-	if err != nil {
-		return nil, 0, err
-	}
-	return nil, offset, nil
 }
 
 func nullStringPtr(value sql.NullString) *string {

--- a/core/internal/auth/audit_cursor.go
+++ b/core/internal/auth/audit_cursor.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type authAuditCursor struct {
+	SortKey string `json:"sort_key"`
+	EventID string `json:"event_id"`
+}
+
+func encodeAuthAuditCursor(sortKey string, eventID string) string {
+	cursor := authAuditCursor{
+		SortKey: strings.TrimSpace(sortKey),
+		EventID: strings.TrimSpace(eventID),
+	}
+	if cursor.SortKey == "" || cursor.EventID == "" {
+		return ""
+	}
+	encoded, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(encoded)
+}
+
+func decodeAuthAuditCursor(cursor string) (*authAuditCursor, error) {
+	if cursor == "" {
+		return nil, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+
+	var decodedCursor authAuditCursor
+	if err := json.Unmarshal(decoded, &decodedCursor); err != nil {
+		return nil, fmt.Errorf("invalid cursor format")
+	}
+
+	decodedCursor.SortKey = strings.TrimSpace(decodedCursor.SortKey)
+	decodedCursor.EventID = strings.TrimSpace(decodedCursor.EventID)
+	if decodedCursor.SortKey == "" || decodedCursor.EventID == "" {
+		return nil, fmt.Errorf("invalid cursor format")
+	}
+
+	return &decodedCursor, nil
+}

--- a/core/internal/auth/cursor_test.go
+++ b/core/internal/auth/cursor_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import "testing"
+
+func TestAuthPrincipalCursorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cursor := encodeAuthPrincipalCursor(7)
+	offset, err := decodeAuthPrincipalCursor(cursor)
+	if err != nil {
+		t.Fatalf("decode principal cursor: %v", err)
+	}
+	if offset != 7 {
+		t.Fatalf("expected offset 7, got %d", offset)
+	}
+}
+
+func TestAuthAuditCursorRejectsPrincipalCursorFormat(t *testing.T) {
+	t.Parallel()
+
+	cursor := encodeAuthPrincipalCursor(2)
+	decoded, err := decodeAuthAuditCursor(cursor)
+	if err == nil {
+		t.Fatalf("expected audit cursor decode error, got cursor %#v", decoded)
+	}
+}

--- a/core/internal/auth/principal_cursor.go
+++ b/core/internal/auth/principal_cursor.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func encodeAuthPrincipalCursor(offset int) string {
+	if offset <= 0 {
+		return ""
+	}
+	cursor := fmt.Sprintf("offset:%d", offset)
+	return base64.StdEncoding.EncodeToString([]byte(cursor))
+}
+
+func decodeAuthPrincipalCursor(cursor string) (int, error) {
+	if cursor == "" {
+		return 0, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 2 || parts[0] != "offset" {
+		return 0, fmt.Errorf("invalid cursor format")
+	}
+	offset, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid cursor offset: %w", err)
+	}
+	if offset <= 0 {
+		return 0, fmt.Errorf("invalid cursor offset: must be greater than zero")
+	}
+	return offset, nil
+}

--- a/core/internal/authaudit/sort_key.go
+++ b/core/internal/authaudit/sort_key.go
@@ -1,0 +1,13 @@
+package authaudit
+
+import "time"
+
+const OccurredAtSortKeyLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+func ParseOccurredAt(raw string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, raw)
+}
+
+func FormatOccurredAtSortKey(occurredAt time.Time) string {
+	return occurredAt.UTC().Format(OccurredAtSortKeyLayout)
+}

--- a/core/internal/authaudit/sort_key_test.go
+++ b/core/internal/authaudit/sort_key_test.go
@@ -1,0 +1,33 @@
+package authaudit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatOccurredAtSortKeyUsesFixedWidthFractions(t *testing.T) {
+	t.Parallel()
+
+	withFraction := FormatOccurredAtSortKey(time.Date(2026, 3, 20, 10, 0, 0, 100_000_000, time.UTC))
+	wholeSecond := FormatOccurredAtSortKey(time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC))
+
+	if withFraction <= wholeSecond {
+		t.Fatalf("expected fractional timestamp sort key %q to order after whole-second key %q", withFraction, wholeSecond)
+	}
+	if wholeSecond != "2026-03-20T10:00:00.000000000Z" {
+		t.Fatalf("expected fixed-width zero fraction, got %q", wholeSecond)
+	}
+}
+
+func TestParseOccurredAtRoundTripsRFC3339Nano(t *testing.T) {
+	t.Parallel()
+
+	raw := "2026-03-20T10:00:00.123456789Z"
+	parsed, err := ParseOccurredAt(raw)
+	if err != nil {
+		t.Fatalf("parse occurred_at: %v", err)
+	}
+	if parsed.Format(time.RFC3339Nano) != raw {
+		t.Fatalf("expected %q, got %q", raw, parsed.Format(time.RFC3339Nano))
+	}
+}

--- a/core/internal/storage/migrations.go
+++ b/core/internal/storage/migrations.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
+
+	"organization-autorunner-core/internal/authaudit"
 )
 
 const createMigrationsTableSQL = `
@@ -686,11 +687,11 @@ func applyAuthAuditSortKeyMigration(ctx context.Context, tx *sql.Tx) error {
 		if err := rows.Scan(&row.id, &row.occurredAt); err != nil {
 			return fmt.Errorf("scan auth audit row for sort key backfill: %w", err)
 		}
-		occurredAt, err := parseAuthAuditOccurredAt(row.occurredAt)
+		occurredAt, err := authaudit.ParseOccurredAt(row.occurredAt)
 		if err != nil {
 			return fmt.Errorf("parse auth audit occurred_at for %s: %w", row.id, err)
 		}
-		row.sortKey = formatAuthAuditSortKey(occurredAt)
+		row.sortKey = authaudit.FormatOccurredAtSortKey(occurredAt)
 		pending = append(pending, row)
 	}
 	if err := rows.Err(); err != nil {
@@ -705,15 +706,6 @@ func applyAuthAuditSortKeyMigration(ctx context.Context, tx *sql.Tx) error {
 
 	return nil
 }
-
-func parseAuthAuditOccurredAt(raw string) (time.Time, error) {
-	return time.Parse(time.RFC3339Nano, raw)
-}
-
-func formatAuthAuditSortKey(occurredAt time.Time) string {
-	return occurredAt.UTC().Format("2006-01-02T15:04:05.000000000Z07:00")
-}
-
 func tableExistsTx(ctx context.Context, tx *sql.Tx, tableName string) (bool, error) {
 	var exists bool
 	if err := tx.QueryRowContext(


### PR DESCRIPTION
## Summary
- split auth principal and auth audit cursor helpers into separate implementations
- centralize auth audit occurred_at sort-key parsing/formatting in a shared helper package used by runtime writes and migration backfills
- add focused tests for cursor isolation and sort-key behavior

## Testing
- make -C core check

Closes #88