### PR TITLE
[codex] Split thread messages from timeline

### DIFF
--- a/web-ui/src/lib/components/thread-detail/ThreadMessageItem.svelte
+++ b/web-ui/src/lib/components/thread-detail/ThreadMessageItem.svelte
@@ -1,0 +1,54 @@
+<script>
+  import Self from "$lib/components/thread-detail/ThreadMessageItem.svelte";
+  import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
+  import RefLink from "$lib/components/RefLink.svelte";
+  import { formatTimestamp } from "$lib/formatDate";
+
+  let { message, threadId, actorName, onReply, depth = 0 } = $props();
+</script>
+
+<article
+  class={`rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-3 ${depth > 0 ? "bg-[var(--ui-panel-muted)]" : ""}`}
+  id={`message-${message.id}`}
+>
+  <div class="flex items-start justify-between gap-3">
+    <div class="min-w-0 flex-1">
+      <MarkdownRenderer
+        source={message.messageText || message.summary || "Untitled message"}
+        class="text-[13px] text-[var(--ui-text)]"
+      />
+      <p class="mt-1 text-[12px] text-[var(--ui-text-muted)]">
+        {actorName(message.actor_id)} · {formatTimestamp(message.ts) || "—"}
+      </p>
+    </div>
+    <button
+      class="shrink-0 cursor-pointer rounded px-2 py-0.5 text-[12px] text-[var(--ui-text-muted)] hover:bg-[var(--ui-bg-soft)] hover:text-[var(--ui-text)]"
+      onclick={() => onReply(message.id)}
+      type="button"
+    >
+      Reply
+    </button>
+  </div>
+
+  {#if message.displayRefs.length > 0}
+    <div class="mt-2 flex flex-wrap gap-1.5 text-[12px]">
+      {#each message.displayRefs as refValue}
+        <RefLink {refValue} {threadId} />
+      {/each}
+    </div>
+  {/if}
+
+  {#if message.children.length > 0}
+    <div class="mt-3 space-y-3 border-l border-[var(--ui-border)] pl-4 sm:pl-5">
+      {#each message.children as child}
+        <Self
+          message={child}
+          {threadId}
+          {actorName}
+          {onReply}
+          depth={depth + 1}
+        />
+      {/each}
+    </div>
+  {/if}
+</article>

--- a/web-ui/src/lib/components/thread-detail/ThreadMessagesTab.svelte
+++ b/web-ui/src/lib/components/thread-detail/ThreadMessagesTab.svelte
@@ -1,0 +1,147 @@
+<script>
+  import { actorRegistry, lookupActorDisplayName } from "$lib/actorSession";
+  import ThreadMessageItem from "$lib/components/thread-detail/ThreadMessageItem.svelte";
+  import {
+    flattenMessageThreadView,
+    toMessageThreadView,
+  } from "$lib/messageThreadUtils";
+  import { threadDetailStore } from "$lib/threadDetailStore";
+
+  let { threadId, onMessagePost } = $props();
+
+  let timeline = $derived($threadDetailStore.timeline);
+  let timelineLoading = $derived($threadDetailStore.timelineLoading);
+  let timelineError = $derived($threadDetailStore.timelineError);
+
+  let actorName = $derived((id) => lookupActorDisplayName(id, $actorRegistry));
+  let messageThreads = $derived(toMessageThreadView(timeline, { threadId }));
+  let allMessages = $derived(flattenMessageThreadView(messageThreads));
+  let replyTargetMessage = $derived(
+    replyToEventId
+      ? (allMessages.find((message) => message.id === replyToEventId) ?? null)
+      : null,
+  );
+
+  let messageText = $state("");
+  let replyToEventId = $state("");
+  let postingMessage = $state(false);
+  let postMessageError = $state("");
+
+  let canPost = $derived(Boolean(messageText.trim()) && !postingMessage);
+
+  function setReplyTarget(eventId) {
+    replyToEventId = eventId;
+  }
+
+  function clearReplyTarget() {
+    replyToEventId = "";
+  }
+
+  async function handlePostMessage() {
+    if (!messageText.trim()) {
+      postMessageError = "Message text is required.";
+      return;
+    }
+    postingMessage = true;
+    postMessageError = "";
+    try {
+      await onMessagePost(threadId, {
+        type: "message_posted",
+        thread_id: threadId,
+        refs: [
+          `thread:${threadId}`,
+          ...(replyToEventId ? [`event:${replyToEventId}`] : []),
+        ],
+        summary: `Message: ${messageText.trim().slice(0, 100)}`,
+        payload: { text: messageText.trim() },
+        provenance: { sources: ["actor_statement:ui"] },
+      });
+      messageText = "";
+      replyToEventId = "";
+    } catch (error) {
+      postMessageError = `Failed to post: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      postingMessage = false;
+    }
+  }
+</script>
+
+<div
+  class="mt-4 rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] p-4"
+>
+  {#if postMessageError}
+    <p class="mb-3 rounded bg-red-500/10 px-3 py-1.5 text-[12px] text-red-400">
+      {postMessageError}
+    </p>
+  {/if}
+  <label
+    class="mb-2 block text-[12px] font-medium text-[var(--ui-text-muted)]"
+    for="message-text"
+  >
+    Message
+  </label>
+  <textarea
+    bind:value={messageText}
+    aria-label="Message"
+    class="w-full rounded border border-[var(--ui-border)] bg-[var(--ui-panel-muted)] px-3 py-2 text-[13px] text-[var(--ui-text)]"
+    id="message-text"
+    placeholder="Write a message..."
+    rows="3"
+  ></textarea>
+  <div class="mt-2 flex items-center justify-between gap-2">
+    <div
+      class="flex min-w-0 items-center gap-2 text-[12px] text-[var(--ui-text-muted)]"
+    >
+      {#if replyToEventId}
+        <span class="truncate">
+          Replying to: {replyTargetMessage?.messageText
+            ? replyTargetMessage.messageText.slice(0, 80)
+            : "message"}
+        </span>
+        <button
+          class="cursor-pointer shrink-0 text-indigo-400 hover:text-indigo-300"
+          onclick={clearReplyTarget}
+          type="button"
+        >
+          Clear
+        </button>
+      {/if}
+    </div>
+    <button
+      class="cursor-pointer rounded bg-indigo-600 px-4 py-1.5 text-[12px] font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+      disabled={!canPost}
+      onclick={handlePostMessage}
+      type="button"
+    >
+      {postingMessage ? "Posting..." : "Post message"}
+    </button>
+  </div>
+</div>
+
+<div class="mt-4">
+  <h2
+    class="mb-3 text-[12px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]"
+  >
+    Messages
+  </h2>
+  {#if timelineLoading}
+    <p class="text-[13px] text-[var(--ui-text-muted)]">Loading messages...</p>
+  {:else if timelineError}
+    <p class="rounded bg-red-500/10 px-3 py-2 text-[13px] text-red-400">
+      {timelineError}
+    </p>
+  {:else if messageThreads.length === 0}
+    <p class="text-[13px] text-[var(--ui-text-muted)]">No messages yet.</p>
+  {:else}
+    <div class="space-y-3">
+      {#each messageThreads as message}
+        <ThreadMessageItem
+          {message}
+          {threadId}
+          {actorName}
+          onReply={setReplyTarget}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/web-ui/src/lib/components/thread-detail/ThreadTimelineTab.svelte
+++ b/web-ui/src/lib/components/thread-detail/ThreadTimelineTab.svelte
@@ -6,7 +6,7 @@
   import RefLink from "$lib/components/RefLink.svelte";
   import { toTimelineView, eventTypeDotClass } from "$lib/timelineUtils";
 
-  let { threadId, onMessagePost } = $props();
+  let { threadId } = $props();
 
   let timeline = $derived($threadDetailStore.timeline);
   let timelineLoading = $derived($threadDetailStore.timelineLoading);
@@ -15,99 +15,7 @@
   let actorName = $derived((id) => lookupActorDisplayName(id, $actorRegistry));
 
   let timelineView = $derived(toTimelineView(timeline, { threadId }));
-  let replyTargetEvent = $derived(
-    replyToEventId
-      ? (timelineView.find((e) => e.id === replyToEventId) ?? null)
-      : null,
-  );
-
-  let messageText = $state("");
-  let replyToEventId = $state("");
-  let postingMessage = $state(false);
-  let postMessageError = $state("");
-
-  let canPost = $derived(Boolean(messageText.trim()) && !postingMessage);
-
-  function setReplyTarget(eventId) {
-    replyToEventId = eventId;
-  }
-
-  function clearReplyTarget() {
-    replyToEventId = "";
-  }
-
-  async function handlePostMessage() {
-    if (!messageText.trim()) {
-      postMessageError = "Message text is required.";
-      return;
-    }
-    postingMessage = true;
-    postMessageError = "";
-    try {
-      await onMessagePost(threadId, {
-        type: "message_posted",
-        thread_id: threadId,
-        refs: [
-          `thread:${threadId}`,
-          ...(replyToEventId ? [`event:${replyToEventId}`] : []),
-        ],
-        summary: `Message: ${messageText.trim().slice(0, 100)}`,
-        payload: { text: messageText.trim() },
-        provenance: { sources: ["actor_statement:ui"] },
-      });
-      messageText = "";
-      replyToEventId = "";
-    } catch (error) {
-      postMessageError = `Failed to post: ${error instanceof Error ? error.message : String(error)}`;
-    } finally {
-      postingMessage = false;
-    }
-  }
 </script>
-
-<div
-  class="mt-4 rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] p-4"
->
-  {#if postMessageError}<p
-      class="mb-3 rounded bg-red-500/10 px-3 py-1.5 text-[12px] text-red-400"
-    >
-      {postMessageError}
-    </p>{/if}
-  <textarea
-    bind:value={messageText}
-    aria-label="Post a message"
-    class="w-full rounded border border-[var(--ui-border)] bg-[var(--ui-panel-muted)] px-3 py-2 text-[13px] text-[var(--ui-text)]"
-    id="message-text"
-    placeholder="Write a message..."
-    rows="2"
-  ></textarea>
-  <div class="mt-2 flex items-center justify-between gap-2">
-    <div
-      class="flex items-center gap-2 text-[12px] text-[var(--ui-text-muted)]"
-    >
-      {#if replyToEventId}
-        <span class="truncate max-w-[40ch]"
-          >Replying to: {replyTargetEvent?.summary
-            ? replyTargetEvent.summary.slice(0, 80)
-            : (replyTargetEvent?.typeLabel ?? "event")}</span
-        >
-        <button
-          class="cursor-pointer shrink-0 text-indigo-400 hover:text-indigo-300"
-          onclick={clearReplyTarget}
-          type="button">Clear</button
-        >
-      {/if}
-    </div>
-    <button
-      class="cursor-pointer rounded bg-indigo-600 px-4 py-1.5 text-[12px] font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
-      disabled={!canPost}
-      onclick={handlePostMessage}
-      type="button"
-    >
-      {postingMessage ? "Posting..." : "Post"}
-    </button>
-  </div>
-</div>
 
 <div class="mt-4">
   <h2
@@ -150,11 +58,6 @@
                 </p>
               </div>
             </div>
-            <button
-              class="shrink-0 cursor-pointer rounded px-2 py-0.5 text-[12px] text-[var(--ui-text-muted)] opacity-0 transition-opacity hover:bg-[var(--ui-bg-soft)] hover:text-[var(--ui-text)] group-hover:opacity-100 focus-visible:opacity-100"
-              onclick={() => setReplyTarget(event.id)}
-              type="button">Reply</button
-            >
           </div>
 
           {#if event.changedFields.length > 0}

--- a/web-ui/src/lib/messageThreadUtils.js
+++ b/web-ui/src/lib/messageThreadUtils.js
@@ -1,0 +1,134 @@
+import { toTimelineViewEvent } from "./timelineUtils.js";
+
+function parseEventTimeMs(event) {
+  const ts = event?.ts;
+  if (ts == null || ts === "") {
+    return Number.NEGATIVE_INFINITY;
+  }
+  const ms = Date.parse(String(ts));
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY;
+}
+
+function compareEventsOldestFirst(a, b) {
+  const ta = parseEventTimeMs(a);
+  const tb = parseEventTimeMs(b);
+  if (ta !== tb) {
+    return ta - tb;
+  }
+  return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+}
+
+function compareEventsNewestFirst(a, b) {
+  const tb = parseEventTimeMs(b);
+  const ta = parseEventTimeMs(a);
+  if (tb !== ta) {
+    return tb - ta;
+  }
+  return String(b.id ?? "").localeCompare(String(a.id ?? ""));
+}
+
+function extractParentEventId(event) {
+  const refs = Array.isArray(event?.refs) ? event.refs : [];
+  for (const ref of refs) {
+    const value = String(ref ?? "");
+    if (value.startsWith("event:")) {
+      return value.slice("event:".length);
+    }
+  }
+  return "";
+}
+
+function stripMessagePrefix(value) {
+  const text = String(value ?? "").trim();
+  if (text.startsWith("Message: ")) {
+    return text.slice("Message: ".length).trim();
+  }
+  return text;
+}
+
+function extractMessageText(event) {
+  const payloadText =
+    typeof event?.payload?.text === "string" ? event.payload.text.trim() : "";
+  if (payloadText) {
+    return payloadText;
+  }
+  return stripMessagePrefix(event?.summary);
+}
+
+function decorateMessageEvent(event, options = {}) {
+  const view = toTimelineViewEvent(event, options);
+  const parentEventId = extractParentEventId(event);
+  const threadId = String(options.threadId ?? event?.thread_id ?? "").trim();
+
+  return {
+    ...view,
+    parentEventId,
+    messageText: extractMessageText(event),
+    displayRefs: view.refs.filter((refValue) => {
+      const ref = String(refValue ?? "");
+      if (threadId && ref === `thread:${threadId}`) {
+        return false;
+      }
+      if (parentEventId && ref === `event:${parentEventId}`) {
+        return false;
+      }
+      return true;
+    }),
+  };
+}
+
+export function toMessageThreadView(events = [], options = {}) {
+  const messages = Array.isArray(events)
+    ? events
+        .filter((event) => String(event?.type ?? "") === "message_posted")
+        .map((event) => decorateMessageEvent(event, options))
+        .sort(compareEventsOldestFirst)
+    : [];
+
+  const nodesById = new Map(
+    messages.map((message) => [message.id, { ...message, children: [] }]),
+  );
+  const roots = [];
+
+  for (const message of messages) {
+    const node = nodesById.get(message.id);
+    const parentNode = message.parentEventId
+      ? nodesById.get(message.parentEventId)
+      : null;
+    if (parentNode) {
+      parentNode.children.push(node);
+      continue;
+    }
+    roots.push(node);
+  }
+
+  function sortChildren(node) {
+    node.children.sort(compareEventsOldestFirst);
+    for (const child of node.children) {
+      sortChildren(child);
+    }
+  }
+
+  for (const root of roots) {
+    sortChildren(root);
+  }
+  roots.sort(compareEventsNewestFirst);
+
+  return roots;
+}
+
+export function flattenMessageThreadView(threads = []) {
+  const out = [];
+
+  function visit(nodes) {
+    for (const node of nodes) {
+      out.push(node);
+      if (Array.isArray(node.children) && node.children.length > 0) {
+        visit(node.children);
+      }
+    }
+  }
+
+  visit(Array.isArray(threads) ? threads : []);
+  return out;
+}

--- a/web-ui/src/routes/[workspace]/threads/[threadId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/threads/[threadId]/+page.svelte
@@ -10,6 +10,7 @@
   import ThreadBoardsPanel from "$lib/components/thread-detail/ThreadBoardsPanel.svelte";
   import ThreadDocumentsPanel from "$lib/components/thread-detail/ThreadDocumentsPanel.svelte";
   import ThreadCommitmentsPanel from "$lib/components/thread-detail/ThreadCommitmentsPanel.svelte";
+  import ThreadMessagesTab from "$lib/components/thread-detail/ThreadMessagesTab.svelte";
   import ThreadWorkTab from "$lib/components/thread-detail/ThreadWorkTab.svelte";
   import ThreadTimelineTab from "$lib/components/thread-detail/ThreadTimelineTab.svelte";
 
@@ -185,7 +186,7 @@
   });
 
   $effect(() => {
-    if (activeTab === "timeline" && threadId) {
+    if ((activeTab === "messages" || activeTab === "timeline") && threadId) {
       void threadDetailStore.loadTimeline(threadId);
     }
   });
@@ -207,7 +208,7 @@
     aria-label="Thread sections"
     role="tablist"
   >
-    {#each [["overview", "Overview"], ["work", "Work"], ["timeline", "Timeline"]] as [tabId, tabLabel]}
+    {#each [["overview", "Overview"], ["work", "Work"], ["messages", "Messages"], ["timeline", "Timeline"]] as [tabId, tabLabel]}
       <button
         class={`relative cursor-pointer px-3 py-2 text-[13px] font-medium transition-colors ${activeTab === tabId ? "text-[var(--ui-text)]" : "text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"}`}
         onclick={() => (activeTab = tabId)}
@@ -254,9 +255,15 @@
     </div>
   {/if}
 
+  {#if activeTab === "messages"}
+    <div role="tabpanel" tabindex="0">
+      <ThreadMessagesTab {threadId} onMessagePost={handleMessagePost} />
+    </div>
+  {/if}
+
   {#if activeTab === "timeline"}
     <div role="tabpanel" tabindex="0">
-      <ThreadTimelineTab {threadId} onMessagePost={handleMessagePost} />
+      <ThreadTimelineTab {threadId} />
     </div>
   {/if}
 {/if}

--- a/web-ui/tests/e2e/integration-core-golden-path.spec.js
+++ b/web-ui/tests/e2e/integration-core-golden-path.spec.js
@@ -375,12 +375,9 @@ test("golden path integration runs against a real oar-core", async ({
 
   await openThreadDetailFromNav(page, threadTitle, threadId);
 
+  await page.getByRole("tab", { name: "Messages" }).click();
   await page.getByLabel("Message").fill(messageText);
-  const replyTarget = page.getByLabel("Reply to event (optional)");
-  await expect
-    .poll(async () => replyTarget.locator("option").count())
-    .toBeGreaterThan(1);
-  await replyTarget.selectOption({ index: 1 });
+  await page.getByRole("button", { name: "Reply" }).first().click();
 
   const postMessageResponsePromise = page.waitForResponse((response) => {
     const postData = response.request().postData() ?? "";
@@ -395,7 +392,7 @@ test("golden path integration runs against a real oar-core", async ({
   await postMessageResponsePromise;
 
   await expect(
-    page.locator("article", { hasText: `Message: ${messageText}` }).first(),
+    page.locator("article", { hasText: messageText }).first(),
   ).toBeVisible();
 
   await postCoreJson(request, coreBaseUrl, "/events", {

--- a/web-ui/tests/e2e/thread-detail.spec.js
+++ b/web-ui/tests/e2e/thread-detail.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("thread detail loads snapshot/timeline and posts reply message", async ({
+test("thread detail separates messages from timeline and nests replies", async ({
   page,
 }) => {
   const actorId = "actor-thread-detail-e2e";
@@ -215,7 +215,7 @@ test("thread detail loads snapshot/timeline and posts reply message", async ({
     "href",
     /\/docs\/doc-onboarding-runbook\?revision=rev-onboarding-runbook-2$/,
   );
-  await page.getByRole("button", { name: "Timeline" }).click();
+  await page.getByRole("tab", { name: "Messages" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Customer Onboarding Workflow" }),
@@ -224,21 +224,30 @@ test("thread detail loads snapshot/timeline and posts reply message", async ({
     page.getByText("Initial timeline message", { exact: true }),
   ).toBeVisible();
   await expect(
-    page.locator("#event-evt-1001").getByRole("button", { name: "Reply" }),
+    page.locator("#message-evt-1001").getByRole("button", { name: "Reply" }),
   ).toBeVisible();
   await page
-    .locator("#event-evt-1001")
+    .locator("#message-evt-1001")
     .getByRole("button", { name: "Reply" })
     .click();
   await page.locator("#message-text").fill("Reply message from e2e");
-  await page.getByRole("button", { name: "Post" }).click();
+  await page.getByRole("button", { name: "Post message" }).click();
 
   await expect.poll(() => postedEvents).toBe(1);
 
   await expect(
+    page
+      .locator("#message-evt-1001")
+      .locator("#message-event-new-1")
+      .getByText("Reply message from e2e", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Timeline" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Timeline" }).click();
+  await expect(page.locator("#message-text")).toHaveCount(0);
+  await expect(
     page.getByText("Message: Reply message from e2e", { exact: true }),
   ).toBeVisible();
-  await expect(page.getByText("Reply target: evt-1001")).toHaveCount(0);
 });
 
 test("thread detail handles snapshot update conflict and retries after reload", async ({
@@ -657,12 +666,12 @@ test("thread detail updates workspace panels from another actor via event stream
     page.getByText("Remote Coordination Checklist", { exact: true }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "Work" }).click();
+  await page.getByRole("tab", { name: "Work" }).click();
   await expect(
     page.getByRole("combobox", { name: "Work order" }),
   ).toContainText("Remote follow-up work order");
 
-  await page.getByRole("button", { name: "Timeline" }).click();
+  await page.getByRole("tab", { name: "Timeline" }).click();
   await expect(
     page.getByText("Remote actor updated coordination context", {
       exact: true,

--- a/web-ui/tests/unit/messageThreadUtils.test.js
+++ b/web-ui/tests/unit/messageThreadUtils.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  flattenMessageThreadView,
+  toMessageThreadView,
+} from "../../src/lib/messageThreadUtils.js";
+
+describe("message thread utils", () => {
+  it("groups replies under their parent and keeps children chronological", () => {
+    const threads = toMessageThreadView(
+      [
+        {
+          id: "reply-2",
+          ts: "2026-03-03T10:02:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1", "event:root-1"],
+          summary: "Message: second reply",
+          payload: { text: "second reply" },
+        },
+        {
+          id: "root-1",
+          ts: "2026-03-03T10:00:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1"],
+          summary: "Message: root message",
+          payload: { text: "root message" },
+        },
+        {
+          id: "reply-1",
+          ts: "2026-03-03T10:01:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1", "event:root-1"],
+          summary: "Message: first reply",
+          payload: { text: "first reply" },
+        },
+      ],
+      { threadId: "thread-1" },
+    );
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("root-1");
+    expect(threads[0].messageText).toBe("root message");
+    expect(threads[0].children.map((child) => child.id)).toEqual([
+      "reply-1",
+      "reply-2",
+    ]);
+    expect(threads[0].children.map((child) => child.messageText)).toEqual([
+      "first reply",
+      "second reply",
+    ]);
+  });
+
+  it("keeps orphan replies as top-level messages and strips structural refs", () => {
+    const threads = toMessageThreadView(
+      [
+        {
+          id: "orphan",
+          ts: "2026-03-03T10:05:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1", "event:missing-parent", "artifact:a-1"],
+          summary: "Message: orphan reply",
+        },
+      ],
+      { threadId: "thread-1" },
+    );
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("orphan");
+    expect(threads[0].displayRefs).toEqual(["artifact:a-1"]);
+  });
+
+  it("flattens threaded messages for lookup helpers", () => {
+    const threads = toMessageThreadView(
+      [
+        {
+          id: "root-1",
+          ts: "2026-03-03T10:00:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1"],
+          summary: "Message: root message",
+        },
+        {
+          id: "reply-1",
+          ts: "2026-03-03T10:01:00.000Z",
+          type: "message_posted",
+          thread_id: "thread-1",
+          refs: ["thread:thread-1", "event:root-1"],
+          summary: "Message: first reply",
+        },
+      ],
+      { threadId: "thread-1" },
+    );
+
+    expect(
+      flattenMessageThreadView(threads).map((message) => message.id),
+    ).toEqual(["root-1", "reply-1"]);
+  });
+});


### PR DESCRIPTION
## What changed

This changes the thread detail UI so conversational messages have their own operator-friendly surface while the existing Timeline remains the full audit trail.

- added a dedicated `Messages` tab on thread detail
- moved the message composer and reply actions out of `Timeline` and into `Messages`
- grouped `message_posted` reply chains under their parent message with nested rendering
- kept `Timeline` as a read-only all-events view
- added unit coverage for message thread grouping and updated thread-detail e2e coverage

## Why

`Timeline` is a broad event feed, not a message-only surface. Keeping the composer and reply flow inside Timeline made the UX confusing because conversational actions were mixed into the audit trail.

This keeps the canonical event model intact while giving operators a clearer messages-first interaction model.

## User impact

Operators now get:

- a dedicated `Messages` tab for conversation and replies
- replies rendered under their parent message with indentation
- an unchanged `Timeline` tab for full activity inspection without composer controls

## Root cause

The previous thread detail tab treated message composition as part of the timeline view, even though the underlying data model mixes messages with many other event types.

## Validation

- `make -C web-ui check`
- `cd web-ui && pnpm exec playwright test tests/e2e/thread-detail.spec.js`
- `cd web-ui && pnpm exec playwright test tests/e2e/integration-core-golden-path.spec.js` (skipped in this environment)
