### PR TITLE
Show joined and last seen on the access page

### DIFF
--- a/contracts/oar-openapi.yaml
+++ b/contracts/oar-openapi.yaml
@@ -3150,10 +3150,11 @@ components:
           type: string
           enum: [passkey, public_key]
         created_at: { type: string, format: date-time }
+        last_seen_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         revoked: { type: boolean }
         revoked_at: { type: string, format: date-time }
-      required: [agent_id, actor_id, username, principal_kind, auth_method, created_at, updated_at, revoked]
+      required: [agent_id, actor_id, username, principal_kind, auth_method, created_at, last_seen_at, updated_at, revoked]
 
     AuthPrincipalsResponse:
       type: object

--- a/core/internal/auth/audit.go
+++ b/core/internal/auth/audit.go
@@ -44,6 +44,7 @@ type AuthPrincipalSummary struct {
 	PrincipalKind string  `json:"principal_kind"`
 	AuthMethod    string  `json:"auth_method"`
 	CreatedAt     string  `json:"created_at"`
+	LastSeenAt    string  `json:"last_seen_at"`
 	UpdatedAt     string  `json:"updated_at"`
 	Revoked       bool    `json:"revoked"`
 	RevokedAt     *string `json:"revoked_at,omitempty"`
@@ -89,6 +90,7 @@ func (s *Store) ListPrincipals(ctx context.Context, filter AuthPrincipalListFilt
 		` + principalKindExpr("a") + `,
 		` + authMethodExpr("a") + `,
 		a.created_at,
+		` + principalLastSeenExpr("a") + `,
 		a.updated_at,
 		a.revoked_at
 	 FROM agents a
@@ -123,6 +125,7 @@ func (s *Store) ListPrincipals(ctx context.Context, filter AuthPrincipalListFilt
 			&item.PrincipalKind,
 			&item.AuthMethod,
 			&item.CreatedAt,
+			&item.LastSeenAt,
 			&item.UpdatedAt,
 			&revokedRaw,
 		); err != nil {

--- a/core/internal/auth/audit_test.go
+++ b/core/internal/auth/audit_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -106,6 +107,89 @@ func TestListAuditEventsUsesKeysetCursorAcrossNewerInsert(t *testing.T) {
 	}
 }
 
+func TestListPrincipalsIncludesDerivedLastSeenAtFromAuthTokens(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	workspace, err := storage.InitializeWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("initialize workspace: %v", err)
+	}
+	defer workspace.Close()
+
+	store := NewStore(workspace.DB())
+	agent := insertAuthAgentForRevokeTest(t, ctx, workspace.DB(), "agent-stale-check", "actor-stale-check", "stale.check")
+	olderSeenAt := time.Date(2026, 3, 21, 11, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	newerSeenAt := time.Date(2026, 3, 22, 12, 30, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	insertAccessTokenForAuditTest(t, ctx, workspace.DB(), "access-old", agent.AgentID, olderSeenAt)
+	insertAccessTokenForAuditTest(t, ctx, workspace.DB(), "access-new", agent.AgentID, newerSeenAt)
+
+	principals, _, err := store.ListPrincipals(ctx, AuthPrincipalListFilter{})
+	if err != nil {
+		t.Fatalf("list principals: %v", err)
+	}
+	if len(principals) != 1 {
+		t.Fatalf("expected one principal, got %#v", principals)
+	}
+	if principals[0].LastSeenAt != newerSeenAt {
+		t.Fatalf("expected last_seen_at=%q, got %#v", newerSeenAt, principals[0])
+	}
+	if principals[0].CreatedAt == principals[0].LastSeenAt {
+		t.Fatalf("expected joined time and last seen time to differ, got %#v", principals[0])
+	}
+}
+
+func TestGetPrincipalSummaryUsesUpdatedAtForControlPlaneLastSeen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	workspace, err := storage.InitializeWorkspace(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("initialize workspace: %v", err)
+	}
+	defer workspace.Close()
+
+	store := NewStore(workspace.DB())
+	createdAt := time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	updatedAt := time.Date(2026, 3, 24, 8, 45, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := workspace.DB().ExecContext(
+		ctx,
+		`INSERT INTO actors(id, display_name, tags_json, created_at, metadata_json)
+		 VALUES (?, ?, ?, ?, ?)`,
+		"actor-cp-human",
+		"Casey Human",
+		`["human","control-plane"]`,
+		createdAt,
+		`{"principal_kind":"human","auth_method":"control_plane"}`,
+	); err != nil {
+		t.Fatalf("insert control-plane actor: %v", err)
+	}
+	if _, err := workspace.DB().ExecContext(
+		ctx,
+		`INSERT INTO agents(id, username, actor_id, created_at, updated_at, revoked_at, metadata_json)
+		 VALUES (?, ?, ?, ?, ?, NULL, ?)`,
+		"agent-cp-human",
+		"cp.casey",
+		"actor-cp-human",
+		createdAt,
+		updatedAt,
+		`{"principal_kind":"human","auth_method":"control_plane"}`,
+	); err != nil {
+		t.Fatalf("insert control-plane principal: %v", err)
+	}
+
+	summary, err := store.GetPrincipalSummary(ctx, "agent-cp-human")
+	if err != nil {
+		t.Fatalf("get principal summary: %v", err)
+	}
+	if summary.LastSeenAt != updatedAt {
+		t.Fatalf("expected control-plane last_seen_at=%q, got %#v", updatedAt, summary)
+	}
+	if summary.AuthMethod != AuthMethodControlPlane {
+		t.Fatalf("expected control-plane auth method, got %#v", summary)
+	}
+}
+
 func recordAuthAuditEventForTest(t *testing.T, ctx context.Context, store *Store, input AuthAuditEventInput) string {
 	t.Helper()
 
@@ -141,4 +225,24 @@ func recordAuthAuditEventForTest(t *testing.T, ctx context.Context, store *Store
 
 func ptrInt(value int) *int {
 	return &value
+}
+
+func insertAccessTokenForAuditTest(t *testing.T, ctx context.Context, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, tokenID string, agentID string, createdAt string) {
+	t.Helper()
+
+	expiresAt := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := db.ExecContext(
+		ctx,
+		`INSERT INTO auth_access_tokens(id, agent_id, token_hash, created_at, expires_at, revoked_at)
+		 VALUES (?, ?, ?, ?, ?, NULL)`,
+		tokenID,
+		agentID,
+		"hash-"+tokenID,
+		createdAt,
+		expiresAt,
+	); err != nil {
+		t.Fatalf("insert access token: %v", err)
+	}
 }

--- a/core/internal/auth/principal_metadata.go
+++ b/core/internal/auth/principal_metadata.go
@@ -51,6 +51,16 @@ func authMethodExpr(agentAlias string) string {
 	)`, agentAlias, agentAlias)
 }
 
+func principalLastSeenExpr(agentAlias string) string {
+	return fmt.Sprintf(`CASE
+		WHEN %s = '%s' THEN %s.updated_at
+		ELSE COALESCE(
+			(SELECT MAX(t.created_at) FROM auth_access_tokens t WHERE t.agent_id = %s.id),
+			%s.created_at
+		)
+	END`, authMethodExpr(agentAlias), AuthMethodControlPlane, agentAlias, agentAlias, agentAlias)
+}
+
 func principalMetadataJSON(kind PrincipalKind, authMethod string, extra map[string]any) (string, error) {
 	payload := map[string]any{
 		"principal_kind": string(kind),

--- a/core/internal/auth/store.go
+++ b/core/internal/auth/store.go
@@ -1077,10 +1077,11 @@ func (s *Store) getPrincipalSummaryQueryRow(ctx context.Context, queryRow func(c
 			%s,
 			%s,
 			a.created_at,
+			%s,
 			a.updated_at,
 			a.revoked_at
 		 FROM agents a
-		 WHERE a.id = ?`, principalKindExpr("a"), authMethodExpr("a")),
+		 WHERE a.id = ?`, principalKindExpr("a"), authMethodExpr("a"), principalLastSeenExpr("a")),
 		agentID,
 	).Scan(
 		&item.AgentID,
@@ -1089,6 +1090,7 @@ func (s *Store) getPrincipalSummaryQueryRow(ctx context.Context, queryRow func(c
 		&item.PrincipalKind,
 		&item.AuthMethod,
 		&item.CreatedAt,
+		&item.LastSeenAt,
 		&item.UpdatedAt,
 		&revokedRaw,
 	)

--- a/web-ui/docs/oar-ui-spec.md
+++ b/web-ui/docs/oar-ui-spec.md
@@ -182,7 +182,7 @@ The Access page provides workspace-local operator visibility and intervention fo
 
 **Principal management:**
 
-- The UI MUST display current principals with their agent ID, kind (human/agent), auth method, and revocation status.
+- The UI MUST display current principals with their agent ID, kind (human/agent), auth method, revocation status, joined time, and last-seen time.
 - Any authenticated principal MAY view the principal list.
 - An operator MAY revoke another principal through the UI using the `auth principals revoke` API path, which creates an audit trail.
 - The UI MUST prevent self-revocation (the calling principal cannot revoke itself through the Access page).

--- a/web-ui/src/routes/[workspace]/access/+page.svelte
+++ b/web-ui/src/routes/[workspace]/access/+page.svelte
@@ -3,7 +3,7 @@
 
   import { authenticatedAgent } from "$lib/authSession";
   import { coreClient } from "$lib/coreClient";
-  import { formatTimestamp } from "$lib/formatDate";
+  import { formatAbsoluteDateTime, formatTimestamp } from "$lib/formatDate";
   import { buildRegistrationMessage } from "$lib/inviteRegistrationMessage";
   import { workspacePath } from "$lib/workspacePaths";
 
@@ -810,9 +810,16 @@
                     {principal.agent_id}
                   </p>
                 </div>
-                <span class="text-[11px] text-[var(--ui-text-muted)]">
-                  {formatTimestamp(principal.created_at)}
-                </span>
+                <div
+                  class="shrink-0 min-w-[8.5rem] text-right text-[11px] leading-4 text-[var(--ui-text-muted)]"
+                >
+                  <p title={formatAbsoluteDateTime(principal.created_at)}>
+                    Joined {formatTimestamp(principal.created_at) || "—"}
+                  </p>
+                  <p title={formatAbsoluteDateTime(principal.last_seen_at)}>
+                    Last seen {formatTimestamp(principal.last_seen_at) || "—"}
+                  </p>
+                </div>
                 {#if !principal.revoked && !isCurrentPrincipal(principal)}
                   {@const lastHuman = isLastActiveHumanPrincipal(principal)}
                   <button

--- a/web-ui/tests/e2e/access.spec.js
+++ b/web-ui/tests/e2e/access.spec.js
@@ -100,7 +100,8 @@ test("does not repeat the username in principal rows", async ({ page }) => {
             username: "m4-hermes",
             principal_kind: "agent",
             auth_method: "public_key",
-            created_at: "2026-03-28T10:00:00Z",
+            created_at: "2026-03-01T10:00:00Z",
+            last_seen_at: "2026-03-20T11:15:00Z",
             updated_at: "2026-03-28T10:00:00Z",
             revoked: false,
           },
@@ -135,4 +136,10 @@ test("does not repeat the username in principal rows", async ({ page }) => {
   await expect(
     page.getByText("m4-hermes • agent via public_key", { exact: true }),
   ).toHaveCount(0);
+  await expect(
+    page.getByText("Joined Mar 1, 2026", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Last seen Mar 20, 2026", { exact: true }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- expose a derived `last_seen_at` field in auth principal summaries
- show both joined and last seen timestamps for principals on the workspace Access page
- cover the backend derivation and access-page rendering with tests

## Validation
- `make contract-gen`
- `make contract-check`
- `go test ./internal/auth ./internal/server`
- `make -C core check`
- `make -C web-ui check`
- `pnpm playwright test tests/e2e/access.spec.js` (new access-row assertions passed; the existing unauthenticated expectation still fails in this environment because `/local/access` falls into the legacy actor picker instead of the auth-first empty state)