### PR TITLE
Allow CSP overrides for Cloudflare Zero Trust

### DIFF
--- a/web-ui/docs/runbook.md
+++ b/web-ui/docs/runbook.md
@@ -4,6 +4,7 @@ This runbook covers local integration and production-like serving for the
 workspace-aware `oar-ui`.
 
 For packed-host SaaS operations, see:
+
 - Architecture: [`../docs/architecture/saas-packed-host-v1.md`](../docs/architecture/saas-packed-host-v1.md)
 - Configuration: [`../runbooks/packed-host-configuration.md`](../runbooks/packed-host-configuration.md)
 - Linux deployment: [`../deploy/linux-packed-host.md`](../deploy/linux-packed-host.md)
@@ -333,6 +334,42 @@ When deploying behind a reverse proxy (Caddy, nginx, Cloudflare, etc.):
 4. **TLS considerations**: The CSP assumes TLS in production. If the proxy
    terminates TLS, ensure it forwards `https://` URLs to the UI so `connect-src
 'self'` resolves correctly.
+
+### Cloudflare Zero Trust and injected resources
+
+Cloudflare products such as Access and Web Analytics can inject additional
+browser resources into HTML responses. With the default strict UI CSP, those
+resources will be blocked unless you explicitly allow them.
+
+Supported runtime overrides:
+
+- `OAR_UI_CSP_SCRIPT_SRC_EXTRA`
+- `OAR_UI_CSP_STYLE_SRC_EXTRA`
+- `OAR_UI_CSP_IMG_SRC_EXTRA`
+- `OAR_UI_CSP_FONT_SRC_EXTRA`
+- `OAR_UI_CSP_CONNECT_SRC_EXTRA`
+- `OAR_UI_CSP_MANIFEST_SRC_EXTRA`
+
+Each variable accepts a whitespace- or comma-separated list of additional CSP
+sources appended to that directive.
+
+Example for a Cloudflare Access + Web Analytics deployment:
+
+```bash
+OAR_UI_CSP_SCRIPT_SRC_EXTRA="https://static.cloudflareinsights.com 'sha256-<inline-script-hash-from-browser-console>'" \
+OAR_UI_CSP_CONNECT_SRC_EXTRA="https://cloudflareinsights.com" \
+OAR_UI_CSP_MANIFEST_SRC_EXTRA="https://scalingforever.cloudflareaccess.com" \
+./scripts/serve
+```
+
+Notes:
+
+- The inline script hash is tenant-dependent. Copy the exact `sha256-...` value
+  reported by the browser CSP error for your Access-injected inline script.
+- Prefer explicit hashes or host allowlists over adding `'unsafe-inline'` to
+  `script-src`.
+- If you do not need Cloudflare Web Analytics automatic injection, disabling it
+  at Cloudflare is tighter than broadening the app CSP.
 
 ### Testing CSP in production
 

--- a/web-ui/src/hooks.server.js
+++ b/web-ui/src/hooks.server.js
@@ -1,4 +1,5 @@
 import { dev } from "$app/environment";
+import { env as privateEnv } from "$env/dynamic/private";
 import { isProxyableCommand } from "$lib/coreRouteCatalog";
 import { getWorkspaceHeader } from "$lib/compat/workspaceCompat";
 import { stripBasePath } from "$lib/workspacePaths";
@@ -155,18 +156,50 @@ async function proxyToCore(event, coreBaseUrl, workspaceSlug) {
 const GOOGLE_FONTS_STYLE = "https://fonts.googleapis.com";
 const GOOGLE_FONTS_FONT = "https://fonts.gstatic.com";
 
-function buildCSPDirectives() {
+function parseCSPExtraSources(rawValue) {
+  return String(rawValue ?? "")
+    .split(/[\s,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function mergeCSPDirectiveSources(baseSources, extraSourcesRaw) {
+  return [
+    ...new Set([...baseSources, ...parseCSPExtraSources(extraSourcesRaw)]),
+  ];
+}
+
+function buildCSPDirectives(env = privateEnv) {
   const scriptSrc = dev
     ? ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
     : ["'self'"];
 
   return {
     "default-src": ["'self'"],
-    "script-src": scriptSrc,
-    "style-src": ["'self'", "'unsafe-inline'", GOOGLE_FONTS_STYLE],
-    "img-src": ["'self'", "data:", "https:"],
-    "font-src": ["'self'", "data:", GOOGLE_FONTS_FONT],
-    "connect-src": ["'self'"],
+    "script-src": mergeCSPDirectiveSources(
+      scriptSrc,
+      env.OAR_UI_CSP_SCRIPT_SRC_EXTRA,
+    ),
+    "style-src": mergeCSPDirectiveSources(
+      ["'self'", "'unsafe-inline'", GOOGLE_FONTS_STYLE],
+      env.OAR_UI_CSP_STYLE_SRC_EXTRA,
+    ),
+    "img-src": mergeCSPDirectiveSources(
+      ["'self'", "data:", "https:"],
+      env.OAR_UI_CSP_IMG_SRC_EXTRA,
+    ),
+    "font-src": mergeCSPDirectiveSources(
+      ["'self'", "data:", GOOGLE_FONTS_FONT],
+      env.OAR_UI_CSP_FONT_SRC_EXTRA,
+    ),
+    "connect-src": mergeCSPDirectiveSources(
+      ["'self'"],
+      env.OAR_UI_CSP_CONNECT_SRC_EXTRA,
+    ),
+    "manifest-src": mergeCSPDirectiveSources(
+      ["'self'"],
+      env.OAR_UI_CSP_MANIFEST_SRC_EXTRA,
+    ),
     "frame-ancestors": ["'none'"],
     "base-uri": ["'self'"],
     "form-action": ["'self'"],

--- a/web-ui/tests/unit/hooks.server.test.js
+++ b/web-ui/tests/unit/hooks.server.test.js
@@ -4,6 +4,8 @@ const authSessionState = {
   currentSession: { accessToken: "expired-token" },
 };
 
+const envState = vi.hoisted(() => ({}));
+
 const authSessionMocks = vi.hoisted(() => ({
   clearWorkspaceAuthSession: vi.fn(),
   getWorkspaceAuthSession: vi.fn(() => authSessionState.currentSession),
@@ -18,7 +20,7 @@ vi.mock("$app/environment", () => ({
 }));
 
 vi.mock("$env/dynamic/private", () => ({
-  env: {},
+  env: envState,
 }));
 
 vi.mock("$lib/coreRouteCatalog", () => ({
@@ -70,6 +72,9 @@ describe("hooks proxy retry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authSessionState.currentSession = { accessToken: "expired-token" };
+    for (const key of Object.keys(envState)) {
+      delete envState[key];
+    }
   });
 
   it("replays the original request body after refreshing workspace auth", async () => {
@@ -122,6 +127,44 @@ describe("hooks proxy retry", () => {
     expect(secondInit.headers.get("authorization")).toBe("Bearer fresh-token");
     expect(authSessionMocks.refreshWorkspaceAuthSession).toHaveBeenCalledTimes(
       1,
+    );
+  });
+
+  it("adds configured CSP sources to document navigation responses", async () => {
+    envState.OAR_UI_CSP_SCRIPT_SRC_EXTRA =
+      "https://static.cloudflareinsights.com 'sha256-examplehash='";
+    envState.OAR_UI_CSP_CONNECT_SRC_EXTRA = "https://cloudflareinsights.com";
+    envState.OAR_UI_CSP_MANIFEST_SRC_EXTRA =
+      "https://scalingforever.cloudflareaccess.com";
+
+    const response = await handle({
+      event: {
+        url: new URL("https://oar.example.test/dtrinity"),
+        request: new Request("https://oar.example.test/dtrinity", {
+          method: "GET",
+          headers: {
+            accept: "text/html",
+          },
+        }),
+      },
+      resolve: vi.fn(
+        () =>
+          new Response("<!doctype html><html><body>ok</body></html>", {
+            status: 200,
+            headers: {
+              "content-type": "text/html",
+            },
+          }),
+      ),
+    });
+
+    const csp = response.headers.get("Content-Security-Policy");
+    expect(csp).toContain(
+      "script-src 'self' https://static.cloudflareinsights.com 'sha256-examplehash='",
+    );
+    expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com");
+    expect(csp).toContain(
+      "manifest-src 'self' https://scalingforever.cloudflareaccess.com",
     );
   });
 });


### PR DESCRIPTION
## Summary
- add runtime CSP directive extensions for script, connect, manifest, and related sources
- keep the default UI CSP strict while allowing explicit Cloudflare Access/Web Analytics sources
- document the Cloudflare Zero Trust deployment settings and add unit coverage for the new CSP behavior

## Testing
- pnpm --dir web-ui exec vitest run tests/unit/hooks.server.test.js