### PR TITLE
Only offer wakeable agents in thread mentions

### DIFF
--- a/web-ui/src/lib/components/thread-detail/ThreadMessagesTab.svelte
+++ b/web-ui/src/lib/components/thread-detail/ThreadMessagesTab.svelte
@@ -11,20 +11,21 @@
     isAccessDevPreview,
   } from "$lib/accessDevMock.js";
   import { coreClient } from "$lib/coreClient";
+  import { enrichPrincipalsWithWakeRouting } from "$lib/principalWakeRouting.js";
   import ThreadMessageItem from "$lib/components/thread-detail/ThreadMessageItem.svelte";
   import {
     flattenMessageThreadView,
     toMessageThreadView,
   } from "$lib/messageThreadUtils";
   import {
-    agentHandlesFromPrincipals,
     filterMentionCandidates,
     parseActiveMention,
+    wakeableAgentHandlesFromPrincipals,
   } from "$lib/threadMentionUtils.js";
   import { threadDetailStore } from "$lib/threadDetailStore";
   import { workspacePath } from "$lib/workspacePaths";
 
-  let { threadId, onMessagePost } = $props();
+  let { threadId, onMessagePost, workspaceId = "" } = $props();
 
   let timeline = $derived($threadDetailStore.timeline);
   let timelineLoading = $derived($threadDetailStore.timelineLoading);
@@ -50,6 +51,7 @@
   let mentionOpen = $state(false);
   let mentionQuery = $state("");
   let mentionHighlight = $state(0);
+  let mentionSignedIn = $state(false);
   let textareaRef = $state(null);
 
   let filteredMentions = $derived(
@@ -67,15 +69,23 @@
       const agent = get(authenticatedAgent);
       const reg = get(actorRegistry);
       const nameFn = (id) => lookupActorDisplayName(id, reg);
+      mentionSignedIn = Boolean(agent);
 
       if (agent) {
         const data = await coreClient.listPrincipals({ limit: 100 });
-        mentionCandidates = agentHandlesFromPrincipals(
+        const principals = await enrichPrincipalsWithWakeRouting(
           data?.principals ?? [],
+          {
+            workspaceBindingTarget: workspaceId,
+            client: coreClient,
+          },
+        );
+        mentionCandidates = wakeableAgentHandlesFromPrincipals(
+          principals,
           nameFn,
         );
       } else if (isAccessDevPreview) {
-        mentionCandidates = agentHandlesFromPrincipals(
+        mentionCandidates = wakeableAgentHandlesFromPrincipals(
           getAccessDevMockData().principals,
           nameFn,
         );
@@ -94,6 +104,7 @@
       return;
     }
     void $authenticatedAgent?.agent_id;
+    void workspaceId;
     void refreshMentionCandidates();
   });
 
@@ -251,10 +262,17 @@
             Loading handles…
           </p>
         {:else if mentionCandidates.length === 0}
-          <p class="px-3 py-2 text-[12px] text-[var(--ui-text-muted)]">
-            No agent handles in this workspace. Sign in or open Access to manage
-            agents.
-          </p>
+          {#if mentionSignedIn}
+            <p class="px-3 py-2 text-[12px] text-[var(--ui-text-muted)]">
+              No wakeable agents in this workspace. See Access to check bridge
+              status.
+            </p>
+          {:else}
+            <p class="px-3 py-2 text-[12px] text-[var(--ui-text-muted)]">
+              No agent handles in this workspace. Sign in or open Access to
+              manage agents.
+            </p>
+          {/if}
         {:else if filteredMentions.length === 0}
           <p class="px-3 py-2 text-[12px] text-[var(--ui-text-muted)]">
             No matching agents.

--- a/web-ui/src/lib/principalWakeRouting.js
+++ b/web-ui/src/lib/principalWakeRouting.js
@@ -1,0 +1,76 @@
+import {
+  bridgeCheckinEventId,
+  describeWakeRouting,
+  registrationDocumentId,
+} from "$lib/wakeRouting";
+
+/**
+ * @param {object[]} principalList
+ * @param {{ workspaceBindingTarget?: string, client: { getDocument: Function, getEvent: Function } }} options
+ */
+export async function enrichPrincipalsWithWakeRouting(
+  principalList,
+  { workspaceBindingTarget = "", client },
+) {
+  const activeAgentHandles = [
+    ...new Set(
+      (principalList ?? [])
+        .filter(
+          (principal) =>
+            principal?.principal_kind === "agent" &&
+            !principal?.revoked &&
+            String(principal?.username ?? "").trim() !== "",
+        )
+        .map((principal) => String(principal.username).trim()),
+    ),
+  ];
+
+  const registrationDocs = new Map();
+  const bridgeCheckins = new Map();
+
+  await Promise.all(
+    activeAgentHandles.map(async (handle) => {
+      try {
+        const registrationDoc = {
+          state: "ok",
+          document: await client.getDocument(registrationDocumentId(handle)),
+        };
+        registrationDocs.set(handle, registrationDoc);
+        const checkinEventId = bridgeCheckinEventId(registrationDoc);
+        if (!checkinEventId) {
+          bridgeCheckins.set(handle, { state: "missing" });
+          return;
+        }
+        try {
+          bridgeCheckins.set(handle, {
+            state: "ok",
+            document: await client.getEvent(checkinEventId),
+          });
+        } catch (error) {
+          bridgeCheckins.set(
+            handle,
+            error?.status === 404 ? { state: "missing" } : { state: "error" },
+          );
+        }
+      } catch (error) {
+        registrationDocs.set(
+          handle,
+          error?.status === 404 ? { state: "missing" } : { state: "error" },
+        );
+        bridgeCheckins.set(handle, { state: "missing" });
+      }
+    }),
+  );
+
+  return Promise.all(
+    (principalList ?? []).map(async (principal) => ({
+      ...principal,
+      wakeRouting: await describeWakeRouting(
+        principal,
+        registrationDocs.get(String(principal?.username ?? "").trim()) ?? null,
+        workspaceBindingTarget,
+        bridgeCheckins.get(String(principal?.username ?? "").trim()) ?? null,
+      ),
+    })),
+  );
+}

--- a/web-ui/src/lib/threadMentionUtils.js
+++ b/web-ui/src/lib/threadMentionUtils.js
@@ -68,3 +68,18 @@ export function agentHandlesFromPrincipals(principals, displayNameForActor) {
   rows.sort((a, b) => a.handle.localeCompare(b.handle));
   return rows;
 }
+
+/**
+ * @param {object[]} principals
+ * @param {(actorId: string) => string} [displayNameForActor]
+ * @returns {{ handle: string, actorId: string, displayLabel: string }[]}
+ */
+export function wakeableAgentHandlesFromPrincipals(
+  principals,
+  displayNameForActor,
+) {
+  return agentHandlesFromPrincipals(
+    (principals ?? []).filter((principal) => principal?.wakeRouting?.wakeable),
+    displayNameForActor,
+  );
+}

--- a/web-ui/src/routes/[workspace]/access/+page.svelte
+++ b/web-ui/src/routes/[workspace]/access/+page.svelte
@@ -5,11 +5,7 @@
   import { coreClient } from "$lib/coreClient";
   import { formatAbsoluteDateTime, formatTimestamp } from "$lib/formatDate";
   import { buildRegistrationMessage } from "$lib/inviteRegistrationMessage";
-  import {
-    bridgeCheckinEventId,
-    describeWakeRouting,
-    registrationDocumentId,
-  } from "$lib/wakeRouting";
+  import { enrichPrincipalsWithWakeRouting as loadPrincipalsWithWakeRouting } from "$lib/principalWakeRouting.js";
   import { workspacePath } from "$lib/workspacePaths";
   import {
     getAccessDevMockData,
@@ -368,70 +364,10 @@
   }
 
   async function enrichPrincipalsWithWakeRouting(principalList) {
-    const workspaceBindingTarget = data?.workspaceId ?? "";
-    const activeAgentHandles = [
-      ...new Set(
-        (principalList ?? [])
-          .filter(
-            (principal) =>
-              principal?.principal_kind === "agent" &&
-              !principal?.revoked &&
-              String(principal?.username ?? "").trim() !== "",
-          )
-          .map((principal) => String(principal.username).trim()),
-      ),
-    ];
-
-    const registrationDocs = new Map();
-    const bridgeCheckins = new Map();
-    await Promise.all(
-      activeAgentHandles.map(async (handle) => {
-        try {
-          const registrationDoc = {
-            state: "ok",
-            document: await coreClient.getDocument(
-              registrationDocumentId(handle),
-            ),
-          };
-          registrationDocs.set(handle, registrationDoc);
-          const checkinEventId = bridgeCheckinEventId(registrationDoc);
-          if (!checkinEventId) {
-            bridgeCheckins.set(handle, { state: "missing" });
-            return;
-          }
-          try {
-            bridgeCheckins.set(handle, {
-              state: "ok",
-              document: await coreClient.getEvent(checkinEventId),
-            });
-          } catch (error) {
-            bridgeCheckins.set(
-              handle,
-              error?.status === 404 ? { state: "missing" } : { state: "error" },
-            );
-          }
-        } catch (error) {
-          registrationDocs.set(
-            handle,
-            error?.status === 404 ? { state: "missing" } : { state: "error" },
-          );
-          bridgeCheckins.set(handle, { state: "missing" });
-        }
-      }),
-    );
-
-    return Promise.all(
-      (principalList ?? []).map(async (principal) => ({
-        ...principal,
-        wakeRouting: await describeWakeRouting(
-          principal,
-          registrationDocs.get(String(principal?.username ?? "").trim()) ??
-            null,
-          workspaceBindingTarget,
-          bridgeCheckins.get(String(principal?.username ?? "").trim()) ?? null,
-        ),
-      })),
-    );
+    return loadPrincipalsWithWakeRouting(principalList, {
+      workspaceBindingTarget: data?.workspaceId ?? "",
+      client: coreClient,
+    });
   }
 
   function workspaceHref(pathname = "/") {

--- a/web-ui/src/routes/[workspace]/threads/[threadId]/+page.server.js
+++ b/web-ui/src/routes/[workspace]/threads/[threadId]/+page.server.js
@@ -1,0 +1,13 @@
+import { resolveWorkspaceBySlug } from "$lib/server/workspaceResolver";
+
+export async function load(event) {
+  const resolved = await resolveWorkspaceBySlug({
+    event,
+    workspaceSlug: event.params.workspace,
+  });
+
+  return {
+    workspaceId:
+      resolved.workspace?.workspaceId ?? resolved.workspace?.id ?? "",
+  };
+}

--- a/web-ui/src/routes/[workspace]/threads/[threadId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/threads/[threadId]/+page.svelte
@@ -14,6 +14,7 @@
   import ThreadWorkTab from "$lib/components/thread-detail/ThreadWorkTab.svelte";
   import ThreadTimelineTab from "$lib/components/thread-detail/ThreadTimelineTab.svelte";
 
+  let { data } = $props();
   let threadId = $derived($page.params.threadId);
 
   let snapshot = $derived($threadDetailStore.snapshot);
@@ -257,7 +258,11 @@
 
   {#if activeTab === "messages"}
     <div role="tabpanel" tabindex="0">
-      <ThreadMessagesTab {threadId} onMessagePost={handleMessagePost} />
+      <ThreadMessagesTab
+        {threadId}
+        onMessagePost={handleMessagePost}
+        workspaceId={data?.workspaceId ?? ""}
+      />
     </div>
   {/if}
 

--- a/web-ui/tests/e2e/thread-detail.spec.js
+++ b/web-ui/tests/e2e/thread-detail.spec.js
@@ -1,9 +1,62 @@
 import { expect, test } from "@playwright/test";
+import { webcrypto } from "node:crypto";
+
+const bridgeProofKeyPromise = (async () => {
+  const keyPair = await webcrypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+  const publicKey = await webcrypto.subtle.exportKey("spki", keyPair.publicKey);
+  return {
+    privateKey: keyPair.privateKey,
+    publicKeyB64: Buffer.from(publicKey).toString("base64"),
+  };
+})();
+
+function stableJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableJsonValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .reduce((normalized, key) => {
+        normalized[key] = stableJsonValue(value[key]);
+        return normalized;
+      }, {});
+  }
+  return value;
+}
+
+async function signCheckinPayload(content) {
+  const { privateKey } = await bridgeProofKeyPromise;
+  const signature = await webcrypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    Buffer.from(
+      JSON.stringify(
+        stableJsonValue({
+          v: "agent-bridge-checkin-proof/v1",
+          handle: String(content.handle ?? "").trim(),
+          actor_id: String(content.actor_id ?? "").trim(),
+          workspace_id: String(content.workspace_id ?? "").trim(),
+          bridge_instance_id: String(content.bridge_instance_id ?? "").trim(),
+          checked_in_at: String(content.checked_in_at ?? "").trim(),
+          expires_at: String(content.expires_at ?? "").trim(),
+        }),
+      ),
+      "utf8",
+    ),
+  );
+  return Buffer.from(signature).toString("base64");
+}
 
 test("thread detail separates messages from timeline and nests replies", async ({
   page,
 }) => {
   const actorId = "actor-thread-detail-e2e";
+  const { publicKeyB64 } = await bridgeProofKeyPromise;
   let postedEvents = 0;
   let timeline = [
     {
@@ -22,6 +75,65 @@ test("thread detail separates messages from timeline and nests replies", async (
   await page.addInitScript((selectedActorId) => {
     window.localStorage.setItem("oar_ui_actor_id", selectedActorId);
   }, actorId);
+  await page.context().addCookies([
+    {
+      name: "oar_ui_session_local",
+      value: "test-refresh-token",
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+    },
+  ]);
+
+  await page.route("**/auth/session", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        agent: {
+          agent_id: "agent-ops-ai",
+          actor_id: actorId,
+          username: "ops-ai",
+        },
+      }),
+    });
+  });
+
+  await page.route("**/auth/principals?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        principals: [
+          {
+            agent_id: "agent-m4-hermes",
+            actor_id: "actor-m4-hermes",
+            username: "m4-hermes",
+            principal_kind: "agent",
+            auth_method: "public_key",
+            revoked: false,
+          },
+          {
+            agent_id: "agent-jarvis",
+            actor_id: "actor-jarvis",
+            username: "jarvis",
+            principal_kind: "agent",
+            auth_method: "public_key",
+            revoked: false,
+          },
+          {
+            agent_id: "agent-clawd",
+            actor_id: "actor-clawd",
+            username: "clawd",
+            principal_kind: "agent",
+            auth_method: "public_key",
+            revoked: false,
+          },
+        ],
+      }),
+    });
+  });
 
   await page.route(/\/actors$/, async (route) => {
     await route.fulfill({
@@ -59,6 +171,126 @@ test("thread detail separates messages from timeline and nests replies", async (
           updated_at: "2026-03-04T00:00:00.000Z",
           updated_by: actorId,
           provenance: { sources: ["actor_statement:event-1001"] },
+        },
+      }),
+    });
+  });
+
+  await page.route("**/docs/agentreg.m4-hermes", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        document: {
+          id: "agentreg.m4-hermes",
+          status: "active",
+        },
+        revision: {
+          content: {
+            handle: "m4-hermes",
+            actor_id: "actor-m4-hermes",
+            status: "active",
+            bridge_signing_public_key_spki_b64: publicKeyB64,
+            bridge_checkin_event_id: "event-bridge-checkin-m4-hermes",
+            workspace_bindings: [{ workspace_id: "local", enabled: true }],
+          },
+        },
+      }),
+    });
+  });
+
+  await page.route("**/docs/agentreg.jarvis", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        document: {
+          id: "agentreg.jarvis",
+          status: "active",
+        },
+        revision: {
+          content: {
+            handle: "jarvis",
+            actor_id: "actor-jarvis",
+            status: "pending",
+            workspace_bindings: [{ workspace_id: "local", enabled: true }],
+          },
+        },
+      }),
+    });
+  });
+
+  await page.route("**/docs/agentreg.clawd", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        document: {
+          id: "agentreg.clawd",
+          status: "active",
+        },
+        revision: {
+          content: {
+            handle: "clawd",
+            actor_id: "actor-clawd",
+            status: "active",
+            bridge_signing_public_key_spki_b64: publicKeyB64,
+            bridge_checkin_event_id: "event-bridge-checkin-clawd",
+            workspace_bindings: [{ workspace_id: "local", enabled: true }],
+          },
+        },
+      }),
+    });
+  });
+
+  await page.route(
+    "**/events/event-bridge-checkin-m4-hermes",
+    async (route) => {
+      const payload = {
+        handle: "m4-hermes",
+        actor_id: "actor-m4-hermes",
+        workspace_id: "local",
+        bridge_instance_id: "bridge-hermes-1",
+        checked_in_at: "2099-03-20T12:00:00Z",
+        expires_at: "2099-03-20T12:05:00Z",
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          event: {
+            id: "event-bridge-checkin-m4-hermes",
+            type: "agent_bridge_checked_in",
+            payload: {
+              ...payload,
+              proof_signature_b64: await signCheckinPayload(payload),
+            },
+          },
+        }),
+      });
+    },
+  );
+
+  await page.route("**/events/event-bridge-checkin-clawd", async (route) => {
+    const payload = {
+      handle: "clawd",
+      actor_id: "actor-clawd",
+      workspace_id: "local",
+      bridge_instance_id: "bridge-clawd-1",
+      checked_in_at: "2026-03-20T12:00:00Z",
+      expires_at: "2026-03-20T12:05:00Z",
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        event: {
+          id: "event-bridge-checkin-clawd",
+          type: "agent_bridge_checked_in",
+          payload: {
+            ...payload,
+            proof_signature_b64: await signCheckinPayload(payload),
+          },
         },
       }),
     });
@@ -232,6 +464,16 @@ test("thread detail separates messages from timeline and nests replies", async (
   await expect(
     page.getByText("Initial timeline message", { exact: true }),
   ).toBeVisible();
+  await page.locator("#message-text").fill("@");
+  await expect(page.locator("#message-mention-list")).toContainText(
+    "@m4-hermes",
+  );
+  await expect(page.locator("#message-mention-list")).not.toContainText(
+    "@jarvis",
+  );
+  await expect(page.locator("#message-mention-list")).not.toContainText(
+    "@clawd",
+  );
   await expect(
     page.locator("#message-evt-1001").getByRole("button", { name: "Reply" }),
   ).toBeVisible();

--- a/web-ui/tests/unit/threadMentionUtils.test.js
+++ b/web-ui/tests/unit/threadMentionUtils.test.js
@@ -4,6 +4,7 @@ import {
   agentHandlesFromPrincipals,
   filterMentionCandidates,
   parseActiveMention,
+  wakeableAgentHandlesFromPrincipals,
 } from "../../src/lib/threadMentionUtils.js";
 
 describe("parseActiveMention", () => {
@@ -80,5 +81,43 @@ describe("agentHandlesFromPrincipals", () => {
     expect(out.map((r) => r.handle)).toEqual(["a.first", "z.last"]);
     expect(out[0].displayLabel).toBe("Display A");
     expect(out[1].displayLabel).toBe("z.last");
+  });
+});
+
+describe("wakeableAgentHandlesFromPrincipals", () => {
+  it("keeps only wakeable agents", () => {
+    const out = wakeableAgentHandlesFromPrincipals(
+      [
+        {
+          principal_kind: "agent",
+          username: "wakeable.one",
+          actor_id: "a1",
+          revoked: false,
+          wakeRouting: { wakeable: true },
+        },
+        {
+          principal_kind: "agent",
+          username: "not-ready",
+          actor_id: "a2",
+          revoked: false,
+          wakeRouting: { wakeable: false },
+        },
+        {
+          principal_kind: "agent",
+          username: "unknown",
+          actor_id: "a3",
+          revoked: false,
+        },
+      ],
+      (id) => (id === "a1" ? "Wakeable One" : ""),
+    );
+
+    expect(out).toEqual([
+      {
+        handle: "wakeable.one",
+        actorId: "a1",
+        displayLabel: "Wakeable One",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- only offer wakeable agent handles in the thread composer mention dropdown
- reuse shared wake-routing enrichment so Access and thread mentions derive from the same registration and bridge check-in state
- expose workspace id to the workspace thread route when available and update the empty state plus regression coverage for the authenticated mention flow

## Why
The thread composer previously built mention candidates directly from `listPrincipals`, so any non-revoked agent with a username could appear in the `@` dropdown even if its bridge was stale, pending, or otherwise not wakeable. That made it easy to tag an agent that the workspace could not actually wake.

## Testing
- make -C web-ui check
- pnpm test:e2e -- tests/e2e/thread-detail.spec.js

Follow-up to #132.