### PR TITLE
Fix access wakeability when workspace context is missing

### DIFF
--- a/web-ui/src/lib/wakeRouting.js
+++ b/web-ui/src/lib/wakeRouting.js
@@ -215,31 +215,33 @@ export async function describeWakeRouting(
     };
   }
 
-  if (!bindingTarget) {
-    return {
-      ...base,
-      badgeLabel: "Unknown",
-      badgeClass: "bg-slate-500/10 text-slate-300",
-      summary:
-        "Workspace binding status is unavailable because this workspace has no durable workspace ID.",
-    };
-  }
-
   const bindings = Array.isArray(content.workspace_bindings)
     ? content.workspace_bindings
     : [];
+  const enabledBindings = bindings.filter((binding) => {
+    const workspaceId = String(binding?.workspace_id ?? "").trim();
+    return workspaceId && binding?.enabled !== false;
+  });
+
+  if (!bindingTarget && enabledBindings.length === 0) {
+    return {
+      ...base,
+      summary: "Registration is not enabled for any workspace.",
+    };
+  }
+
   const matchingBinding = bindings.find(
     (binding) => String(binding?.workspace_id ?? "").trim() === bindingTarget,
   );
 
-  if (!matchingBinding) {
+  if (bindingTarget && !matchingBinding) {
     return {
       ...base,
       summary: "Registration is not enabled for this workspace.",
     };
   }
 
-  if (matchingBinding.enabled === false) {
+  if (bindingTarget && matchingBinding.enabled === false) {
     return {
       ...base,
       summary: "Registration is disabled for this workspace.",
@@ -314,10 +316,22 @@ export async function describeWakeRouting(
   }
 
   const checkinWorkspaceId = String(checkinContent.workspace_id ?? "").trim();
-  if (checkinWorkspaceId !== bindingTarget) {
+  if (bindingTarget && checkinWorkspaceId !== bindingTarget) {
     return {
       ...base,
       summary: "Bridge check-in is for a different workspace.",
+    };
+  }
+  if (
+    !bindingTarget &&
+    !enabledBindings.some(
+      (binding) =>
+        String(binding?.workspace_id ?? "").trim() === checkinWorkspaceId,
+    )
+  ) {
+    return {
+      ...base,
+      summary: "Bridge check-in is for an unbound workspace.",
     };
   }
 
@@ -359,6 +373,17 @@ export async function describeWakeRouting(
     return {
       ...base,
       summary: "Bridge check-in is stale. Restart or reconnect the bridge.",
+    };
+  }
+
+  if (!bindingTarget) {
+    return {
+      applicable: true,
+      handle,
+      wakeable: true,
+      badgeLabel: "Wakeable",
+      badgeClass: "bg-emerald-500/10 text-emerald-400",
+      summary: `Wakeable for bound workspace ${checkinWorkspaceId}, but this page has no durable workspace ID to confirm the current workspace match.`,
     };
   }
 

--- a/web-ui/tests/e2e/access.spec.js
+++ b/web-ui/tests/e2e/access.spec.js
@@ -14,21 +14,38 @@ const bridgeProofKeyPromise = (async () => {
   };
 })();
 
+function stableJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableJsonValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .reduce((normalized, key) => {
+        normalized[key] = stableJsonValue(value[key]);
+        return normalized;
+      }, {});
+  }
+  return value;
+}
+
 async function signCheckinPayload(content) {
   const { privateKey } = await bridgeProofKeyPromise;
   const signature = await webcrypto.subtle.sign(
     { name: "ECDSA", hash: "SHA-256" },
     privateKey,
     Buffer.from(
-      JSON.stringify({
-        v: "agent-bridge-checkin-proof/v1",
-        handle: String(content.handle ?? "").trim(),
-        actor_id: String(content.actor_id ?? "").trim(),
-        workspace_id: String(content.workspace_id ?? "").trim(),
-        bridge_instance_id: String(content.bridge_instance_id ?? "").trim(),
-        checked_in_at: String(content.checked_in_at ?? "").trim(),
-        expires_at: String(content.expires_at ?? "").trim(),
-      }),
+      JSON.stringify(
+        stableJsonValue({
+          v: "agent-bridge-checkin-proof/v1",
+          handle: String(content.handle ?? "").trim(),
+          actor_id: String(content.actor_id ?? "").trim(),
+          workspace_id: String(content.workspace_id ?? "").trim(),
+          bridge_instance_id: String(content.bridge_instance_id ?? "").trim(),
+          checked_in_at: String(content.checked_in_at ?? "").trim(),
+          expires_at: String(content.expires_at ?? "").trim(),
+        }),
+      ),
       "utf8",
     ),
   );
@@ -223,10 +240,12 @@ test("does not repeat the username in principal rows", async ({ page }) => {
   await expect(
     page.getByText("agent via public_key", { exact: true }),
   ).toBeVisible();
-  await expect(page.getByText("Unknown", { exact: true })).toBeVisible();
+  const wakeableBadge = page.getByRole("button", { name: "Wakeable" });
+  await expect(wakeableBadge).toBeVisible();
+  await wakeableBadge.click();
   await expect(
     page.getByText(
-      "Workspace binding status is unavailable because this workspace has no durable workspace ID.",
+      "Wakeable for bound workspace local, but this page has no durable workspace ID to confirm the current workspace match.",
       { exact: true },
     ),
   ).toBeVisible();

--- a/web-ui/tests/unit/wakeRouting.test.js
+++ b/web-ui/tests/unit/wakeRouting.test.js
@@ -180,7 +180,7 @@ describe("wakeRouting", () => {
     });
   });
 
-  it("treats missing durable workspace ids as indeterminate", async () => {
+  it("keeps healthy bridge registrations wakeable when page workspace context is missing", async () => {
     const { publicKeyB64 } = await bridgeProofKeyPromise;
     const result = await describeWakeRouting(
       principal,
@@ -205,10 +205,10 @@ describe("wakeRouting", () => {
 
     expect(result).toMatchObject({
       applicable: true,
-      wakeable: false,
-      badgeLabel: "Unknown",
+      wakeable: true,
+      badgeLabel: "Wakeable",
       summary:
-        "Workspace binding status is unavailable because this workspace has no durable workspace ID.",
+        "Wakeable for bound workspace ws-123, but this page has no durable workspace ID to confirm the current workspace match.",
     });
   });
 


### PR DESCRIPTION
## Summary
- keep healthy bridge registrations wakeable even when the access page lacks a durable workspace id
- require the live check-in workspace to match an enabled binding before reporting wakeable without page workspace context
- update unit and access e2e coverage for the new status and align the e2e proof fixture with production signing

## Testing
- make -C web-ui check
- pnpm test:e2e -- tests/e2e/access.spec.js

Closes #132