### PR TITLE
[codex] Fix access invite registration URL

### DIFF
--- a/web-ui/src/routes/[workspace]/access/+page.server.js
+++ b/web-ui/src/routes/[workspace]/access/+page.server.js
@@ -11,7 +11,8 @@ function isLoopbackHost(hostname) {
     normalized.endsWith(".localhost") ||
     normalized === "127.0.0.1" ||
     normalized === "0.0.0.0" ||
-    normalized === "::1"
+    normalized === "::1" ||
+    normalized === "[::1]"
   );
 }
 

--- a/web-ui/tests/unit/accessRoute.test.js
+++ b/web-ui/tests/unit/accessRoute.test.js
@@ -58,4 +58,27 @@ describe("access route", () => {
         "https://m2-internal.tail7e1eb.ts.net/oar/scalingforever",
     });
   });
+
+  it("treats bracketed ipv6 loopback as a local request origin", async () => {
+    workspaceResolverMocks.resolveWorkspaceBySlug.mockResolvedValue({
+      workspaceSlug: "scalingforever",
+      workspace: {
+        coreBaseUrl: "http://127.0.0.1:8002",
+        publicOrigin: "https://m2-internal.tail7e1eb.ts.net",
+      },
+    });
+
+    const result = await load({
+      params: {
+        workspace: "scalingforever",
+      },
+      url: new URL("http://[::1]:4173/oar/scalingforever/access"),
+    });
+
+    expect(result).toEqual({
+      coreBaseUrl: "http://127.0.0.1:8002",
+      registrationBaseUrl:
+        "https://m2-internal.tail7e1eb.ts.net/oar/scalingforever",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- prevent the access-page invite copy from using a loopback UI origin in the generated `oar --base-url` command
- preserve the active request path so mounted installs such as `/oar/<workspace>` still copy correctly
- add a regression test for the loopback-origin fallback path

## Root Cause
The access page derived the registration URL directly from `event.url.origin`. In deployments where the UI process was configured with a local origin, the copied invite command used `http://127.0.0.1:4173/...` even when the workspace had a public URL.

## Impact
Operators now get a usable public registration command from the access page even when the UI server sees a loopback origin.

## Validation
- `pnpm vitest run tests/unit/accessRoute.test.js`
- `make -C web-ui check`
