### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.3.0
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: true

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -19,10 +19,10 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5.0.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       web_ui: ${{ steps.filter.outputs.web_ui }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
             automation:
@@ -62,7 +62,7 @@ jobs:
     if: needs.changes.outputs.automation == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node And pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -77,7 +77,7 @@ jobs:
     if: needs.changes.outputs.contracts == 'true' || needs.changes.outputs.go_shared == 'true' || needs.changes.outputs.node_shared == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -98,7 +98,7 @@ jobs:
     if: needs.changes.outputs.core == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.go_shared == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -116,7 +116,7 @@ jobs:
     if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.go_shared == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -135,7 +135,7 @@ jobs:
     if: needs.changes.outputs.web_ui == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.node_shared == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node And pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -26,7 +26,7 @@ jobs:
         run: ./scripts/build-cli-release-artifacts.sh "${GITHUB_REF_NAME}" dist
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.6.1
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/system-smokes.yml
+++ b/.github/workflows/system-smokes.yml
@@ -56,12 +56,12 @@ jobs:
 
       - name: Checkout
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect push changes
         id: filter
         if: github.event_name == 'push'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
             hosted:
@@ -107,7 +107,7 @@ jobs:
             artifact_path: .tmp/hosted-smoke/**
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload hosted artifacts
         if: always() && matrix.artifact_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_path }}
@@ -150,7 +150,7 @@ jobs:
             artifact_path: .tmp/saas-e2e/**
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload SaaS artifacts
         if: always() && matrix.artifact_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_path }}
@@ -179,7 +179,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.run_saas_load_smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload saas-load-smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: saas-load-smoke-artifacts
           path: .tmp/saas-load-smoke/**
@@ -210,7 +210,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.run_e2e_smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -228,7 +228,7 @@ jobs:
 
       - name: Upload e2e artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: e2e-smoke-artifacts
           path: .tmp/e2e-smoke/**


### PR DESCRIPTION
## Summary
- bump GitHub Actions to current upstream releases across shared action wrappers and workflows
- move checkout/setup-go/setup-node/pnpm/paths-filter/upload-artifact pins to current releases
- pin release publishing to the latest available softprops/action-gh-release v2 tag

## Validation
- pnpm -C web-ui exec prettier --check "../.github/**/*.{yml,yaml}"

## Notes
- this addresses the post-release follow-up to refresh action versions after the Node 20 deprecation warning in the release workflow
- softprops/action-gh-release has no newer major than v2; this PR moves it to the latest released v2.6.1 tag