### PR TITLE
[codex] Document self-serve wake registration

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -6,10 +6,10 @@ This reference is bundled with the CLI. Print the full document with `oar meta d
 
 - `onboarding` (manual): Offline quick-start mental model and first command flow.
 - `agent-guide` (manual): Prescriptive agent guide for choosing OAR primitives, operating safely, and automating the CLI well.
-- `wake-routing` (manual): How `@handle` wake routing works, what counts as wakeable, and how to inspect registrations.
+- `wake-routing` (manual): How `@handle` wake routing works, including self-registration, verification, and troubleshooting.
 - `draft` (manual): Local draft staging, listing, commit, and discard workflow.
 - `provenance` (manual): Deterministic provenance walk reference and examples.
-- `auth whoami` (manual): Validate the active profile and print resolved identity metadata.
+- `auth whoami` (manual): Validate the active profile, print resolved identity metadata, and point agents at wake-registration next steps.
 - `auth list` (manual): List local CLI profiles and the active profile.
 - `auth update-username` (manual): Rename the authenticated agent and sync the local profile.
 - `auth rotate` (manual): Rotate the active agent key and refresh stored credentials.
@@ -250,7 +250,7 @@ When starting in a new environment:
 3. Register the first principal with `oar auth register --username <username> --bootstrap-token <token>` or later principals with `--invite-token <token>`.
 4. Confirm identity.
 5. Run a cheap read command.
-6. If this agent should be tag-addressable from thread messages, read `oar meta doc wake-routing`.
+6. If this agent should be tag-addressable from thread messages, read `oar meta doc wake-routing` and create or verify `agentreg.<handle>` for the current workspace.
 
 When stuck:
 
@@ -269,7 +269,7 @@ Maintenance rule
 
 ## `wake-routing`
 
-How `@handle` wake routing works, what counts as wakeable, and how to inspect registrations.
+How `@handle` wake routing works, including self-registration, verification, and troubleshooting.
 
 ```text
 Wake routing
@@ -304,12 +304,135 @@ How agents discover it
 - Use `oar auth principals list --json` to inspect known agent principals.
 - Use `oar docs get --document-id agentreg.<handle> --json` to inspect a specific registration document.
 
+Self-serve registration
+
+Preferred path when you are using `oar-agent-bridge`
+
+- During initial auth, register and write the wake registration in one step:
+
+  oar-agent-bridge auth register --config <agent.toml> --invite-token <token> --apply-registration
+
+- After auth already exists, upsert the registration document again with:
+
+  oar-agent-bridge registration apply --config <agent.toml>
+
+Generic OAR CLI path
+
+1. Confirm the identity you are registering:
+
+  oar auth whoami
+
+  Use the server-resolved username from that output as `<handle>` and the server actor id as `<actor-id>`.
+
+2. Resolve the durable workspace id you want to enable:
+
+  - If you are using `oar-agent-bridge`, read `oar.workspace_id` from your agent or router config file.
+  - The bundled example bridge configs use `ws_main`.
+  - Do not use a workspace slug or URL path segment here.
+
+3. Create a file such as `wake-registration.json` with the exact registration payload:
+
+  {
+    "document": {
+      "document_id": "agentreg.<handle>",
+      "title": "Agent registration @<handle>",
+      "status": "active",
+      "labels": [
+        "agent-registration",
+        "handle:<handle>",
+        "actor:<actor-id>"
+      ]
+    },
+    "content_type": "structured",
+    "content": {
+      "version": "agent-registration/v1",
+      "handle": "<handle>",
+      "actor_id": "<actor-id>",
+      "delivery_mode": "pull",
+      "driver_kind": "custom",
+      "resume_policy": "resume_or_create",
+      "status": "active",
+      "adapter_kind": "custom",
+      "updated_at": "2026-01-01T00:00:00Z",
+      "workspace_bindings": [
+        {
+          "workspace_id": "<workspace-id>",
+          "enabled": true
+        }
+      ]
+    }
+  }
+
+4. Create the document:
+
+  oar docs create --from-file wake-registration.json --json
+
+Registration schema
+
+- Durable document id must be `agentreg.<handle>`.
+- Fields required for routing correctness are:
+  - `content.handle` matching the principal username
+  - `content.actor_id` matching the principal actor id
+  - at least one enabled `content.workspace_bindings[].workspace_id` matching the router workspace id
+- Fields the bridge writes for compatibility and clarity are:
+  - `content.version` = `agent-registration/v1`
+  - `content.delivery_mode` = `pull`
+  - `content.driver_kind`
+  - `content.resume_policy` = `resume_or_create`
+  - `content.status` = `active`
+  - `content.adapter_kind`
+  - `content.updated_at`
+- `workspace_bindings[].enabled` defaults to true when omitted by bridge code, but setting it explicitly is clearer.
+- The workspace binding value must be the durable workspace id used by the router, typically `oar.workspace_id` in bridge config, not a URL slug or UI path segment.
+
+Verification flow
+
+1. Confirm your local and server identity:
+
+  oar auth whoami
+
+2. Confirm a principal exists for the target handle:
+
+  oar auth principals list --json
+
+3. Read the registration document:
+
+  oar docs get --document-id agentreg.<handle> --json
+
+4. Verify all of the following:
+  - principal kind is `agent`
+  - principal username is exactly `<handle>`
+  - principal actor id matches `content.actor_id`
+  - registration `content.status` is `active`
+  - `workspace_bindings` contains the current workspace id with `enabled: true`
+
+5. If you are using `oar-agent-bridge`, confirm the router and target bridge are running:
+
+  oar-agent-bridge router run --config <router.toml>
+  oar-agent-bridge bridge run --config <agent.toml>
+
+Concrete wake example
+
+1. Ensure the router and target bridge are running, then post a thread message containing `@<handle>`, for example:
+
+  @<handle> summarize the latest onboarding blockers.
+
+2. Expected durable trace:
+  - existing `message_posted`
+  - new `agent_wakeup_requested`
+  - new `agent_wakeup_claimed`
+  - new bridge reply `message_posted`
+  - new `agent_wakeup_completed`
+
+3. If the request is durable but never gets claimed, the registration may be valid while the router or bridge runtime is offline.
+
 Common failure modes
 
 - unknown handle: no matching agent principal username exists
 - missing registration: `agentreg.<handle>` does not exist
 - registration actor mismatch: the registration doc points at a different actor
 - workspace not bound: registration exists but is not enabled for this workspace
+- wrong workspace id: the registration uses a workspace slug or another id that does not match the router configuration
 - bridge offline: the wake request is durable in OAR, but no local bridge is consuming it
 
 Operational note
@@ -320,6 +443,7 @@ Next steps
 
   oar meta doc agent-guide
   oar auth whoami
+  oar help docs create
   oar auth principals list --json
 ```
 
@@ -409,12 +533,12 @@ Examples:
 
 ## `auth whoami`
 
-Validate the active profile and print resolved identity metadata.
+Validate the active profile, print resolved identity metadata, and point agents at wake-registration next steps.
 
 ```text
 Local Help: auth whoami
 
-Validate the active profile against the server and print resolved identity metadata.
+Validate the active profile against the server, print resolved identity metadata, and point to wake-registration next steps.
 
 Usage:
   oar auth whoami
@@ -422,6 +546,9 @@ Usage:
 Examples:
   oar auth whoami
   oar --json auth whoami
+
+Next steps:
+  If this agent should be wakeable by `@handle`, read `oar meta doc wake-routing`.
 
 Global flags:
   Global flags can appear before or after the command path.

--- a/cli/internal/app/agent_guide.go
+++ b/cli/internal/app/agent_guide.go
@@ -130,7 +130,7 @@ func agentGuideSections() []guideSection {
 				"3. Register the first principal with `oar auth register --username <username> --bootstrap-token <token>` or later principals with `--invite-token <token>`.",
 				"4. Confirm identity.",
 				"5. Run a cheap read command.",
-				"6. If this agent should be tag-addressable from thread messages, read `oar meta doc wake-routing`.",
+				"6. If this agent should be tag-addressable from thread messages, read `oar meta doc wake-routing` and create or verify `agentreg.<handle>` for the current workspace.",
 				"",
 				"When stuck:",
 				"",

--- a/cli/internal/app/auth_commands.go
+++ b/cli/internal/app/auth_commands.go
@@ -489,6 +489,7 @@ func (a *App) runAuthRegister(ctx context.Context, service *authcli.Service, arg
 		"Agent ID: " + registered.Profile.AgentID,
 		"Username: " + registered.Profile.Username,
 		"Profile path: " + cfg.ProfilePath,
+		authWakeRoutingHint(registered.Profile.Username),
 	}, "\n")
 	data := map[string]any{
 		"profile":      registered.Profile,
@@ -505,12 +506,19 @@ func (a *App) runAuthWhoAmI(ctx context.Context, service *authcli.Service) (*com
 		return nil, err
 	}
 	serverAgent, _ := result.Server["agent"].(map[string]any)
+	hintHandle := strings.TrimSpace(anyString(serverAgent["username"]))
+	if hintHandle == "" {
+		hintHandle = result.Profile.Username
+	}
 	text := strings.Join([]string{
 		"Local profile: " + result.Profile.Agent,
 		"Local username: " + result.Profile.Username,
 		"Local agent ID: " + result.Profile.AgentID,
+		"Local actor ID: " + result.Profile.ActorID,
 		"Server username: " + anyString(serverAgent["username"]),
 		"Server agent ID: " + anyString(serverAgent["agent_id"]),
+		"Server actor ID: " + anyString(serverAgent["actor_id"]),
+		authWakeRoutingHint(hintHandle),
 	}, "\n")
 	redacted := result.Profile
 	redacted.AccessToken = ""
@@ -521,6 +529,17 @@ func (a *App) runAuthWhoAmI(ctx context.Context, service *authcli.Service) (*com
 		"server":  result.Server,
 	}
 	return &commandResult{Text: text, Data: data}, nil
+}
+
+func authWakeRoutingHint(username string) string {
+	handle := strings.TrimSpace(username)
+	if handle == "" {
+		return "Wake registration help: oar meta doc wake-routing; oar help docs create"
+	}
+	return fmt.Sprintf(
+		"Wake registration help: oar meta doc wake-routing; oar help docs create (document id: agentreg.%s)",
+		handle,
+	)
 }
 
 func (a *App) runAuthUpdateUsername(ctx context.Context, service *authcli.Service, args []string) (*commandResult, error) {

--- a/cli/internal/app/auth_commands_test.go
+++ b/cli/internal/app/auth_commands_test.go
@@ -158,6 +158,78 @@ func TestAuthWhoAmIAutoRefreshesExpiredAccessToken(t *testing.T) {
 	}
 }
 
+func TestAuthTextOutputIncludesWakeRoutingNextSteps(t *testing.T) {
+	t.Parallel()
+
+	core := newFakeAuthCore(t)
+	server := httptest.NewServer(http.HandlerFunc(core.handle))
+	defer server.Close()
+
+	home := t.TempDir()
+	env := map[string]string{}
+
+	registerOut := runCLIForTest(t, home, env, nil, []string{
+		"--base-url", server.URL,
+		"--agent", "agent-text",
+		"auth", "register",
+		"--username", "agent.text",
+	})
+	if !strings.Contains(registerOut, "Wake registration help: oar meta doc wake-routing; oar help docs create (document id: agentreg.agent.text)") {
+		t.Fatalf("expected wake registration hint in register output=%s", registerOut)
+	}
+
+	whoamiOut := runCLIForTest(t, home, env, nil, []string{
+		"--base-url", server.URL,
+		"--agent", "agent-text",
+		"auth", "whoami",
+	})
+	if !strings.Contains(whoamiOut, "Wake registration help: oar meta doc wake-routing; oar help docs create (document id: agentreg.agent.text)") {
+		t.Fatalf("expected wake registration hint in whoami output=%s", whoamiOut)
+	}
+	if !strings.Contains(whoamiOut, "Server actor ID: agent-123") {
+		t.Fatalf("expected server actor id in whoami output=%s", whoamiOut)
+	}
+}
+
+func TestAuthWhoAmIHintUsesServerResolvedUsername(t *testing.T) {
+	t.Parallel()
+
+	core := newFakeAuthCore(t)
+	server := httptest.NewServer(http.HandlerFunc(core.handle))
+	defer server.Close()
+
+	home := t.TempDir()
+	env := map[string]string{}
+
+	_ = runCLIForTest(t, home, env, nil, []string{
+		"--json", "--base-url", server.URL,
+		"--agent", "agent-renamed",
+		"auth", "register",
+		"--username", "server.name",
+	})
+
+	profilePath := filepath.Join(home, ".config", "oar", "profiles", "agent-renamed.json")
+	storedProfile, ok, err := profile.Load(profilePath)
+	if err != nil || !ok {
+		t.Fatalf("load profile after register: ok=%t err=%v", ok, err)
+	}
+	storedProfile.Username = "local-stale-name"
+	jsonDisabled := false
+	storedProfile.JSON = &jsonDisabled
+	if err := profile.Save(profilePath, storedProfile); err != nil {
+		t.Fatalf("save stale profile username: %v", err)
+	}
+
+	whoamiOut := runCLIForTest(t, home, env, nil, []string{
+		"--base-url", server.URL,
+		"--agent", "agent-renamed",
+		"auth", "whoami",
+	})
+	if !strings.Contains(whoamiOut, "Wake registration help: oar meta doc wake-routing; oar help docs create (document id: agentreg.server.name)") {
+		t.Fatalf("expected server-resolved wake registration hint output=%s", whoamiOut)
+	}
+}
+
 func TestAuthRegisterPersistsProfileDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/help_catalog.go
+++ b/cli/internal/app/help_catalog.go
@@ -36,10 +36,10 @@ var (
 var runtimeHelpManualDocTopics = []runtimeHelpDocTopic{
 	{Path: "onboarding", Kind: "manual", Summary: "Offline quick-start mental model and first command flow."},
 	{Path: "agent-guide", Kind: "manual", Summary: "Prescriptive agent guide for choosing OAR primitives, operating safely, and automating the CLI well."},
-	{Path: "wake-routing", Kind: "manual", Summary: "How `@handle` wake routing works, what counts as wakeable, and how to inspect registrations."},
+	{Path: "wake-routing", Kind: "manual", Summary: "How `@handle` wake routing works, including self-registration, verification, and troubleshooting."},
 	{Path: "draft", Kind: "manual", Summary: "Local draft staging, listing, commit, and discard workflow."},
 	{Path: "provenance", Kind: "manual", Summary: "Deterministic provenance walk reference and examples."},
-	{Path: "auth whoami", Kind: "manual", Summary: "Validate the active profile and print resolved identity metadata."},
+	{Path: "auth whoami", Kind: "manual", Summary: "Validate the active profile, print resolved identity metadata, and point agents at wake-registration next steps."},
 	{Path: "auth list", Kind: "manual", Summary: "List local CLI profiles and the active profile."},
 	{Path: "auth update-username", Kind: "manual", Summary: "Rename the authenticated agent and sync the local profile."},
 	{Path: "auth rotate", Kind: "manual", Summary: "Rotate the active agent key and refresh stored credentials."},

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -988,7 +988,7 @@ func authLocalHelpText(topic string) (string, bool) {
 	}
 	topics := map[string]authTopic{
 		"auth whoami": {
-			summary:  "Validate the active profile against the server and print resolved identity metadata.",
+			summary:  "Validate the active profile against the server, print resolved identity metadata, and point to wake-registration next steps.",
 			usage:    "oar auth whoami",
 			examples: []string{"oar auth whoami", "oar --json auth whoami"},
 		},
@@ -1032,6 +1032,10 @@ func authLocalHelpText(topic string) (string, bool) {
 		for _, example := range entry.examples {
 			b.WriteString("  " + strings.TrimSpace(example) + "\n")
 		}
+	}
+	if strings.Join(strings.Fields(strings.TrimSpace(topic)), " ") == "auth whoami" {
+		b.WriteString("\nNext steps:\n")
+		b.WriteString("  If this agent should be wakeable by `@handle`, read `oar meta doc wake-routing`.\n")
 	}
 	b.WriteString("\n")
 	b.WriteString(formatGlobalFlagUsage(topic))

--- a/cli/internal/app/meta_docs_test.go
+++ b/cli/internal/app/meta_docs_test.go
@@ -57,6 +57,9 @@ func TestRunMetaDocPrintsLocalAuthLifecycleTopicMarkdown(t *testing.T) {
 	if !strings.Contains(output, "Local Help: auth whoami") {
 		t.Fatalf("expected embedded auth whoami help text output=%s", output)
 	}
+	if !strings.Contains(output, "oar meta doc wake-routing") {
+		t.Fatalf("expected wake-routing next step output=%s", output)
+	}
 }
 
 func TestRunMetaDocPrintsAgentGuideMarkdown(t *testing.T) {
@@ -86,6 +89,21 @@ func TestRunMetaDocPrintsWakeRoutingMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(output, "`agentreg.<handle>`") {
 		t.Fatalf("expected registration doc guidance output=%s", output)
+	}
+	if !strings.Contains(output, "oar docs create --from-file wake-registration.json --json") {
+		t.Fatalf("expected docs create registration example output=%s", output)
+	}
+	if !strings.Contains(output, "agent-registration/v1") {
+		t.Fatalf("expected registration schema version output=%s", output)
+	}
+	if !strings.Contains(output, "oar-agent-bridge registration apply --config <agent.toml>") {
+		t.Fatalf("expected bridge registration shortcut output=%s", output)
+	}
+	if !strings.Contains(output, "oar.workspace_id") || !strings.Contains(output, "ws_main") {
+		t.Fatalf("expected workspace-id discovery guidance output=%s", output)
+	}
+	if !strings.Contains(output, "server actor id as `<actor-id>`") {
+		t.Fatalf("expected actor-id sourcing guidance output=%s", output)
 	}
 }
 

--- a/cli/internal/app/wake_routing_guide.go
+++ b/cli/internal/app/wake_routing_guide.go
@@ -3,53 +3,179 @@ package app
 import "strings"
 
 func wakeRoutingGuideText() string {
-	return strings.TrimSpace(`Wake routing
+	const tickToken = "<<tick>>"
+	guide := strings.TrimSpace(`Wake routing
 
-Use this when you want humans or agents to wake other agents from thread messages by tagging ` + "`@handle`" + `.
+Use this when you want humans or agents to wake other agents from thread messages by tagging <<tick>>@handle<<tick>>.
 
 How it works
 
-- Wake routing is implemented by the adapter bridge layer, not by ` + "`oar-core`" + ` itself.
+- Wake routing is implemented by the adapter bridge layer, not by <<tick>>oar-core<<tick>> itself.
 - A tagged message becomes durable wake work only when the target agent has a registered handle and the router/bridge daemons are running.
-- The durable registration document id is ` + "`agentreg.<handle>`" + `.
+- The durable registration document id is <<tick>>agentreg.<handle><<tick>>.
 
 What counts as wakeable
 
-- principal kind is ` + "`agent`" + `
+- principal kind is <<tick>>agent<<tick>>
 - principal is not revoked
 - principal has a username/handle
-- registration document ` + "`agentreg.<handle>`" + ` exists
-- registration document ` + "`actor_id`" + ` matches the principal actor
+- registration document <<tick>>agentreg.<handle><<tick>> exists
+- registration document <<tick>>actor_id<<tick>> matches the principal actor
 - registration status is active
 - registration has an enabled binding for the current workspace
 
 How humans discover it
 
-- In the web UI Access page, look for agent principals marked Wakeable and their ` + "`@handle`" + `.
-- In a thread message composer, tagging ` + "`@handle`" + ` requests a wakeup for that agent.
+- In the web UI Access page, look for agent principals marked Wakeable and their <<tick>>@handle<<tick>>.
+- In a thread message composer, tagging <<tick>>@handle<<tick>> requests a wakeup for that agent.
 
 How agents discover it
 
-- Read this topic with ` + "`oar meta doc wake-routing`" + `.
-- Use ` + "`oar auth whoami`" + ` to confirm your current username and agent id.
-- Use ` + "`oar auth principals list --json`" + ` to inspect known agent principals.
-- Use ` + "`oar docs get --document-id agentreg.<handle> --json`" + ` to inspect a specific registration document.
+- Read this topic with <<tick>>oar meta doc wake-routing<<tick>>.
+- Use <<tick>>oar auth whoami<<tick>> to confirm your current username and agent id.
+- Use <<tick>>oar auth principals list --json<<tick>> to inspect known agent principals.
+- Use <<tick>>oar docs get --document-id agentreg.<handle> --json<<tick>> to inspect a specific registration document.
+
+Self-serve registration
+
+Preferred path when you are using <<tick>>oar-agent-bridge<<tick>>
+
+- During initial auth, register and write the wake registration in one step:
+
+  oar-agent-bridge auth register --config <agent.toml> --invite-token <token> --apply-registration
+
+- After auth already exists, upsert the registration document again with:
+
+  oar-agent-bridge registration apply --config <agent.toml>
+
+Generic OAR CLI path
+
+1. Confirm the identity you are registering:
+
+  oar auth whoami
+
+  Use the server-resolved username from that output as <<tick>><handle><<tick>> and the server actor id as <<tick>><actor-id><<tick>>.
+
+2. Resolve the durable workspace id you want to enable:
+
+  - If you are using <<tick>>oar-agent-bridge<<tick>>, read <<tick>>oar.workspace_id<<tick>> from your agent or router config file.
+  - The bundled example bridge configs use <<tick>>ws_main<<tick>>.
+  - Do not use a workspace slug or URL path segment here.
+
+3. Create a file such as <<tick>>wake-registration.json<<tick>> with the exact registration payload:
+
+  {
+    "document": {
+      "document_id": "agentreg.<handle>",
+      "title": "Agent registration @<handle>",
+      "status": "active",
+      "labels": [
+        "agent-registration",
+        "handle:<handle>",
+        "actor:<actor-id>"
+      ]
+    },
+    "content_type": "structured",
+    "content": {
+      "version": "agent-registration/v1",
+      "handle": "<handle>",
+      "actor_id": "<actor-id>",
+      "delivery_mode": "pull",
+      "driver_kind": "custom",
+      "resume_policy": "resume_or_create",
+      "status": "active",
+      "adapter_kind": "custom",
+      "updated_at": "2026-01-01T00:00:00Z",
+      "workspace_bindings": [
+        {
+          "workspace_id": "<workspace-id>",
+          "enabled": true
+        }
+      ]
+    }
+  }
+
+4. Create the document:
+
+  oar docs create --from-file wake-registration.json --json
+
+Registration schema
+
+- Durable document id must be <<tick>>agentreg.<handle><<tick>>.
+- Fields required for routing correctness are:
+  - <<tick>>content.handle<<tick>> matching the principal username
+  - <<tick>>content.actor_id<<tick>> matching the principal actor id
+  - at least one enabled <<tick>>content.workspace_bindings[].workspace_id<<tick>> matching the router workspace id
+- Fields the bridge writes for compatibility and clarity are:
+  - <<tick>>content.version<<tick>> = <<tick>>agent-registration/v1<<tick>>
+  - <<tick>>content.delivery_mode<<tick>> = <<tick>>pull<<tick>>
+  - <<tick>>content.driver_kind<<tick>>
+  - <<tick>>content.resume_policy<<tick>> = <<tick>>resume_or_create<<tick>>
+  - <<tick>>content.status<<tick>> = <<tick>>active<<tick>>
+  - <<tick>>content.adapter_kind<<tick>>
+  - <<tick>>content.updated_at<<tick>>
+- <<tick>>workspace_bindings[].enabled<<tick>> defaults to true when omitted by bridge code, but setting it explicitly is clearer.
+- The workspace binding value must be the durable workspace id used by the router, typically <<tick>>oar.workspace_id<<tick>> in bridge config, not a URL slug or UI path segment.
+
+Verification flow
+
+1. Confirm your local and server identity:
+
+  oar auth whoami
+
+2. Confirm a principal exists for the target handle:
+
+  oar auth principals list --json
+
+3. Read the registration document:
+
+  oar docs get --document-id agentreg.<handle> --json
+
+4. Verify all of the following:
+  - principal kind is <<tick>>agent<<tick>>
+  - principal username is exactly <<tick>><handle><<tick>>
+  - principal actor id matches <<tick>>content.actor_id<<tick>>
+  - registration <<tick>>content.status<<tick>> is <<tick>>active<<tick>>
+  - <<tick>>workspace_bindings<<tick>> contains the current workspace id with <<tick>>enabled: true<<tick>>
+
+5. If you are using <<tick>>oar-agent-bridge<<tick>>, confirm the router and target bridge are running:
+
+  oar-agent-bridge router run --config <router.toml>
+  oar-agent-bridge bridge run --config <agent.toml>
+
+Concrete wake example
+
+1. Ensure the router and target bridge are running, then post a thread message containing <<tick>>@<handle><<tick>>, for example:
+
+  @<handle> summarize the latest onboarding blockers.
+
+2. Expected durable trace:
+  - existing <<tick>>message_posted<<tick>>
+  - new <<tick>>agent_wakeup_requested<<tick>>
+  - new <<tick>>agent_wakeup_claimed<<tick>>
+  - new bridge reply <<tick>>message_posted<<tick>>
+  - new <<tick>>agent_wakeup_completed<<tick>>
+
+3. If the request is durable but never gets claimed, the registration may be valid while the router or bridge runtime is offline.
 
 Common failure modes
 
 - unknown handle: no matching agent principal username exists
-- missing registration: ` + "`agentreg.<handle>`" + ` does not exist
+- missing registration: <<tick>>agentreg.<handle><<tick>> does not exist
 - registration actor mismatch: the registration doc points at a different actor
 - workspace not bound: registration exists but is not enabled for this workspace
+- wrong workspace id: the registration uses a workspace slug or another id that does not match the router configuration
 - bridge offline: the wake request is durable in OAR, but no local bridge is consuming it
 
 Operational note
 
-- This mechanism is discoverable from the CLI and UI, but actual wake dispatch is owned by the ` + "`adapters/agent-bridge`" + ` runtime.
+- This mechanism is discoverable from the CLI and UI, but actual wake dispatch is owned by the <<tick>>adapters/agent-bridge<<tick>> runtime.
 
 Next steps
 
   oar meta doc agent-guide
   oar auth whoami
+  oar help docs create
   oar auth principals list --json`)
+	return strings.ReplaceAll(guide, tickToken, "`")
 }


### PR DESCRIPTION
## Summary

Closes #124.

This makes wake registration self-serve from the CLI docs and auth flow instead of stopping at inspection-only guidance.

## What changed

- Expanded `oar meta doc wake-routing` with the full `agentreg.<handle>` schema, a copy-paste `oar docs create --from-file` example, bridge-specific shortcuts, verification steps, a concrete wake trace, and troubleshooting.
- Updated `oar auth whoami` to print local and server `actor_id` values and to point directly at wake-registration next steps.
- Updated the agent guide, help catalog, and generated runtime help so the registration path is discoverable from the normal CLI help surface.
- Added tests covering the new wake-routing docs and the `auth whoami` hint behavior, including stale local username handling.

## Why

Wake routing had become discoverable, but not operable. Agents could learn that `agentreg.<handle>` was required without being told how to create it correctly, how to source `actor_id` and workspace binding values, or how to verify the result.

## Validation

- `cd cli && go test ./internal/app`
- `cd cli && go run ./cmd/oar-docs-gen`

## Notes

This is a docs-first fix. The repo already had the underlying document write path (`oar docs create`) and the bridge-side shortcut commands (`oar-agent-bridge auth register --apply-registration` / `registration apply`), so this change closes the usability gap without introducing a new CLI mutation command.