### PR TITLE
fix: repair bridge bootstrap regressions

### DIFF
--- a/adapters/agent-bridge/oar_agent_bridge/cli.py
+++ b/adapters/agent-bridge/oar_agent_bridge/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 from . import __version__
@@ -91,7 +92,7 @@ def cmd_registration_apply(args: argparse.Namespace) -> int:
     client = build_client(config, auth)
     try:
         result = apply_registration(config, auth, client)
-        print(json.dumps(result.__dict__, indent=2))
+        print(json.dumps(asdict(result), indent=2))
         return 0
     finally:
         client.close()
@@ -103,7 +104,7 @@ def cmd_registration_status(args: argparse.Namespace) -> int:
     client = build_client(config, auth)
     try:
         result = registration_status(config, auth, client)
-        print(json.dumps(result.__dict__, indent=2))
+        print(json.dumps(asdict(result), indent=2))
         return 0
     finally:
         client.close()

--- a/adapters/agent-bridge/oar_agent_bridge/oar_client.py
+++ b/adapters/agent-bridge/oar_agent_bridge/oar_client.py
@@ -147,7 +147,9 @@ class OARClient:
             document.setdefault("document_id", document_id)
             return self.create_document(document=document, content=content, content_type=content_type, request_key=request_key)
         revision = current["revision"]
-        return self.update_document(document_id, if_base_revision=str(revision["revision_id"]), document=document, content=content, content_type=content_type)
+        update_document = dict(document)
+        update_document.pop("document_id", None)
+        return self.update_document(document_id, if_base_revision=str(revision["revision_id"]), document=update_document, content=content, content_type=content_type)
 
     def create_event(self, *, event: dict[str, Any], request_key: str | None = None) -> dict[str, Any]:
         body: dict[str, Any] = {"event": event}

--- a/adapters/agent-bridge/oar_agent_bridge/registry.py
+++ b/adapters/agent-bridge/oar_agent_bridge/registry.py
@@ -72,6 +72,8 @@ def publish_bridge_checkin(
         event={
             "type": BRIDGE_CHECKED_IN_EVENT,
             "summary": f"Agent bridge checked in @{config.agent.handle}",
+            "refs": [],
+            "provenance": {"sources": ["inferred"]},
             "payload": checkin.to_content(),
         },
         request_key=f"bridge-checkin-{sha256_text(config.agent.handle, state.actor_id, bridge_instance_id, checked_in_at, length=24)}",

--- a/adapters/agent-bridge/tests/test_bridge.py
+++ b/adapters/agent-bridge/tests/test_bridge.py
@@ -142,8 +142,11 @@ def test_bridge_checkin_upserts_active_registration():
     assert reg_payload["content"]["bridge_expires_at"] != ""
     assert reg_payload["content"]["bridge_checkin_event_id"] == "event-1"
     assert len(client.created_events) == 1
-    checkin_payload = client.created_events[0]["event"]["payload"]
-    assert client.created_events[0]["event"]["type"] == "agent_bridge_checked_in"
+    checkin_event = client.created_events[0]["event"]
+    checkin_payload = checkin_event["payload"]
+    assert checkin_event["type"] == "agent_bridge_checked_in"
+    assert checkin_event["refs"] == []
+    assert checkin_event["provenance"] == {"sources": ["inferred"]}
     assert checkin_payload["bridge_instance_id"] == "bridge-test"
     assert checkin_payload["workspace_id"] == "ws_main"
     assert checkin_payload["proof_signature_b64"] != ""

--- a/adapters/agent-bridge/tests/test_cli.py
+++ b/adapters/agent-bridge/tests/test_cli.py
@@ -1,7 +1,11 @@
+import argparse
+
 import pytest
 
 from oar_agent_bridge import __version__
+from oar_agent_bridge import cli as cli_module
 from oar_agent_bridge.cli import build_parser
+from oar_agent_bridge.registry import RegistrationStatusResult
 
 
 def test_version_flag_prints_package_version(capsys):
@@ -33,3 +37,41 @@ def test_bridge_doctor_subcommand_is_available():
     assert args.command == "bridge"
     assert args.bridge_command == "doctor"
     assert args.config == "agent.toml"
+
+
+def test_cmd_registration_status_serializes_slots_dataclass(monkeypatch, capsys):
+    closed = {"value": False}
+    config = argparse.Namespace(auth_state_path="state.json")
+
+    class DummyClient:
+        def close(self):
+            closed["value"] = True
+
+    monkeypatch.setattr(cli_module, "load_config", lambda _path: config)
+    monkeypatch.setattr(cli_module, "AuthManager", lambda _path: object())
+    monkeypatch.setattr(cli_module, "build_client", lambda _config, _auth: DummyClient())
+    monkeypatch.setattr(
+        cli_module,
+        "registration_status",
+        lambda _config, _auth, _client: RegistrationStatusResult(
+            document_id="agentreg.hermes",
+            handle="hermes",
+            actor_id="actor-1",
+            registration_status="active",
+            workspace_id="ws_main",
+            workspace_bound=True,
+            bridge_checkin_event_id="event-1",
+            bridge_checked_in_at="2026-03-29T00:00:00Z",
+            bridge_expires_at="2026-03-29T00:05:00Z",
+            wakeable=True,
+            blockers=[],
+        ),
+    )
+
+    result = cli_module.cmd_registration_status(argparse.Namespace(config="agent.toml"))
+
+    assert result == 0
+    assert closed["value"] is True
+    captured = capsys.readouterr()
+    assert '"document_id": "agentreg.hermes"' in captured.out
+    assert '"wakeable": true' in captured.out

--- a/adapters/agent-bridge/tests/test_oar_client.py
+++ b/adapters/agent-bridge/tests/test_oar_client.py
@@ -46,3 +46,27 @@ def test_create_document_includes_actor_id_from_auth_state(monkeypatch):
 
     assert captured["path"] == "/docs"
     assert captured["body"]["actor_id"] == "actor-123"
+
+
+def test_upsert_document_omits_document_id_on_patch(monkeypatch):
+    client = OARClient("http://oar.test", auth_manager=DummyAuthManager())
+    captured = {}
+
+    monkeypatch.setattr(client, "get_document", lambda _document_id: {"revision": {"revision_id": "rev-1"}})
+
+    def fake_update_document(document_id, **kwargs):
+        captured["document_id"] = document_id
+        captured["kwargs"] = kwargs
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "update_document", fake_update_document)
+
+    client.upsert_document(
+        "doc-1",
+        document={"document_id": "doc-1", "title": "Title", "status": "active"},
+        content={"ok": True},
+    )
+
+    assert captured["document_id"] == "doc-1"
+    assert captured["kwargs"]["document"] == {"title": "Title", "status": "active"}
+    assert captured["kwargs"]["if_base_revision"] == "rev-1"


### PR DESCRIPTION
## Summary
This fixes a few concrete regressions in the `oar-agent-bridge` bootstrap / readiness path that showed up during a real local bridge bring-up.

### Fixes
- serialize registration dataclasses safely in the CLI instead of using `__dict__` on `slots=True` dataclasses
- include required `refs` and `provenance` fields when publishing bridge check-in events
- omit `document.document_id` from PATCH updates during document upsert

### Tests
- add a CLI regression test covering slots-dataclass serialization
- add an OAR client regression test covering `document_id` stripping on patch updates
- extend bridge check-in tests to assert the required event envelope fields

## Validation
- `PYTHONPATH=. pytest tests/test_cli.py tests/test_oar_client.py tests/test_bridge.py`
- manually verified against a live OAR instance that the bridge could become wakeable after these fixes

Refs #130
