### PR TITLE
feat(cli): add explicit update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Install the `oar` CLI on any Linux or macOS host:
 curl -sSfL https://raw.githubusercontent.com/Git-on-my-level/organization-autorunner/main/scripts/install-oar.sh | sh
 ```
 
+After install, check or apply CLI updates explicitly with:
+
+```bash
+oar update --check
+oar update
+```
+
 See `runbooks/release.md` for version-pinning and custom install directory options.
 
 ## Useful Targets

--- a/cli/docs/runbook.md
+++ b/cli/docs/runbook.md
@@ -244,7 +244,8 @@ oar --json --base-url <core> --agent <agent> api call --path /meta/handshake
 - `recommended_cli_version`
 - `cli_download_url`
 
-3. Upgrade CLI binary and re-run `oar version` + `oar doctor`.
+3. Run `oar update --check` to inspect the selected target, then `oar update` to replace the current binary in place. Use `oar update --version <tag>` to pin a specific release.
+4. Re-run `oar version` + `oar doctor`.
 
 ### SSE stream issues (`events stream` / `inbox stream`)
 

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -72,7 +72,7 @@ func (a *App) Run(args []string) int {
 	if len(remaining) > 1 {
 		subPeek = remaining[1]
 	}
-	configLenient := cmdPeek == "version" || cmdPeek == "help" || cmdPeek == "--help" || cmdPeek == "-h" || cmdPeek == "meta" ||
+	configLenient := cmdPeek == "version" || cmdPeek == "help" || cmdPeek == "--help" || cmdPeek == "-h" || cmdPeek == "meta" || cmdPeek == "update" ||
 		(cmdPeek == "import" && isConfigLenientImportCommand(remaining[1:])) ||
 		(cmdPeek == "auth" && (subPeek == "list" || subPeek == "ls" || subPeek == "profiles"))
 

--- a/cli/internal/app/commands.go
+++ b/cli/internal/app/commands.go
@@ -43,6 +43,9 @@ func (a *App) runCommand(ctx context.Context, args []string, cfg config.Resolved
 	case "doctor":
 		result, err := a.runDoctor(ctx, cfg)
 		return "doctor", result, err
+	case "update":
+		result, err := a.runUpdate(ctx, args[1:], cfg)
+		return "update", result, err
 	case "auth":
 		result, name, err := a.runAuth(ctx, args[1:], cfg)
 		return name, result, err

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -355,6 +355,7 @@ Usage:
 Core Commands:
   version       Print CLI/runtime version details
   doctor        Validate local and network preconditions
+  update        Replace the installed CLI binary with the recommended or requested release
   auth          Manage agent registration, profile auth, and token lifecycle
   import        Bootstrap a precision-first workspace import and run local import helpers
   draft         Stage write requests locally and commit them later
@@ -410,6 +411,9 @@ func helpTopicText(topic string) (string, bool) {
 	}
 	if topic == "onboarding" {
 		return onboardingHelpText(), true
+	}
+	if topic == "update" {
+		return updateUsageText() + "\n", true
 	}
 	if topic == "agent-guide" {
 		return agentGuideText(), true

--- a/cli/internal/app/update_command.go
+++ b/cli/internal/app/update_command.go
@@ -1,0 +1,517 @@
+package app
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"organization-autorunner-cli/internal/config"
+	"organization-autorunner-cli/internal/errnorm"
+	"organization-autorunner-cli/internal/httpclient"
+)
+
+var (
+	updateReleaseBaseURL = "https://github.com/Git-on-my-level/organization-autorunner/releases"
+	updateExecutablePath = os.Executable
+	updateMkdirTemp      = os.MkdirTemp
+	updateRemoveAll      = os.RemoveAll
+	updateStat           = os.Stat
+	updateWriteFile      = os.WriteFile
+	updateChmod          = os.Chmod
+	updateRename         = os.Rename
+	updateGOOS           = runtime.GOOS
+	updateGOARCH         = runtime.GOARCH
+)
+
+type updatePlan struct {
+	CurrentVersion        string
+	TargetVersion         string
+	MinCLIVersion         string
+	RecommendedCLIVersion string
+	CLIDownloadURL        string
+	InstallPath           string
+	ArchiveName           string
+	Source                string
+	HandshakeWarning      string
+	UpdateAvailable       bool
+	AlreadyCurrent        bool
+}
+
+func (a *App) runUpdate(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
+	fs := newSilentFlagSet("update")
+	var (
+		checkFlag   trackedBool
+		versionFlag trackedString
+	)
+	fs.Var(&checkFlag, "check", "Report update availability without downloading or replacing the binary")
+	fs.Var(&versionFlag, "version", "Install a specific release tag (for example v0.0.1)")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, errnorm.Usage("invalid_update_flags", err.Error())
+	}
+	if len(fs.Args()) > 0 {
+		return nil, errnorm.Usage("invalid_update_args", "unexpected positional arguments for `oar update`")
+	}
+
+	plan, err := buildUpdatePlan(ctx, cfg, strings.TrimSpace(versionFlag.value))
+	if err != nil {
+		return nil, err
+	}
+	if checkFlag.value || plan.AlreadyCurrent {
+		return renderUpdatePlan(plan, false), nil
+	}
+
+	binaryBytes, mode, err := downloadUpdateBinary(ctx, cfg.Timeout, plan.TargetVersion, plan.ArchiveName)
+	if err != nil {
+		return nil, err
+	}
+	if err := replaceExecutable(plan.InstallPath, binaryBytes, mode); err != nil {
+		return nil, err
+	}
+	return renderUpdatePlan(plan, true), nil
+}
+
+func buildUpdatePlan(ctx context.Context, cfg config.Resolved, requestedVersion string) (updatePlan, error) {
+	installPath, err := updateExecutablePath()
+	if err != nil {
+		return updatePlan{}, errnorm.Wrap(errnorm.KindLocal, "install_path_unavailable", "failed to resolve current executable path", err)
+	}
+
+	plan := updatePlan{
+		CurrentVersion: normalizeReleaseTag(httpclient.CLIVersion),
+		InstallPath:    installPath,
+	}
+
+	if requestedVersion != "" {
+		plan.TargetVersion = normalizeReleaseTag(requestedVersion)
+		plan.Source = "explicit_version"
+		plan.ArchiveName, err = updateArchiveName(plan.TargetVersion)
+		if err != nil {
+			return updatePlan{}, err
+		}
+		plan.AlreadyCurrent = strings.EqualFold(plan.CurrentVersion, plan.TargetVersion)
+		plan.UpdateAvailable = !plan.AlreadyCurrent
+		return plan, nil
+	}
+
+	handshake, handshakeErr := fetchUpdateHandshake(ctx, cfg)
+	if handshakeErr == nil {
+		plan.MinCLIVersion = normalizeReleaseTag(anyString(handshake["min_cli_version"]))
+		plan.RecommendedCLIVersion = normalizeReleaseTag(anyString(handshake["recommended_cli_version"]))
+		plan.CLIDownloadURL = strings.TrimSpace(anyString(handshake["cli_download_url"]))
+		plan.TargetVersion = firstNonEmpty(plan.RecommendedCLIVersion, plan.MinCLIVersion)
+		if plan.TargetVersion != "" {
+			plan.Source = "handshake"
+		}
+	} else {
+		plan.HandshakeWarning = handshakeErr.Error()
+	}
+
+	if plan.TargetVersion == "" {
+		latest, latestErr := resolveLatestReleaseTag(ctx, cfg.Timeout)
+		if latestErr != nil {
+			if plan.HandshakeWarning != "" {
+				return updatePlan{}, errnorm.WithDetails(
+					errnorm.Wrap(errnorm.KindNetwork, "update_unavailable", "failed to resolve an update target from handshake or latest release", latestErr),
+					map[string]any{"handshake_error": plan.HandshakeWarning},
+				)
+			}
+			return updatePlan{}, errnorm.Wrap(errnorm.KindNetwork, "update_unavailable", "failed to resolve latest release version", latestErr)
+		}
+		plan.TargetVersion = latest
+		plan.Source = "latest_release"
+	}
+	plan.ArchiveName, err = updateArchiveName(plan.TargetVersion)
+	if err != nil {
+		return updatePlan{}, err
+	}
+
+	comparison, compareErr := compareSemanticVersions(plan.CurrentVersion, plan.TargetVersion)
+	if compareErr == nil {
+		plan.AlreadyCurrent = comparison >= 0
+	} else {
+		plan.AlreadyCurrent = strings.EqualFold(plan.CurrentVersion, plan.TargetVersion)
+	}
+	plan.UpdateAvailable = !plan.AlreadyCurrent
+	return plan, nil
+}
+
+func renderUpdatePlan(plan updatePlan, updated bool) *commandResult {
+	data := map[string]any{
+		"current_version":         plan.CurrentVersion,
+		"target_version":          plan.TargetVersion,
+		"min_cli_version":         plan.MinCLIVersion,
+		"recommended_cli_version": plan.RecommendedCLIVersion,
+		"cli_download_url":        plan.CLIDownloadURL,
+		"install_path":            plan.InstallPath,
+		"archive_name":            plan.ArchiveName,
+		"source":                  plan.Source,
+		"update_available":        plan.UpdateAvailable,
+		"already_current":         plan.AlreadyCurrent,
+		"updated":                 updated,
+		"handshake_warning":       plan.HandshakeWarning,
+	}
+
+	lines := []string{
+		"CLI update",
+		"Current version: " + displayValue(plan.CurrentVersion),
+		"Target version: " + displayValue(plan.TargetVersion),
+		"Source: " + displayValue(plan.Source),
+		"Install path: " + displayValue(plan.InstallPath),
+		"Archive: " + displayValue(plan.ArchiveName),
+	}
+	if plan.RecommendedCLIVersion != "" {
+		lines = append(lines, "Recommended version: "+plan.RecommendedCLIVersion)
+	}
+	if plan.MinCLIVersion != "" {
+		lines = append(lines, "Minimum version: "+plan.MinCLIVersion)
+	}
+	if plan.CLIDownloadURL != "" {
+		lines = append(lines, "Download URL: "+plan.CLIDownloadURL)
+	}
+	if plan.HandshakeWarning != "" {
+		lines = append(lines, "Handshake warning: "+plan.HandshakeWarning)
+	}
+	switch {
+	case updated:
+		lines = append(lines, "Status: updated in place; re-run `oar version` to confirm the active binary.")
+	case plan.AlreadyCurrent:
+		lines = append(lines, "Status: already at or above the selected target version.")
+	default:
+		lines = append(lines, "Status: update available.")
+	}
+	return &commandResult{Data: data, Text: strings.Join(lines, "\n")}
+}
+
+func fetchUpdateHandshake(ctx context.Context, cfg config.Resolved) (map[string]any, error) {
+	client, err := httpclient.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	callCtx, cancel := httpclient.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	resp, err := client.RawCall(callCtx, httpclient.RawRequest{Method: http.MethodGet, Path: "/meta/handshake"})
+	if err != nil {
+		return nil, errnorm.Wrap(errnorm.KindNetwork, "request_failed", "handshake request failed", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, errnorm.FromHTTPFailure(resp.StatusCode, resp.Body)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return nil, errnorm.Wrap(errnorm.KindRemote, "invalid_response", "handshake response is not valid JSON", err)
+	}
+	return payload, nil
+}
+
+func resolveLatestReleaseTag(ctx context.Context, timeout time.Duration) (string, error) {
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(updateReleaseBaseURL, "/")+"/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	tag := strings.TrimSpace(pathBase(resp.Request.URL.Path))
+	if tag == "" || strings.EqualFold(tag, "latest") {
+		return "", fmt.Errorf("latest release redirect did not resolve a tag")
+	}
+	return normalizeReleaseTag(tag), nil
+}
+
+func updateArchiveName(version string) (string, error) {
+	goos := strings.TrimSpace(updateGOOS)
+	goarch := strings.TrimSpace(updateGOARCH)
+	version = normalizeReleaseTag(version)
+	if version == "" {
+		return "", errnorm.Local("version_required", "release version is required to resolve the update archive name")
+	}
+	switch goos {
+	case "linux", "darwin", "windows":
+	default:
+		return "", errnorm.Local("unsupported_os", fmt.Sprintf("unsupported OS: %s", goos))
+	}
+	switch goarch {
+	case "amd64", "arm64":
+	default:
+		return "", errnorm.Local("unsupported_arch", fmt.Sprintf("unsupported architecture: %s", goarch))
+	}
+
+	if goos == "windows" {
+		return fmt.Sprintf("oar_%s_%s_%s.zip", version, goos, goarch), nil
+	}
+	return fmt.Sprintf("oar_%s_%s_%s.tar.gz", version, goos, goarch), nil
+}
+
+func downloadUpdateBinary(ctx context.Context, timeout time.Duration, version string, archiveName string) ([]byte, os.FileMode, error) {
+	client := &http.Client{Timeout: timeout}
+	baseURL := strings.TrimRight(updateReleaseBaseURL, "/") + "/download/" + normalizeReleaseTag(version)
+
+	archiveBytes, err := fetchBytes(ctx, client, baseURL+"/"+archiveName)
+	if err != nil {
+		return nil, 0, errnorm.Wrap(errnorm.KindNetwork, "download_failed", "failed to download CLI release archive", err)
+	}
+	checksumBytes, err := fetchBytes(ctx, client, baseURL+"/checksums.txt")
+	if err != nil {
+		return nil, 0, errnorm.Wrap(errnorm.KindNetwork, "download_failed", "failed to download CLI checksum manifest", err)
+	}
+	if err := verifyReleaseChecksum(archiveName, archiveBytes, checksumBytes); err != nil {
+		return nil, 0, err
+	}
+	return extractReleaseBinary(archiveName, archiveBytes)
+}
+
+func fetchBytes(ctx context.Context, client *http.Client, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+	return body, nil
+}
+
+func verifyReleaseChecksum(archiveName string, archiveBytes []byte, checksumBytes []byte) error {
+	expected := ""
+	for _, line := range strings.Split(string(checksumBytes), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[len(fields)-1] == archiveName {
+			expected = strings.TrimSpace(fields[0])
+			break
+		}
+	}
+	if expected == "" {
+		return errnorm.Local("checksum_missing", fmt.Sprintf("archive %s not found in checksums.txt", archiveName))
+	}
+	actualBytes := sha256.Sum256(archiveBytes)
+	actual := hex.EncodeToString(actualBytes[:])
+	if !strings.EqualFold(expected, actual) {
+		return errnorm.WithDetails(
+			errnorm.Local("checksum_mismatch", "downloaded CLI archive checksum did not match checksums.txt"),
+			map[string]any{"expected": expected, "actual": actual, "archive_name": archiveName},
+		)
+	}
+	return nil
+}
+
+func extractReleaseBinary(archiveName string, archiveBytes []byte) ([]byte, os.FileMode, error) {
+	if strings.HasSuffix(archiveName, ".zip") {
+		return extractZIPBinary(archiveBytes)
+	}
+	return extractTarGZBinary(archiveBytes)
+}
+
+func extractZIPBinary(archiveBytes []byte) ([]byte, os.FileMode, error) {
+	reader, err := zip.NewReader(bytes.NewReader(archiveBytes), int64(len(archiveBytes)))
+	if err != nil {
+		return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to read CLI zip archive", err)
+	}
+	for _, file := range reader.File {
+		if pathBase(file.Name) != "oar.exe" {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to open CLI binary inside zip archive", err)
+		}
+		defer rc.Close()
+		body, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to read CLI binary inside zip archive", err)
+		}
+		mode := file.Mode()
+		if mode == 0 {
+			mode = 0o755
+		}
+		return body, mode, nil
+	}
+	return nil, 0, errnorm.Local("archive_invalid", "CLI zip archive did not contain oar.exe")
+}
+
+func extractTarGZBinary(archiveBytes []byte) ([]byte, os.FileMode, error) {
+	gzReader, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+	if err != nil {
+		return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to open CLI tar.gz archive", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to read CLI tar archive", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if pathBase(header.Name) != "oar" {
+			continue
+		}
+		body, err := io.ReadAll(tarReader)
+		if err != nil {
+			return nil, 0, errnorm.Wrap(errnorm.KindLocal, "archive_invalid", "failed to read CLI binary inside tar archive", err)
+		}
+		mode := os.FileMode(header.Mode)
+		if mode == 0 {
+			mode = 0o755
+		}
+		return body, mode, nil
+	}
+	return nil, 0, errnorm.Local("archive_invalid", "CLI tar.gz archive did not contain oar")
+}
+
+func replaceExecutable(installPath string, binaryBytes []byte, mode os.FileMode) error {
+	info, err := updateStat(installPath)
+	if err == nil && info.Mode() != 0 {
+		mode = info.Mode().Perm()
+	}
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	tmpDir, err := updateMkdirTemp(filepath.Dir(installPath), ".oar-update-")
+	if err != nil {
+		return errnorm.Wrap(errnorm.KindLocal, "update_write_failed", "failed to allocate a temporary install directory", err)
+	}
+	defer func() { _ = updateRemoveAll(tmpDir) }()
+
+	tmpPath := filepath.Join(tmpDir, filepath.Base(installPath))
+	if err := updateWriteFile(tmpPath, binaryBytes, mode); err != nil {
+		return errnorm.Wrap(errnorm.KindLocal, "update_write_failed", "failed to write the updated CLI binary", err)
+	}
+	if err := updateChmod(tmpPath, mode); err != nil {
+		return errnorm.Wrap(errnorm.KindLocal, "update_write_failed", "failed to set executable permissions on the updated CLI binary", err)
+	}
+	if err := updateRename(tmpPath, installPath); err != nil {
+		return errnorm.Wrap(errnorm.KindLocal, "update_replace_failed", "failed to replace the current CLI binary in place", err)
+	}
+	return nil
+}
+
+func compareSemanticVersions(left string, right string) (int, error) {
+	leftParts, err := parseSemanticVersion(left)
+	if err != nil {
+		return 0, err
+	}
+	rightParts, err := parseSemanticVersion(right)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < 3; i++ {
+		if leftParts[i] < rightParts[i] {
+			return -1, nil
+		}
+		if leftParts[i] > rightParts[i] {
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func parseSemanticVersion(raw string) ([3]int, error) {
+	var out [3]int
+	raw = strings.TrimSpace(strings.TrimPrefix(raw, "v"))
+	if raw == "" {
+		return out, fmt.Errorf("empty version")
+	}
+	if idx := strings.IndexAny(raw, "-+"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	parts := strings.Split(raw, ".")
+	if len(parts) < 1 || len(parts) > 3 {
+		return out, fmt.Errorf("invalid semantic version: %s", raw)
+	}
+	for i := 0; i < 3; i++ {
+		if i >= len(parts) {
+			continue
+		}
+		value, err := strconv.Atoi(strings.TrimSpace(parts[i]))
+		if err != nil || value < 0 {
+			return out, fmt.Errorf("invalid semantic version: %s", raw)
+		}
+		out[i] = value
+	}
+	return out, nil
+}
+
+func normalizeReleaseTag(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "v") {
+		return "v" + strings.TrimPrefix(raw[1:], "v")
+	}
+	return "v" + raw
+}
+
+func displayValue(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return "(none)"
+	}
+	return strings.TrimSpace(raw)
+}
+
+func pathBase(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimRight(raw, "/")
+	if raw == "" {
+		return ""
+	}
+	return filepath.Base(raw)
+}
+
+func updateUsageText() string {
+	return strings.TrimSpace(`Update the installed oar CLI binary in place.
+
+Usage:
+  oar update [--check] [--version <tag>]
+
+Options:
+  --check          report the selected target version without changing the binary
+  --version <tag>  install a specific release tag instead of the recommended/latest version
+
+Behavior:
+  - prefers the recommended version from /meta/handshake when core is reachable
+  - falls back to the latest GitHub release when handshake metadata is unavailable
+  - downloads the matching release archive for the current OS/arch and replaces the current binary
+
+Examples:
+  oar update --check
+  oar --base-url https://example.com/oar/team-a update --check
+  oar update
+  oar update --version v0.0.1`)
+}

--- a/cli/internal/app/update_command_test.go
+++ b/cli/internal/app/update_command_test.go
@@ -1,0 +1,221 @@
+package app
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"organization-autorunner-cli/internal/httpclient"
+)
+
+func TestRunUpdateCheckUsesHandshakeRecommendation(t *testing.T) {
+	restoreVersion := httpclient.CLIVersion
+	httpclient.CLIVersion = "v0.0.1"
+	t.Cleanup(func() { httpclient.CLIVersion = restoreVersion })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/meta/handshake" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"min_cli_version":"0.0.1","recommended_cli_version":"0.0.2","cli_download_url":"https://example.com/oar"}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "--base-url", server.URL, "update", "--check"})
+	payload := assertEnvelopeOK(t, raw)
+	if got := anyStringValue(payload["command"]); got != "update" {
+		t.Fatalf("unexpected command: %#v", payload)
+	}
+	data, _ := payload["data"].(map[string]any)
+	if got := anyStringValue(data["target_version"]); got != "v0.0.2" {
+		t.Fatalf("expected handshake target version, got %#v", data)
+	}
+	if got := anyStringValue(data["source"]); got != "handshake" {
+		t.Fatalf("expected handshake source, got %#v", data)
+	}
+	if got, _ := data["update_available"].(bool); !got {
+		t.Fatalf("expected update_available=true, got %#v", data)
+	}
+}
+
+func TestRunUpdateCheckFallsBackToLatestRelease(t *testing.T) {
+	restoreVersion := httpclient.CLIVersion
+	restoreBaseURL := updateReleaseBaseURL
+	httpclient.CLIVersion = "v0.0.1"
+	t.Cleanup(func() {
+		httpclient.CLIVersion = restoreVersion
+		updateReleaseBaseURL = restoreBaseURL
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			http.Redirect(w, r, server.URL+"/releases/tag/v0.0.3", http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	updateReleaseBaseURL = server.URL + "/releases"
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "update", "--check"})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	if got := anyStringValue(data["target_version"]); got != "v0.0.3" {
+		t.Fatalf("expected latest release target version, got %#v", data)
+	}
+	if got := anyStringValue(data["source"]); got != "latest_release" {
+		t.Fatalf("expected latest_release source, got %#v", data)
+	}
+}
+
+func TestRunUpdateReplacesBinaryFromRequestedVersion(t *testing.T) {
+	restoreVersion := httpclient.CLIVersion
+	restoreBaseURL := updateReleaseBaseURL
+	restoreExecPath := updateExecutablePath
+	httpclient.CLIVersion = "v0.0.1"
+	t.Cleanup(func() {
+		httpclient.CLIVersion = restoreVersion
+		updateReleaseBaseURL = restoreBaseURL
+		updateExecutablePath = restoreExecPath
+	})
+
+	version := "v0.0.2"
+	archiveName, err := updateArchiveName(version)
+	if err != nil {
+		t.Fatalf("archive name: %v", err)
+	}
+	archiveBytes := buildReleaseArchiveForTest(t, archiveName, []byte("new-binary-bytes"))
+	checksum := sha256HexForTest(archiveBytes)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/download/" + version + "/" + archiveName:
+			_, _ = w.Write(archiveBytes)
+		case "/releases/download/" + version + "/checksums.txt":
+			_, _ = w.Write([]byte(checksum + "  " + archiveName + "\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	updateReleaseBaseURL = server.URL + "/releases"
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, executableNameForTest())
+	if err := os.WriteFile(execPath, []byte("old-binary-bytes"), 0o755); err != nil {
+		t.Fatalf("write old binary: %v", err)
+	}
+	updateExecutablePath = func() (string, error) { return execPath, nil }
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "update", "--version", version})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	if got, _ := data["updated"].(bool); !got {
+		t.Fatalf("expected updated=true, got %#v", data)
+	}
+	if got := anyStringValue(data["target_version"]); got != version {
+		t.Fatalf("unexpected target version: %#v", data)
+	}
+
+	installedBytes, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatalf("read installed binary: %v", err)
+	}
+	if string(installedBytes) != "new-binary-bytes" {
+		t.Fatalf("expected replaced binary bytes, got %q", string(installedBytes))
+	}
+}
+
+func TestHelpUpdateTopic(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cli := New()
+	cli.Stdout = stdout
+	cli.Stderr = stderr
+	cli.Stdin = strings.NewReader("")
+	cli.StdinIsTTY = func() bool { return true }
+	cli.UserHomeDir = func() (string, error) { return t.TempDir(), nil }
+	cli.ReadFile = os.ReadFile
+
+	exitCode := cli.Run([]string{"help", "update"})
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code: %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "oar update [--check] [--version <tag>]") {
+		t.Fatalf("expected update help output, got %q", stdout.String())
+	}
+}
+
+func buildReleaseArchiveForTest(t *testing.T, archiveName string, binary []byte) []byte {
+	t.Helper()
+
+	if strings.HasSuffix(archiveName, ".zip") {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		name := "oar.exe"
+		file, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry: %v", err)
+		}
+		if _, err := file.Write(binary); err != nil {
+			t.Fatalf("write zip entry: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("close zip: %v", err)
+		}
+		return buf.Bytes()
+	}
+
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	header := &tar.Header{
+		Name: "oar",
+		Mode: 0o755,
+		Size: int64(len(binary)),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatalf("write tar payload: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return raw.Bytes()
+}
+
+func executableNameForTest() string {
+	if runtime.GOOS == "windows" {
+		return "oar.exe"
+	}
+	return "oar"
+}
+
+func sha256HexForTest(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary
- add a top-level `oar update` command so CLI upgrades are explicit instead of implicit through the install script
- resolve the target version from `/meta/handshake` when available, with fallback to the latest GitHub release
- download the matching release archive, verify checksums, and replace the current binary in place
- document the new check/update flow in the repo README and CLI runbook

## Command behavior
- `oar update --check` reports the selected target version without modifying the binary
- `oar update` updates in place to the recommended handshake version or latest release
- `oar update --version <tag>` installs a specific release tag explicitly

## Validation
- `cd cli && go test ./...`
- `make cli-check`