### PR TITLE
Fix invite onboarding copy and control-plane public URL defaults

### DIFF
--- a/cli/docs/generated/commands.md
+++ b/cli/docs/generated/commands.md
@@ -228,7 +228,7 @@ Generated from `contracts/oar-openapi.yaml`.
 - Output: Returns `{ invite, token }`. The raw token is returned only once at creation time.
 - Agent notes: Requires Bearer access token. `kind` may be `human`, `agent`, or `any`.
 - Examples:
-  - Create agent invite: `oar auth invites create --kind agent --note 'ops bot' --json`
+  - Create agent invite: `oar auth invites create --kind agent --json`
 
 ## `auth.invites.list`
 

--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -1009,11 +1009,11 @@ Generated Help: auth invites create
 - Agent notes: Requires Bearer access token. `kind` may be `human`, `agent`, or `any`.
 - Adjacent commands: `auth audit list`, `auth bootstrap status`, `auth invites list`, `auth invites revoke`, `auth passkey login options`, `auth passkey login verify`, `auth passkey register options`, `auth passkey register verify`, `auth principals list`, `auth principals revoke`, `auth register`, `auth token`
 - Examples:
-  - Create agent invite: `oar auth invites create --kind agent --note 'ops bot' --json`
+  - Create agent invite: `oar auth invites create --kind agent --json`
 
 Body schema:
   Required: kind (string)
-  Optional: expires_at (datetime), note (string)
+  Optional: expires_at (datetime)
   Enum values: kind: agent, any, human
 
 Global flags:

--- a/cli/internal/app/auth_commands.go
+++ b/cli/internal/app/auth_commands.go
@@ -93,11 +93,7 @@ func (a *App) runAuthInvitesList(ctx context.Context, service *authcli.Service) 
 		} else if invite.ConsumedAt != "" {
 			status = "consumed"
 		}
-		line := fmt.Sprintf("  %s  kind=%s  status=%s", invite.ID, invite.Kind, status)
-		if invite.Note != "" {
-			line += "  note=" + invite.Note
-		}
-		lines = append(lines, line)
+		lines = append(lines, fmt.Sprintf("  %s  kind=%s  status=%s", invite.ID, invite.Kind, status))
 	}
 	header := fmt.Sprintf("Invites (%d):", len(result.Invites))
 	text := header + "\n" + strings.Join(lines, "\n")
@@ -107,9 +103,7 @@ func (a *App) runAuthInvitesList(ctx context.Context, service *authcli.Service) 
 func (a *App) runAuthInvitesCreate(ctx context.Context, service *authcli.Service, args []string) (*commandResult, error) {
 	fs := newSilentFlagSet("auth invites create")
 	var kindFlag trackedString
-	var noteFlag trackedString
 	fs.Var(&kindFlag, "kind", "Invite kind (human, agent, or any)")
-	fs.Var(&noteFlag, "note", "Optional note describing the invite")
 	if err := fs.Parse(args); err != nil {
 		return nil, errnorm.Usage("invalid_auth_invites_flags", err.Error())
 	}
@@ -123,7 +117,7 @@ func (a *App) runAuthInvitesCreate(ctx context.Context, service *authcli.Service
 	if kind != "human" && kind != "agent" && kind != "any" {
 		return nil, errnorm.Usage("invalid_invite_kind", "kind must be human, agent, or any")
 	}
-	result, err := service.CreateInvite(ctx, kind, strings.TrimSpace(noteFlag.value))
+	result, err := service.CreateInvite(ctx, kind)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -30,7 +30,7 @@ var authSubcommandSpec = subcommandSpec{
 		"oar auth whoami",
 		"oar auth list",
 		"oar auth invites list",
-		"oar auth invites create --kind agent --note 'ops bot'",
+		"oar auth invites create --kind agent",
 		"oar auth bootstrap status",
 		"oar auth principals list",
 		"oar auth principals revoke --agent-id <agent-id>",
@@ -47,7 +47,7 @@ var authSubcommandSpec = subcommandSpec{
 var authInvitesSubcommandSpec = subcommandSpec{
 	command:  "auth invites",
 	valid:    []string{"list", "create", "revoke"},
-	examples: []string{"oar auth invites list", "oar auth invites create --kind agent --note 'ops bot'", "oar auth invites revoke --invite-id <id>"},
+	examples: []string{"oar auth invites list", "oar auth invites create --kind agent", "oar auth invites revoke --invite-id <id>"},
 	aliases: map[string]string{
 		"ls": "list",
 	},

--- a/cli/internal/authcli/service.go
+++ b/cli/internal/authcli/service.go
@@ -56,7 +56,6 @@ type TokenStatusResult struct {
 type Invite struct {
 	ID                string `json:"id"`
 	Kind              string `json:"kind"`
-	Note              string `json:"note,omitempty"`
 	CreatedAt         string `json:"created_at"`
 	ConsumedAt        string `json:"consumed_at,omitempty"`
 	ConsumedByAgentID string `json:"consumed_by_agent_id,omitempty"`
@@ -527,7 +526,7 @@ func (s *Service) ListInvites(ctx context.Context) (ListInvitesResult, error) {
 	return ListInvitesResult{Invites: payload.Invites}, nil
 }
 
-func (s *Service) CreateInvite(ctx context.Context, kind, note string) (CreateInviteResult, error) {
+func (s *Service) CreateInvite(ctx context.Context, kind string) (CreateInviteResult, error) {
 	prof, err := s.ensureAccessToken(ctx)
 	if err != nil {
 		return CreateInviteResult{}, err
@@ -538,7 +537,6 @@ func (s *Service) CreateInvite(ctx context.Context, kind, note string) (CreateIn
 	}
 	body, _ := json.Marshal(map[string]any{
 		"kind": kind,
-		"note": note,
 	})
 	resp, err := client.RawCall(ctx, httpclient.RawRequest{Method: http.MethodPost, Path: "/auth/invites", Body: body})
 	if err != nil {

--- a/cli/internal/registry/commands.json
+++ b/cli/internal/registry/commands.json
@@ -726,7 +726,7 @@
       "examples": [
         {
           "title": "Create agent invite",
-          "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+          "command": "oar auth invites create --kind agent --json"
         }
       ],
       "body_schema": {
@@ -745,10 +745,6 @@
           {
             "name": "expires_at",
             "type": "datetime"
-          },
-          {
-            "name": "note",
-            "type": "string"
           }
         ]
       },

--- a/cli/internal/registry/concepts.json
+++ b/cli/internal/registry/concepts.json
@@ -961,7 +961,7 @@
           "examples": [
             {
               "title": "Create agent invite",
-              "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+              "command": "oar auth invites create --kind agent --json"
             }
           ],
           "body_schema": {
@@ -980,10 +980,6 @@
               {
                 "name": "expires_at",
                 "type": "datetime"
-              },
-              {
-                "name": "note",
-                "type": "string"
               }
             ]
           },
@@ -6868,7 +6864,7 @@
           "examples": [
             {
               "title": "Create agent invite",
-              "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+              "command": "oar auth invites create --kind agent --json"
             }
           ],
           "body_schema": {
@@ -6887,10 +6883,6 @@
               {
                 "name": "expires_at",
                 "type": "datetime"
-              },
-              {
-                "name": "note",
-                "type": "string"
               }
             ]
           },

--- a/cli/internal/registry/help.json
+++ b/cli/internal/registry/help.json
@@ -886,7 +886,7 @@
       "examples": [
         {
           "title": "Create agent invite",
-          "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+          "command": "oar auth invites create --kind agent --json"
         }
       ],
       "body_schema": {
@@ -905,10 +905,6 @@
           {
             "name": "expires_at",
             "type": "datetime"
-          },
-          {
-            "name": "note",
-            "type": "string"
           }
         ]
       },

--- a/contracts/gen/docs/commands.md
+++ b/contracts/gen/docs/commands.md
@@ -228,7 +228,7 @@ Generated from `contracts/oar-openapi.yaml`.
 - Output: Returns `{ invite, token }`. The raw token is returned only once at creation time.
 - Agent notes: Requires Bearer access token. `kind` may be `human`, `agent`, or `any`.
 - Examples:
-  - Create agent invite: `oar auth invites create --kind agent --note 'ops bot' --json`
+  - Create agent invite: `oar auth invites create --kind agent --json`
 
 ## `auth.invites.list`
 

--- a/contracts/gen/go/client/client_gen.go
+++ b/contracts/gen/go/client/client_gen.go
@@ -298,7 +298,7 @@ var CommandRegistry = []CommandSpec{
 		Examples: []Example{
 			{
 				Title:   "Create agent invite",
-				Command: "oar auth invites create --kind agent --note 'ops bot' --json",
+				Command: "oar auth invites create --kind agent --json",
 			},
 		},
 	},

--- a/contracts/gen/meta/commands.json
+++ b/contracts/gen/meta/commands.json
@@ -726,7 +726,7 @@
       "examples": [
         {
           "title": "Create agent invite",
-          "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+          "command": "oar auth invites create --kind agent --json"
         }
       ],
       "body_schema": {
@@ -745,10 +745,6 @@
           {
             "name": "expires_at",
             "type": "datetime"
-          },
-          {
-            "name": "note",
-            "type": "string"
           }
         ]
       },

--- a/contracts/gen/meta/concepts.json
+++ b/contracts/gen/meta/concepts.json
@@ -961,7 +961,7 @@
           "examples": [
             {
               "title": "Create agent invite",
-              "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+              "command": "oar auth invites create --kind agent --json"
             }
           ],
           "body_schema": {
@@ -980,10 +980,6 @@
               {
                 "name": "expires_at",
                 "type": "datetime"
-              },
-              {
-                "name": "note",
-                "type": "string"
               }
             ]
           },
@@ -6868,7 +6864,7 @@
           "examples": [
             {
               "title": "Create agent invite",
-              "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+              "command": "oar auth invites create --kind agent --json"
             }
           ],
           "body_schema": {
@@ -6887,10 +6883,6 @@
               {
                 "name": "expires_at",
                 "type": "datetime"
-              },
-              {
-                "name": "note",
-                "type": "string"
               }
             ]
           },

--- a/contracts/gen/meta/help.json
+++ b/contracts/gen/meta/help.json
@@ -886,7 +886,7 @@
       "examples": [
         {
           "title": "Create agent invite",
-          "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+          "command": "oar auth invites create --kind agent --json"
         }
       ],
       "body_schema": {
@@ -905,10 +905,6 @@
           {
             "name": "expires_at",
             "type": "datetime"
-          },
-          {
-            "name": "note",
-            "type": "string"
           }
         ]
       },

--- a/contracts/gen/ts/client.ts
+++ b/contracts/gen/ts/client.ts
@@ -765,7 +765,7 @@ export const commandRegistry: CommandSpec[] = [
     "examples": [
       {
         "title": "Create agent invite",
-        "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+        "command": "oar auth invites create --kind agent --json"
       }
     ],
     "body_schema": {
@@ -784,10 +784,6 @@ export const commandRegistry: CommandSpec[] = [
         {
           "name": "expires_at",
           "type": "datetime"
-        },
-        {
-          "name": "note",
-          "type": "string"
         }
       ]
     },

--- a/contracts/gen/ts/dist/client.js
+++ b/contracts/gen/ts/dist/client.js
@@ -720,7 +720,7 @@ export const commandRegistry = [
         "examples": [
             {
                 "title": "Create agent invite",
-                "command": "oar auth invites create --kind agent --note 'ops bot' --json"
+                "command": "oar auth invites create --kind agent --json"
             }
         ],
         "body_schema": {
@@ -739,10 +739,6 @@ export const commandRegistry = [
                 {
                     "name": "expires_at",
                     "type": "datetime"
-                },
-                {
-                    "name": "note",
-                    "type": "string"
                 }
             ]
         },

--- a/contracts/oar-openapi.yaml
+++ b/contracts/oar-openapi.yaml
@@ -626,7 +626,7 @@ paths:
       x-oar-why: "Mint a single-use invite token for a future human or agent registration."
       x-oar-examples:
         - title: Create agent invite
-          command: oar auth invites create --kind agent --note 'ops bot' --json
+          command: oar auth invites create --kind agent --json
       x-oar-input-mode: "json-body"
       x-oar-streaming: { mode: none }
       x-oar-output-envelope: "Returns `{ invite, token }`. The raw token is returned only once at creation time."
@@ -3127,7 +3127,6 @@ components:
           enum: [human, agent, any]
         created_by_agent_id: { type: string }
         created_by_actor_id: { type: string }
-        note: { type: string }
         created_at: { type: string, format: date-time }
         expires_at: { type: string, format: date-time }
         consumed_at: { type: string, format: date-time }
@@ -3136,7 +3135,7 @@ components:
         revoked_at: { type: string, format: date-time }
         revoked_by_agent_id: { type: string }
         revoked_by_actor_id: { type: string }
-      required: [id, kind, created_by_agent_id, created_by_actor_id, note, created_at]
+      required: [id, kind, created_by_agent_id, created_by_actor_id, created_at]
 
     AuthPrincipalSummary:
       type: object
@@ -3326,7 +3325,6 @@ components:
         kind:
           type: string
           enum: [human, agent, any]
-        note: { type: string }
         expires_at: { type: string, format: date-time }
       required: [kind]
 

--- a/core/cmd/oar-control-plane/main.go
+++ b/core/cmd/oar-control-plane/main.go
@@ -25,8 +25,6 @@ const (
 	defaultWorkspaceRoot             = ".oar-control-plane"
 	defaultShutdownTimeout           = 15 * time.Second
 	defaultBackupMaintenanceInterval = 5 * time.Minute
-	defaultWorkspaceURLTmpl          = "http://127.0.0.1:8000/%s"
-	defaultInviteURLTmpl             = "http://127.0.0.1:8100/invites/%s"
 )
 
 func main() {
@@ -35,10 +33,11 @@ func main() {
 		port                      = envInt("OAR_CONTROL_PLANE_PORT", defaultPort)
 		listenAddress             = envString("OAR_CONTROL_PLANE_LISTEN_ADDR", "")
 		workspaceRoot             = envString("OAR_CONTROL_PLANE_WORKSPACE_ROOT", defaultWorkspaceRoot)
+		publicBaseURL             = envString("OAR_CONTROL_PLANE_PUBLIC_BASE_URL", "")
 		webAuthnRPID              = envString("OAR_CONTROL_PLANE_WEBAUTHN_RPID", "")
 		webAuthnOrigin            = envString("OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN", "")
-		workspaceURLTemplate      = envString("OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE", defaultWorkspaceURLTmpl)
-		inviteURLTemplate         = envString("OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE", defaultInviteURLTmpl)
+		workspaceURLTemplate      = envString("OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE", "")
+		inviteURLTemplate         = envString("OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE", "")
 		workspaceGrantIssuer      = envString("OAR_CONTROL_PLANE_WORKSPACE_GRANT_ISSUER", "")
 		workspaceGrantAudience    = envString("OAR_CONTROL_PLANE_WORKSPACE_GRANT_AUDIENCE", "")
 		workspaceGrantSigningKey  = envString("OAR_CONTROL_PLANE_WORKSPACE_GRANT_SIGNING_KEY", "")
@@ -54,6 +53,7 @@ func main() {
 	flag.IntVar(&port, "port", port, "port to listen on")
 	flag.StringVar(&listenAddress, "listen-addr", listenAddress, "full listen address host:port; overrides --host/--port")
 	flag.StringVar(&workspaceRoot, "workspace-root", workspaceRoot, "root directory for control-plane sqlite workspace")
+	flag.StringVar(&publicBaseURL, "public-base-url", publicBaseURL, "public browser-facing base URL for control-plane routes; used as the default base for workspace URLs, invite URLs, workspace-grant issuer, and WebAuthn origin")
 	flag.StringVar(&webAuthnRPID, "webauthn-rpid", webAuthnRPID, "explicit WebAuthn RP ID")
 	flag.StringVar(&webAuthnOrigin, "webauthn-origin", webAuthnOrigin, "explicit WebAuthn origin")
 	flag.StringVar(&workspaceURLTemplate, "workspace-url-template", workspaceURLTemplate, "workspace base URL template containing optional %s slug placeholder")
@@ -72,10 +72,26 @@ func main() {
 	if strings.TrimSpace(addr) == "" {
 		addr = net.JoinHostPort(host, strconv.Itoa(port))
 	}
+	normalizedPublicBaseURL, err := controlplane.NormalizePublicBaseURL(publicBaseURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid OAR_CONTROL_PLANE_PUBLIC_BASE_URL: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(webAuthnOrigin) == "" && normalizedPublicBaseURL != "" {
+		webAuthnOrigin, err = controlplane.PublicBaseOrigin(normalizedPublicBaseURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid control-plane public base URL origin: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	var workspaceGrantSigner *controlplaneauth.WorkspaceHumanGrantSigner
 	if strings.TrimSpace(workspaceGrantSigningKey) != "" || strings.TrimSpace(workspaceGrantAudience) != "" || strings.TrimSpace(workspaceGrantIssuer) != "" {
 		if strings.TrimSpace(workspaceGrantIssuer) == "" {
-			workspaceGrantIssuer = "http://" + addr
+			if normalizedPublicBaseURL != "" {
+				workspaceGrantIssuer = normalizedPublicBaseURL
+			} else {
+				workspaceGrantIssuer = "http://" + addr
+			}
 		}
 		privateKey, err := controlplaneauth.ParseEd25519PrivateKeyBase64(workspaceGrantSigningKey)
 		if err != nil {
@@ -101,6 +117,7 @@ func main() {
 	defer workspace.Close()
 
 	service := controlplane.NewService(workspace, controlplane.Config{
+		PublicBaseURL:        normalizedPublicBaseURL,
 		SessionTTL:           sessionTTL,
 		CeremonyTTL:          ceremonyTTL,
 		LaunchTTL:            launchTTL,

--- a/core/docs/http-api.md
+++ b/core/docs/http-api.md
@@ -135,7 +135,7 @@ Projection endpoints return a `section_kinds` field to distinguish canonical vs 
 
 - `POST /auth/invites`
   - Auth: bearer token required
-  - Body: `{ "kind": "human" | "agent" | "any", "note"?: "..." }`
+  - Body: `{ "kind": "human" | "agent" | "any" }`
   - Response: `{ "invite": <invite>, "token": "<raw_token_once>" }`
 
 - `POST /auth/invites/{invite_id}/revoke`

--- a/core/docs/runbook.md
+++ b/core/docs/runbook.md
@@ -125,11 +125,12 @@ Relevant control-plane configuration:
 | Listen host | `--host` | `OAR_CONTROL_PLANE_HOST` | `127.0.0.1` |
 | Listen port | `--port` | `OAR_CONTROL_PLANE_PORT` | `8100` |
 | Full listen address (overrides host+port) | `--listen-addr` | `OAR_CONTROL_PLANE_LISTEN_ADDR` | unset |
+| Public base URL | `--public-base-url` | `OAR_CONTROL_PLANE_PUBLIC_BASE_URL` | unset |
 | WebAuthn RP ID | `--webauthn-rpid` | `OAR_CONTROL_PLANE_WEBAUTHN_RPID` | derived from browser origin |
-| WebAuthn origin | `--webauthn-origin` | `OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN` | derived from browser origin |
-| Workspace URL template | `--workspace-url-template` | `OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE` | `http://127.0.0.1:8000/%s` |
-| Invite URL template | `--invite-url-template` | `OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE` | `http://127.0.0.1:8100/invites/%s` |
-| Workspace grant issuer | `--workspace-grant-issuer` | `OAR_CONTROL_PLANE_WORKSPACE_GRANT_ISSUER` | listen URL when signing is enabled |
+| WebAuthn origin | `--webauthn-origin` | `OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN` | derived from browser origin or `public-base-url` origin |
+| Workspace URL template | `--workspace-url-template` | `OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE` | `<public-base-url>/%s`, else `http://127.0.0.1:8000/%s` |
+| Invite URL template | `--invite-url-template` | `OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE` | `<public-base-url>/invites/%s`, else `http://127.0.0.1:8100/invites/%s` |
+| Workspace grant issuer | `--workspace-grant-issuer` | `OAR_CONTROL_PLANE_WORKSPACE_GRANT_ISSUER` | `public-base-url` when signing is enabled, else listen URL |
 | Workspace grant audience | `--workspace-grant-audience` | `OAR_CONTROL_PLANE_WORKSPACE_GRANT_AUDIENCE` | unset |
 | Workspace grant signing key (base64 Ed25519 private key) | n/a | `OAR_CONTROL_PLANE_WORKSPACE_GRANT_SIGNING_KEY` | unset |
 | Session TTL | `--session-ttl` | `OAR_CONTROL_PLANE_SESSION_TTL` | `12h` |

--- a/core/internal/auth/onboarding.go
+++ b/core/internal/auth/onboarding.go
@@ -45,7 +45,6 @@ type Invite struct {
 	Kind              string  `json:"kind"`
 	CreatedByAgentID  string  `json:"created_by_agent_id"`
 	CreatedByActorID  string  `json:"created_by_actor_id"`
-	Note              string  `json:"note"`
 	CreatedAt         string  `json:"created_at"`
 	ExpiresAt         *string `json:"expires_at,omitempty"`
 	ConsumedAt        *string `json:"consumed_at,omitempty"`
@@ -58,7 +57,6 @@ type Invite struct {
 
 type CreateInviteInput struct {
 	Kind      string
-	Note      string
 	ExpiresAt *time.Time
 }
 
@@ -161,11 +159,6 @@ func (s *Store) CreateInvite(ctx context.Context, createdBy Principal, input Cre
 		return Invite{}, "", fmt.Errorf("%w: authenticated principal is required", ErrAuthRequired)
 	}
 
-	note := strings.TrimSpace(input.Note)
-	if len(note) > 240 {
-		return Invite{}, "", fmt.Errorf("%w: note must be 240 characters or fewer", ErrInvalidRequest)
-	}
-
 	var expiresAtText *string
 	if input.ExpiresAt != nil {
 		expiresAt := input.ExpiresAt.UTC()
@@ -213,7 +206,7 @@ func (s *Store) CreateInvite(ctx context.Context, createdBy Principal, input Cre
 		string(kind),
 		createdBy.AgentID,
 		createdBy.ActorID,
-		note,
+		"",
 		nowText,
 		expiresAtText,
 	)
@@ -223,9 +216,6 @@ func (s *Store) CreateInvite(ctx context.Context, createdBy Principal, input Cre
 	}
 
 	metadata := map[string]any{"kind": string(kind)}
-	if note != "" {
-		metadata["note"] = note
-	}
 	if expiresAtText != nil {
 		metadata["expires_at"] = *expiresAtText
 	}
@@ -251,7 +241,6 @@ func (s *Store) CreateInvite(ctx context.Context, createdBy Principal, input Cre
 		Kind:             string(kind),
 		CreatedByAgentID: createdBy.AgentID,
 		CreatedByActorID: createdBy.ActorID,
-		Note:             note,
 		CreatedAt:        nowText,
 		ExpiresAt:        expiresAtText,
 	}, token, nil
@@ -579,6 +568,7 @@ type inviteScanner interface {
 func scanInvite(scanner inviteScanner) (Invite, error) {
 	var (
 		invite            Invite
+		ignoredNote       string
 		expiresAt         sql.NullString
 		consumedAt        sql.NullString
 		consumedByAgentID sql.NullString
@@ -592,7 +582,7 @@ func scanInvite(scanner inviteScanner) (Invite, error) {
 		&invite.Kind,
 		&invite.CreatedByAgentID,
 		&invite.CreatedByActorID,
-		&invite.Note,
+		&ignoredNote,
 		&invite.CreatedAt,
 		&expiresAt,
 		&consumedAt,

--- a/core/internal/controlplane/public_base.go
+++ b/core/internal/controlplane/public_base.go
@@ -1,0 +1,56 @@
+package controlplane
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func NormalizePublicBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("public base URL must include scheme and host")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = strings.TrimRight(parsed.RawPath, "/")
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func PublicBaseOrigin(raw string) (string, error) {
+	normalized, err := NormalizePublicBaseURL(raw)
+	if err != nil || normalized == "" {
+		return normalized, err
+	}
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func WorkspaceURLTemplateFromPublicBase(raw string) (string, error) {
+	normalized, err := NormalizePublicBaseURL(raw)
+	if err != nil || normalized == "" {
+		return normalized, err
+	}
+	return normalized + "/%s", nil
+}
+
+func InviteURLTemplateFromPublicBase(raw string) (string, error) {
+	normalized, err := NormalizePublicBaseURL(raw)
+	if err != nil || normalized == "" {
+		return normalized, err
+	}
+	return normalized + "/invites/%s", nil
+}

--- a/core/internal/controlplane/public_base_test.go
+++ b/core/internal/controlplane/public_base_test.go
@@ -1,0 +1,43 @@
+package controlplane
+
+import "testing"
+
+func TestNormalizePublicBaseURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizePublicBaseURL("https://example.com/oar/team-alpha/?q=ignored")
+	if err != nil {
+		t.Fatalf("NormalizePublicBaseURL returned error: %v", err)
+	}
+	if got != "https://example.com/oar/team-alpha" {
+		t.Fatalf("expected normalized public base URL, got %q", got)
+	}
+}
+
+func TestPublicBaseDerivedTemplates(t *testing.T) {
+	t.Parallel()
+
+	workspaceTemplate, err := WorkspaceURLTemplateFromPublicBase("https://example.com/oar")
+	if err != nil {
+		t.Fatalf("WorkspaceURLTemplateFromPublicBase returned error: %v", err)
+	}
+	if workspaceTemplate != "https://example.com/oar/%s" {
+		t.Fatalf("unexpected workspace template %q", workspaceTemplate)
+	}
+
+	inviteTemplate, err := InviteURLTemplateFromPublicBase("https://example.com/oar")
+	if err != nil {
+		t.Fatalf("InviteURLTemplateFromPublicBase returned error: %v", err)
+	}
+	if inviteTemplate != "https://example.com/oar/invites/%s" {
+		t.Fatalf("unexpected invite template %q", inviteTemplate)
+	}
+
+	origin, err := PublicBaseOrigin("https://example.com/oar/team-alpha")
+	if err != nil {
+		t.Fatalf("PublicBaseOrigin returned error: %v", err)
+	}
+	if origin != "https://example.com" {
+		t.Fatalf("unexpected public origin %q", origin)
+	}
+}

--- a/core/internal/controlplane/service.go
+++ b/core/internal/controlplane/service.go
@@ -60,6 +60,7 @@ var (
 )
 
 type Config struct {
+	PublicBaseURL        string
 	SessionTTL           time.Duration
 	CeremonyTTL          time.Duration
 	LaunchTTL            time.Duration
@@ -135,13 +136,31 @@ func NewService(workspace *cpstorage.Workspace, config Config) *Service {
 	if nowFn == nil {
 		nowFn = func() time.Time { return time.Now().UTC() }
 	}
+	publicBaseURL, err := NormalizePublicBaseURL(config.PublicBaseURL)
+	if err != nil {
+		panic(fmt.Sprintf("invalid control-plane public base URL: %v", err))
+	}
 	workspaceURLTemplate := strings.TrimSpace(config.WorkspaceURLTemplate)
 	if workspaceURLTemplate == "" {
-		workspaceURLTemplate = defaultWorkspaceURL
+		if publicBaseURL != "" {
+			workspaceURLTemplate, err = WorkspaceURLTemplateFromPublicBase(publicBaseURL)
+			if err != nil {
+				panic(fmt.Sprintf("invalid control-plane public base URL: %v", err))
+			}
+		} else {
+			workspaceURLTemplate = defaultWorkspaceURL
+		}
 	}
 	inviteURLTemplate := strings.TrimSpace(config.InviteURLTemplate)
 	if inviteURLTemplate == "" {
-		inviteURLTemplate = defaultInviteURL
+		if publicBaseURL != "" {
+			inviteURLTemplate, err = InviteURLTemplateFromPublicBase(publicBaseURL)
+			if err != nil {
+				panic(fmt.Sprintf("invalid control-plane public base URL: %v", err))
+			}
+		} else {
+			inviteURLTemplate = defaultInviteURL
+		}
 	}
 	hostedScriptsDir := strings.TrimSpace(config.HostedScriptsDir)
 	if hostedScriptsDir == "" {

--- a/core/internal/server/auth_integration_test.go
+++ b/core/internal/server/auth_integration_test.go
@@ -193,7 +193,6 @@ func TestAgentAuthLifecycleAndActorCompatibility(t *testing.T) {
 
 	inviteToken := createInviteToken(t, serverURL, registerPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "duplicate-username-check",
 	})
 
 	dupResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/agents/register", map[string]any{
@@ -659,7 +658,6 @@ func TestBootstrapAndInviteGatedRegistrationFlow(t *testing.T) {
 
 	invite, inviteToken := createInvite(t, serverURL, firstPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "second-agent",
 	})
 	if invite["token"] != nil {
 		t.Fatalf("invite metadata unexpectedly included token: %#v", invite)
@@ -684,9 +682,6 @@ func TestBootstrapAndInviteGatedRegistrationFlow(t *testing.T) {
 		matched = true
 		if asString(listed["kind"]) != "agent" {
 			t.Fatalf("unexpected invite kind: %#v", listed)
-		}
-		if asString(listed["note"]) != "second-agent" {
-			t.Fatalf("unexpected invite note: %#v", listed)
 		}
 		if listed["token"] != nil {
 			t.Fatalf("listed invite unexpectedly exposed token: %#v", listed)
@@ -724,7 +719,6 @@ func TestInviteLifecycleRejectsExpiredRevokedWrongKindAndReuse(t *testing.T) {
 
 	singleUseInvite, singleUseToken := createInvite(t, serverURL, bootstrapPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "single-use",
 	})
 	firstUseResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/agents/register", map[string]any{
 		"username":     "single.use",
@@ -743,7 +737,6 @@ func TestInviteLifecycleRejectsExpiredRevokedWrongKindAndReuse(t *testing.T) {
 
 	wrongKindInvite, wrongKindToken := createInvite(t, serverURL, bootstrapPayload.Tokens.AccessToken, map[string]any{
 		"kind": "human",
-		"note": "wrong-kind",
 	})
 	wrongKindResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/agents/register", map[string]any{
 		"username":     "wrong.kind",
@@ -755,7 +748,6 @@ func TestInviteLifecycleRejectsExpiredRevokedWrongKindAndReuse(t *testing.T) {
 
 	revokedInvite, revokedToken := createInvite(t, serverURL, bootstrapPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "revoked",
 	})
 	revokeResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/invites/"+asString(revokedInvite["id"])+"/revoke", map[string]any{}, bootstrapPayload.Tokens.AccessToken, http.StatusOK)
 	defer revokeResp.Body.Close()
@@ -770,7 +762,6 @@ func TestInviteLifecycleRejectsExpiredRevokedWrongKindAndReuse(t *testing.T) {
 
 	expiredInvite, expiredToken := createInvite(t, serverURL, bootstrapPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "expired",
 	})
 	if _, err := env.workspace.DB().ExecContext(
 		context.Background(),
@@ -821,7 +812,6 @@ func TestAuthAuditAndPrincipalInventoryVisibility(t *testing.T) {
 
 	consumedInvite, consumedToken := createInvite(t, serverURL, adminPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "consumed-invite",
 	})
 
 	secondResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/agents/register", map[string]any{
@@ -846,7 +836,6 @@ func TestAuthAuditAndPrincipalInventoryVisibility(t *testing.T) {
 
 	revokedInvite, _ := createInvite(t, serverURL, adminPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "revoked-invite",
 	})
 	revokeInviteResp := postJSONExpectStatusWithAuth(t, serverURL+"/auth/invites/"+asString(revokedInvite["id"])+"/revoke", map[string]any{}, adminPayload.Tokens.AccessToken, http.StatusOK)
 	revokeInviteResp.Body.Close()
@@ -1050,7 +1039,6 @@ func TestAdminPrincipalRevocationAndLastActiveSafeguards(t *testing.T) {
 
 	memberInvite, memberToken := createInvite(t, serverURL, adminPayload.Tokens.AccessToken, map[string]any{
 		"kind": "agent",
-		"note": "member-revoke",
 	})
 	_ = memberInvite
 
@@ -1632,7 +1620,7 @@ func TestConcurrentFreshAuthRegistrationsSucceed(t *testing.T) {
 		inputs = append(inputs, input{
 			username:    fmt.Sprintf("user-%d", i+1),
 			publicKey:   publicKey,
-			inviteToken: createInviteToken(t, serverURL, initialPayload.Tokens.AccessToken, map[string]any{"kind": "agent", "note": fmt.Sprintf("concurrent-%d", i+1)}),
+			inviteToken: createInviteToken(t, serverURL, initialPayload.Tokens.AccessToken, map[string]any{"kind": "agent"}),
 		})
 	}
 

--- a/core/internal/server/auth_onboarding_handlers.go
+++ b/core/internal/server/auth_onboarding_handlers.go
@@ -34,7 +34,6 @@ func handleCreateInvite(w http.ResponseWriter, r *http.Request, opts handlerOpti
 
 	var req struct {
 		Kind      string `json:"kind"`
-		Note      string `json:"note"`
 		ExpiresAt string `json:"expires_at"`
 	}
 	if !decodeJSONBody(w, r, &req) {
@@ -54,7 +53,6 @@ func handleCreateInvite(w http.ResponseWriter, r *http.Request, opts handlerOpti
 
 	invite, token, err := opts.authStore.CreateInvite(r.Context(), *principal, auth.CreateInviteInput{
 		Kind:      req.Kind,
-		Note:      req.Note,
 		ExpiresAt: expiresAt,
 	})
 	if err != nil {

--- a/runbooks/packed-host-configuration.md
+++ b/runbooks/packed-host-configuration.md
@@ -35,10 +35,11 @@ Required settings:
 |---|---|
 | `OAR_CONTROL_PLANE_LISTEN_ADDR` | Loopback bind address, e.g. `127.0.0.1:8100` |
 | `OAR_CONTROL_PLANE_WORKSPACE_ROOT` | Persistent state directory for control-plane DB |
+| `OAR_CONTROL_PLANE_PUBLIC_BASE_URL` | Public browser-facing base URL used for workspace URLs, invite URLs, and launch-grant issuer defaults |
 | `OAR_CONTROL_PLANE_WEBAUTHN_RPID` | Public hostname for passkey ceremonies |
-| `OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN` | Full origin including `https://` |
-| `OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE` | Pattern for workspace URLs, `%s` = workspace slug |
-| `OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE` | Pattern for invite acceptance URLs |
+| `OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN` | Full origin including `https://`; defaults to the origin of `OAR_CONTROL_PLANE_PUBLIC_BASE_URL` when set |
+| `OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE` | Optional override pattern for workspace URLs, `%s` = workspace path |
+| `OAR_CONTROL_PLANE_INVITE_URL_TEMPLATE` | Optional override pattern for invite acceptance URLs |
 | `OAR_CONTROL_PLANE_WORKSPACE_GRANT_SIGNING_KEY` | Base64 Ed25519 private key for signing launch grants |
 
 Placement defaults for packed-host:

--- a/runbooks/packed-host-launch-notes.md
+++ b/runbooks/packed-host-launch-notes.md
@@ -75,8 +75,9 @@ Key smoke outcomes from that run:
 - Loopback ports are chosen dynamically during `scripts/packed-host-smoke`.
 - `OAR_CONTROL_PLANE_WEBAUTHN_ORIGIN` is set to
   `http://localhost:<ui-port>` for the local smoke browser origin.
-- `OAR_CONTROL_PLANE_WORKSPACE_URL_TEMPLATE` is set to
-  `http://localhost:<ui-port>/%s` for the local shared-UI route shape.
+- `OAR_CONTROL_PLANE_PUBLIC_BASE_URL` is set to `http://localhost:<ui-port>`
+  so shared control-plane invite URLs and workspace URLs use the same local
+  browser-facing base.
 - The local smoke builds the shared UI with `web-ui/scripts/build` before it
   starts the Node adapter server.
 - The local smoke serves the shared UI with `web-ui/scripts/serve` and sets

--- a/web-ui/docs/oar-ui-spec.md
+++ b/web-ui/docs/oar-ui-spec.md
@@ -192,7 +192,7 @@ The Access page provides workspace-local operator visibility and intervention fo
 
 **Invite management:**
 
-- The UI MUST display pending and revoked invites with their invite ID, kind, note, and creation time.
+- The UI MUST display pending and revoked invites with their invite ID, kind, and creation time.
 - Any authenticated principal MAY create and revoke invites.
 - The UI SHOULD display created invite tokens with a copy-to-clipboard affordance and a clear warning that tokens are shown only once.
 

--- a/web-ui/src/lib/inviteRegistrationMessage.js
+++ b/web-ui/src/lib/inviteRegistrationMessage.js
@@ -1,0 +1,54 @@
+function joinWithAnd(parts) {
+  if (parts.length <= 1) {
+    return parts[0] ?? "";
+  }
+  if (parts.length === 2) {
+    return `${parts[0]} and ${parts[1]}`;
+  }
+  return `${parts.slice(0, -1).join(", ")}, and ${parts.at(-1)}`;
+}
+
+export function buildRegistrationMessage(
+  token,
+  baseUrl,
+  agentName = "",
+  username = "",
+) {
+  const normalizedToken = String(token ?? "").trim();
+  const normalizedBaseUrl =
+    String(baseUrl ?? "").trim() || "<OAR_WORKSPACE_URL>";
+  const normalizedAgentName = String(agentName ?? "").trim();
+  const normalizedUsername = String(username ?? "").trim();
+
+  const missingLabels = [];
+  if (!normalizedAgentName) {
+    missingLabels.push("an agent profile name");
+  }
+  if (!normalizedUsername) {
+    missingLabels.push("a username");
+  }
+
+  const lines = [
+    "Register with this OAR workspace using the invite token below.",
+    "",
+  ];
+
+  if (missingLabels.length > 0) {
+    lines.push(
+      `If you leave the placeholders in place, the registering agent should choose ${joinWithAnd(missingLabels)}.`,
+      "",
+      "Run the following command (replace any placeholder values you want to set yourself):",
+    );
+  } else {
+    lines.push("Run the following command:");
+  }
+
+  lines.push(
+    "",
+    `  oar --base-url ${normalizedBaseUrl} --agent ${normalizedAgentName || "<agent-name>"} auth register --username ${normalizedUsername || "<username>"} --invite-token ${normalizedToken}`,
+    "",
+    "This invite token is single-use.",
+  );
+
+  return lines.join("\n");
+}

--- a/web-ui/src/routes/[workspace]/access/+page.server.js
+++ b/web-ui/src/routes/[workspace]/access/+page.server.js
@@ -1,9 +1,33 @@
+import { normalizeBaseUrl } from "$lib/config";
 import { resolveWorkspaceBySlug } from "$lib/server/workspaceResolver";
+import { workspacePath } from "$lib/workspacePaths";
+
+function resolveRegistrationBaseUrl(event, resolved) {
+  const requestPath = String(event?.url?.pathname ?? "");
+  if (requestPath.endsWith("/access")) {
+    return normalizeBaseUrl(`${event.url.origin}${requestPath.slice(0, -7)}`);
+  }
+
+  try {
+    const workspaceUrl = new URL(
+      workspacePath(resolved.workspaceSlug),
+      event.url,
+    ).toString();
+    return normalizeBaseUrl(workspaceUrl);
+  } catch {
+    return normalizeBaseUrl(
+      resolved.workspace?.publicOrigin ?? resolved.workspace?.coreBaseUrl ?? "",
+    );
+  }
+}
 
 export async function load(event) {
   const resolved = await resolveWorkspaceBySlug({
     event,
     workspaceSlug: event.params.workspace,
   });
-  return { coreBaseUrl: resolved.workspace?.coreBaseUrl ?? "" };
+  return {
+    coreBaseUrl: resolved.workspace?.coreBaseUrl ?? "",
+    registrationBaseUrl: resolveRegistrationBaseUrl(event, resolved),
+  };
 }

--- a/web-ui/src/routes/[workspace]/access/+page.svelte
+++ b/web-ui/src/routes/[workspace]/access/+page.svelte
@@ -4,6 +4,7 @@
   import { authenticatedAgent } from "$lib/authSession";
   import { coreClient } from "$lib/coreClient";
   import { formatTimestamp } from "$lib/formatDate";
+  import { buildRegistrationMessage } from "$lib/inviteRegistrationMessage";
   import { workspacePath } from "$lib/workspacePaths";
 
   let { data } = $props();
@@ -27,11 +28,14 @@
 
   let creatingInvite = $state(false);
   let inviteError = $state("");
-  let newInviteNote = $state("");
   let newInviteKind = $state("agent");
+  let newInviteAgentName = $state("");
+  let newInviteUsername = $state("");
 
   let createdToken = $state("");
   let createdInviteKind = $state("");
+  let createdInviteAgentName = $state("");
+  let createdInviteUsername = $state("");
   let tokenCopied = $state(false);
   let messageCopied = $state(false);
   let tokenDismissed = $state(false);
@@ -181,13 +185,13 @@
       const payload = {
         kind: newInviteKind,
       };
-      if (newInviteNote.trim()) {
-        payload.note = newInviteNote.trim();
-      }
       const result = await coreClient.createInvite(payload);
       createdToken = result.token ?? "";
       createdInviteKind = newInviteKind;
-      newInviteNote = "";
+      createdInviteAgentName = newInviteAgentName.trim();
+      createdInviteUsername = newInviteUsername.trim();
+      newInviteAgentName = "";
+      newInviteUsername = "";
       await loadAccessData();
     } catch (error) {
       inviteError = extractErrorMessage(error, "Failed to create invite");
@@ -301,24 +305,16 @@
     }
   }
 
-  function buildRegistrationMessage(token, baseUrl) {
-    const url = baseUrl || "<CORE_API_URL>";
-    return [
-      "Register with this OAR workspace using the invite token below.",
-      "",
-      "Run the following command (replace <agent-name> with a profile name and <username> with your desired username):",
-      "",
-      `  oar --base-url ${url} --agent <agent-name> auth register --username <username> --invite-token ${token}`,
-      "",
-      "This invite token is single-use.",
-    ].join("\n");
-  }
-
   async function copyRegistrationMessage() {
     if (!createdToken) return;
     try {
       await navigator.clipboard.writeText(
-        buildRegistrationMessage(createdToken, data.coreBaseUrl),
+        buildRegistrationMessage(
+          createdToken,
+          data.registrationBaseUrl,
+          createdInviteAgentName,
+          createdInviteUsername,
+        ),
       );
       messageCopied = true;
     } catch {
@@ -330,6 +326,8 @@
     tokenDismissed = true;
     createdToken = "";
     createdInviteKind = "";
+    createdInviteAgentName = "";
+    createdInviteUsername = "";
   }
 
   function extractErrorMessage(error, fallback) {
@@ -666,21 +664,38 @@
                 <option value="any">Any</option>
               </select>
             </div>
-            <div class="flex-[2] min-w-[240px]">
-              <label
-                class="mb-1 block text-[11px] font-medium text-[var(--ui-text-muted)]"
-                for="invite-note"
-              >
-                Note (optional)
-              </label>
-              <input
-                bind:value={newInviteNote}
-                class="w-full rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg)] px-2 py-1.5 text-[13px] text-[var(--ui-text)]"
-                id="invite-note"
-                placeholder="e.g. 'ops bot for CI'"
-                type="text"
-              />
-            </div>
+            {#if newInviteKind === "agent" || newInviteKind === "any"}
+              <div class="flex-[2] min-w-[240px]">
+                <label
+                  class="mb-1 block text-[11px] font-medium text-[var(--ui-text-muted)]"
+                  for="invite-agent-name"
+                >
+                  Agent name (optional)
+                </label>
+                <input
+                  bind:value={newInviteAgentName}
+                  class="w-full rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg)] px-2 py-1.5 text-[13px] text-[var(--ui-text)]"
+                  id="invite-agent-name"
+                  placeholder="e.g. hermes-prod"
+                  type="text"
+                />
+              </div>
+              <div class="flex-[2] min-w-[240px]">
+                <label
+                  class="mb-1 block text-[11px] font-medium text-[var(--ui-text-muted)]"
+                  for="invite-username"
+                >
+                  Username (optional)
+                </label>
+                <input
+                  bind:value={newInviteUsername}
+                  class="w-full rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg)] px-2 py-1.5 text-[13px] text-[var(--ui-text)]"
+                  id="invite-username"
+                  placeholder="e.g. hermes.prod"
+                  type="text"
+                />
+              </div>
+            {/if}
             <button
               class="cursor-pointer rounded-md bg-indigo-600 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
               disabled={creatingInvite}
@@ -731,7 +746,7 @@
                     {invite.id}
                   </p>
                   <p class="text-[11px] text-[var(--ui-text-muted)]">
-                    {invite.kind} - {invite.note || "No note"}
+                    {invite.kind}
                   </p>
                 </div>
                 <span class="text-[11px] text-[var(--ui-text-muted)]">

--- a/web-ui/tests/unit/accessRoute.test.js
+++ b/web-ui/tests/unit/accessRoute.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+const workspaceResolverMocks = vi.hoisted(() => ({
+  resolveWorkspaceBySlug: vi.fn(),
+}));
+
+vi.mock("$lib/server/workspaceResolver", () => ({
+  resolveWorkspaceBySlug: workspaceResolverMocks.resolveWorkspaceBySlug,
+}));
+
+import { load } from "../../src/routes/[workspace]/access/+page.server.js";
+
+describe("access route", () => {
+  it("uses the current browser workspace path for copied registration commands", async () => {
+    workspaceResolverMocks.resolveWorkspaceBySlug.mockResolvedValue({
+      workspaceSlug: "scalingforever",
+      workspace: {
+        coreBaseUrl: "http://127.0.0.1:8002",
+        publicOrigin: "https://stale.example.test/oar/scalingforever",
+      },
+    });
+
+    const result = await load({
+      params: {
+        workspace: "scalingforever",
+      },
+      url: new URL(
+        "https://m2-internal.scalingforever.com/oar/scalingforever/access",
+      ),
+    });
+
+    expect(result).toEqual({
+      coreBaseUrl: "http://127.0.0.1:8002",
+      registrationBaseUrl:
+        "https://m2-internal.scalingforever.com/oar/scalingforever",
+    });
+  });
+});

--- a/web-ui/tests/unit/inviteRegistrationMessage.test.js
+++ b/web-ui/tests/unit/inviteRegistrationMessage.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRegistrationMessage } from "../../src/lib/inviteRegistrationMessage.js";
+
+describe("inviteRegistrationMessage", () => {
+  it("fills in agent name and username when provided", () => {
+    const message = buildRegistrationMessage(
+      "oinv_123",
+      "https://example.com/oar/team-alpha",
+      "hermes-prod",
+      "hermes.prod",
+    );
+
+    expect(message).toContain(
+      "oar --base-url https://example.com/oar/team-alpha --agent hermes-prod auth register --username hermes.prod --invite-token oinv_123",
+    );
+    expect(message).not.toContain("replace any placeholder values");
+  });
+
+  it("asks the registering agent to choose missing names", () => {
+    const message = buildRegistrationMessage(
+      "oinv_123",
+      "https://example.com/oar/team-alpha",
+      "",
+      "",
+    );
+
+    expect(message).toContain(
+      "If you leave the placeholders in place, the registering agent should choose an agent profile name and a username.",
+    );
+    expect(message).toContain("--agent <agent-name>");
+    expect(message).toContain("--username <username>");
+  });
+});


### PR DESCRIPTION
## Summary
- fix workspace Access invite copy so it uses the browser-facing workspace URL and optional agent name/username fields instead of an internal core URL and unused note metadata
- retire invite `note` from the shared auth invite contract, core handler/store, and CLI surface/docs
- add `OAR_CONTROL_PLANE_PUBLIC_BASE_URL` / `--public-base-url` and derive workspace URLs, invite URLs, launch-grant issuer defaults, and WebAuthn origin defaults from it when explicit overrides are absent

## Validation
- `make contract-gen`
- `pnpm exec tsc --project contracts/gen/ts/tsconfig.json --pretty false`
- `pnpm exec tsc --project contracts/gen/control/ts/tsconfig.json --pretty false`
- `cd cli && go run ./cmd/oar-docs-gen`
- `go test ./internal/auth ./internal/controlplane ./internal/server ./cmd/oar-control-plane` in `core/`
- `go test ./internal/app ./internal/authcli` in `cli/`
- `make check` in `web-ui/`
