### PR TITLE
fix: harden web UI workspace session refresh

### DIFF
--- a/web-ui/src/hooks.server.js
+++ b/web-ui/src/hooks.server.js
@@ -44,6 +44,7 @@ async function refreshAndRetry(
   workspaceSlug,
   targetUrl,
   requestBody,
+  hadAccessToken,
 ) {
   if (!readWorkspaceRefreshToken(event, workspaceSlug)) {
     return null;
@@ -56,7 +57,7 @@ async function refreshAndRetry(
       coreBaseUrl,
     });
   } catch (error) {
-    if (!isLikelyStaleWorkspaceRefreshFailure(error)) {
+    if (!isLikelyStaleWorkspaceRefreshFailure(error, { hadAccessToken })) {
       clearWorkspaceAuthSession(event, workspaceSlug);
     }
     return null;
@@ -138,6 +139,7 @@ async function proxyToCore(event, coreBaseUrl, workspaceSlug) {
       workspaceSlug,
       targetUrl,
       requestBody,
+      Boolean(session?.accessToken),
     );
     if (retriedResponse) {
       upstreamResponse = retriedResponse;

--- a/web-ui/src/lib/server/authSession.js
+++ b/web-ui/src/lib/server/authSession.js
@@ -266,9 +266,14 @@ export async function refreshWorkspaceAuthSession({
   return applyRefreshResult(event, workspaceSlug, await refreshPromise);
 }
 
-export function isLikelyStaleWorkspaceRefreshFailure(error) {
+export function isLikelyStaleWorkspaceRefreshFailure(
+  error,
+  { hadAccessToken = false } = {},
+) {
   return (
-    error?.status === 401 && error?.details?.error?.code === "invalid_token"
+    hadAccessToken &&
+    error?.status === 401 &&
+    error?.details?.error?.code === "invalid_token"
   );
 }
 
@@ -326,11 +331,20 @@ export async function loadWorkspaceAuthenticatedAgent({
     }
     return await fetchCurrentAgent(accessToken);
   } catch (error) {
-    if (error?.status === 401 && !isLikelyStaleWorkspaceRefreshFailure(error)) {
+    if (
+      error?.status === 401 &&
+      !isLikelyStaleWorkspaceRefreshFailure(error, {
+        hadAccessToken: Boolean(accessToken),
+      })
+    ) {
       clearWorkspaceAuthSession(event, workspaceSlug);
       return null;
     }
-    if (isLikelyStaleWorkspaceRefreshFailure(error)) {
+    if (
+      isLikelyStaleWorkspaceRefreshFailure(error, {
+        hadAccessToken: Boolean(accessToken),
+      })
+    ) {
       return null;
     }
     throw error;

--- a/web-ui/tests/unit/hooks.server.test.js
+++ b/web-ui/tests/unit/hooks.server.test.js
@@ -10,7 +10,9 @@ const envState = vi.hoisted(() => ({}));
 const authSessionMocks = vi.hoisted(() => ({
   clearWorkspaceAuthSession: vi.fn(),
   getWorkspaceAuthSession: vi.fn(() => authSessionState.currentSession),
-  isLikelyStaleWorkspaceRefreshFailure: vi.fn((error) => error?.status === 401),
+  isLikelyStaleWorkspaceRefreshFailure: vi.fn(
+    (error, options) => error?.status === 401 && options?.hadAccessToken,
+  ),
   readWorkspaceRefreshToken: vi.fn(() => "refresh-token"),
   refreshWorkspaceAuthSession: vi.fn(async () => {
     authSessionState.currentSession = { accessToken: "fresh-token" };
@@ -77,7 +79,7 @@ describe("hooks proxy retry", () => {
     vi.clearAllMocks();
     authSessionState.currentSession = { accessToken: "expired-token" };
     authSessionMocks.isLikelyStaleWorkspaceRefreshFailure.mockImplementation(
-      (error) => error?.status === 401,
+      (error, options) => error?.status === 401 && options?.hadAccessToken,
     );
     for (const key of Object.keys(envState)) {
       delete envState[key];
@@ -213,6 +215,53 @@ describe("hooks proxy retry", () => {
     });
 
     expect(response.status).toBe(401);
+    expect(authSessionMocks.clearWorkspaceAuthSession).toHaveBeenCalledWith(
+      expect.anything(),
+      "ops",
+    );
+  });
+
+  it("clears the workspace session on invalid refresh failures when no access token was present", async () => {
+    authSessionState.currentSession = { accessToken: "" };
+    authSessionMocks.refreshWorkspaceAuthSession.mockRejectedValueOnce(
+      Object.assign(new Error("invalid refresh token"), {
+        status: 401,
+        details: {
+          error: {
+            code: "invalid_token",
+          },
+        },
+      }),
+    );
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { code: "invalid_token" } }), {
+        status: 401,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const response = await handle({
+      event: {
+        url: new URL("https://oar.example.test/api/threads"),
+        request: new Request("https://oar.example.test/api/threads", {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+          },
+        }),
+      },
+      resolve: vi.fn(),
+    });
+
+    expect(response.status).toBe(401);
+    expect(
+      authSessionMocks.isLikelyStaleWorkspaceRefreshFailure,
+    ).toHaveBeenCalledWith(expect.anything(), {
+      hadAccessToken: false,
+    });
     expect(authSessionMocks.clearWorkspaceAuthSession).toHaveBeenCalledWith(
       expect.anything(),
       "ops",

--- a/web-ui/tests/unit/serverAuthSession.test.js
+++ b/web-ui/tests/unit/serverAuthSession.test.js
@@ -409,4 +409,49 @@ describe("server auth session helpers", () => {
     );
     expect(recorder.deleteCalls).toEqual([]);
   });
+
+  it("clears cookies when refresh fails with invalid_token and no access token was present", async () => {
+    const { event, recorder } = createSessionEvent({
+      refreshToken: "refresh-token",
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "invalid_token",
+            message: "token is invalid, expired, or revoked",
+          },
+        }),
+        {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      loadWorkspaceAuthenticatedAgent({
+        event,
+        workspaceSlug: "alpha",
+        coreBaseUrl: "https://core.example.com",
+      }),
+    ).resolves.toBeNull();
+
+    expect(recorder.values.get("oar_ui_session_alpha")).toBeUndefined();
+    expect(recorder.deleteCalls).toEqual([
+      {
+        name: "oar_ui_session_alpha",
+        options: {
+          path: "/",
+        },
+      },
+      {
+        name: "oar_ui_access_alpha",
+        options: {
+          path: "/",
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- stop clearing workspace auth cookies when a refresh fails with a likely stale rotated refresh token
- extend same-process refresh replay reuse and add explicit cookie lifetimes aligned to the 15 minute access token and 30 day refresh token TTLs
- add regression coverage for stale refresh races in both the auth session helper and proxy retry path

## Root Cause
`oar-core` still issues 15 minute access tokens and 30 day refresh tokens. The web UI refresh path was only replay-safe for 5 seconds in process memory, and any later `401 invalid_token` from a stale rotated refresh token cleared the workspace cookies. When concurrent requests straddled the 15 minute boundary, a stale follower could overwrite freshly rotated cookies and force a passkey re-auth.

## Validation
- `pnpm vitest run tests/unit/serverAuthSession.test.js tests/unit/hooks.server.test.js tests/unit/authSession.test.js tests/unit/oarCoreClientAuth.test.js`
- `make -C web-ui check`
