### PR TITLE
Fix passkey session refresh race in web UI

### DIFF
--- a/web-ui/src/lib/server/authSession.js
+++ b/web-ui/src/lib/server/authSession.js
@@ -83,6 +83,14 @@ function getRefreshDeduplicationKey(workspaceSlug, refreshToken) {
   return `${getWorkspaceSlug(workspaceSlug)}:${String(refreshToken ?? "").trim()}`;
 }
 
+function purgeExpiredRecentRefreshResults(now = Date.now()) {
+  for (const [key, cached] of recentRefreshResults.entries()) {
+    if (now >= cached.expiresAt) {
+      recentRefreshResults.delete(key);
+    }
+  }
+}
+
 function readRecentRefreshResult(key) {
   const cached = recentRefreshResults.get(key);
   if (!cached) {
@@ -109,6 +117,7 @@ function applyRefreshResult(event, workspaceSlug, tokens) {
 }
 
 function cacheRecentRefreshResult(key, tokens) {
+  purgeExpiredRecentRefreshResults();
   recentRefreshResults.set(key, {
     expiresAt: Date.now() + REFRESH_REPLAY_WINDOW_MS,
     result: tokens,
@@ -383,4 +392,9 @@ export async function proxyWorkspaceAuthVerify({
 export function resetWorkspaceAuthRefreshStateForTests() {
   inFlightRefreshes.clear();
   recentRefreshResults.clear();
+}
+
+export function getRecentRefreshResultCountForTests() {
+  purgeExpiredRecentRefreshResults();
+  return recentRefreshResults.size;
 }

--- a/web-ui/tests/unit/serverAuthSession.test.js
+++ b/web-ui/tests/unit/serverAuthSession.test.js
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearWorkspaceAccessToken,
   clearWorkspaceRefreshToken,
+  getRecentRefreshResultCountForTests,
   handleWorkspaceAuthVerifyResponse,
   refreshWorkspaceAuthSession,
   resetWorkspaceAuthRefreshStateForTests,
@@ -56,6 +57,7 @@ function createSessionEvent({
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   resetWorkspaceAuthRefreshStateForTests();
 });
@@ -309,5 +311,45 @@ describe("server auth session helpers", () => {
     expect(second.recorder.values.get("oar_ui_access_alpha")).toBe(
       "next-access-token",
     );
+  });
+
+  it("evicts expired replay entries when caching newer refresh results", async () => {
+    vi.useFakeTimers();
+    const first = createSessionEvent({ refreshToken: "refresh-token-1" });
+    const second = createSessionEvent({ refreshToken: "refresh-token-2" });
+    let accessTokenCounter = 0;
+    const fetchMock = vi.fn(async () => {
+      accessTokenCounter += 1;
+      return new Response(
+        JSON.stringify({
+          tokens: {
+            access_token: `next-access-token-${accessTokenCounter}`,
+            refresh_token: `next-refresh-token-${accessTokenCounter}`,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshWorkspaceAuthSession({
+      event: first.event,
+      workspaceSlug: "alpha",
+      coreBaseUrl: "https://core.example.com",
+    });
+    expect(getRecentRefreshResultCountForTests()).toBe(1);
+
+    vi.advanceTimersByTime(5_001);
+
+    await refreshWorkspaceAuthSession({
+      event: second.event,
+      workspaceSlug: "alpha",
+      coreBaseUrl: "https://core.example.com",
+    });
+
+    expect(getRecentRefreshResultCountForTests()).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- dedupe in-flight workspace auth refreshes by workspace and refresh token
- replay a just-rotated refresh result briefly so stale concurrent requests adopt the new tokens instead of clearing the session
- add unit coverage for concurrent refreshes and stale follow-up requests

## Testing
- pnpm exec vitest run tests/unit/serverAuthSession.test.js tests/unit/hooks.server.test.js
- make check
