### PR TITLE
[codex] Fix bridge readiness proof verification

### DIFF
--- a/web-ui/src/lib/wakeRouting.js
+++ b/web-ui/src/lib/wakeRouting.js
@@ -79,6 +79,76 @@ function base64ToBytes(value) {
   return null;
 }
 
+function readDerLength(bytes, offset) {
+  const first = bytes[offset];
+  if (first == null) return null;
+  if ((first & 0x80) === 0) {
+    return { length: first, nextOffset: offset + 1 };
+  }
+  const byteCount = first & 0x7f;
+  if (byteCount === 0 || byteCount > 4) {
+    return null;
+  }
+  let length = 0;
+  for (let index = 0; index < byteCount; index += 1) {
+    const value = bytes[offset + 1 + index];
+    if (value == null) return null;
+    length = (length << 8) | value;
+  }
+  return { length, nextOffset: offset + 1 + byteCount };
+}
+
+function decodeDerInteger(bytes, offset, size) {
+  if (bytes[offset] !== 0x02) {
+    return null;
+  }
+  const parsedLength = readDerLength(bytes, offset + 1);
+  if (!parsedLength) return null;
+  const { length, nextOffset } = parsedLength;
+  const endOffset = nextOffset + length;
+  if (endOffset > bytes.length) {
+    return null;
+  }
+  let value = bytes.slice(nextOffset, endOffset);
+  while (value.length > 0 && value[0] === 0x00) {
+    value = value.slice(1);
+  }
+  if (value.length > size) {
+    return null;
+  }
+  const normalized = new Uint8Array(size);
+  normalized.set(value, size - value.length);
+  return { value: normalized, nextOffset: endOffset };
+}
+
+function derSignatureToP1363(signatureBytes, size = 32) {
+  if (!(signatureBytes instanceof Uint8Array)) {
+    return null;
+  }
+  if (signatureBytes.length === size * 2) {
+    return signatureBytes;
+  }
+  if (signatureBytes[0] !== 0x30) {
+    return null;
+  }
+  const parsedLength = readDerLength(signatureBytes, 1);
+  if (!parsedLength) return null;
+  const { length, nextOffset } = parsedLength;
+  if (nextOffset + length !== signatureBytes.length) {
+    return null;
+  }
+  const r = decodeDerInteger(signatureBytes, nextOffset, size);
+  if (!r) return null;
+  const s = decodeDerInteger(signatureBytes, r.nextOffset, size);
+  if (!s || s.nextOffset !== signatureBytes.length) {
+    return null;
+  }
+  const normalized = new Uint8Array(size * 2);
+  normalized.set(r.value, 0);
+  normalized.set(s.value, size);
+  return normalized;
+}
+
 async function verifyBridgeProof(publicKeyB64, checkinContent) {
   const subtle = globalThis?.crypto?.subtle;
   const publicKeyBytes = base64ToBytes(publicKeyB64);
@@ -94,11 +164,28 @@ async function verifyBridgeProof(publicKeyB64, checkinContent) {
       false,
       ["verify"],
     );
+    const messageBytes = new TextEncoder().encode(
+      bridgeProofMessage(checkinContent),
+    );
+    if (
+      await subtle.verify(
+        { name: "ECDSA", hash: "SHA-256" },
+        publicKey,
+        signatureBytes,
+        messageBytes,
+      )
+    ) {
+      return true;
+    }
+    const normalizedSignature = derSignatureToP1363(signatureBytes);
+    if (!normalizedSignature || normalizedSignature === signatureBytes) {
+      return false;
+    }
     return subtle.verify(
       { name: "ECDSA", hash: "SHA-256" },
       publicKey,
-      signatureBytes,
-      new TextEncoder().encode(bridgeProofMessage(checkinContent)),
+      normalizedSignature,
+      messageBytes,
     );
   } catch {
     return false;

--- a/web-ui/tests/e2e/access.spec.js
+++ b/web-ui/tests/e2e/access.spec.js
@@ -1,15 +1,14 @@
 import { expect, test } from "@playwright/test";
-import { webcrypto } from "node:crypto";
+import { createSign, generateKeyPairSync } from "node:crypto";
 
-const bridgeProofKeyPromise = (async () => {
-  const keyPair = await webcrypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign", "verify"],
-  );
-  const publicKey = await webcrypto.subtle.exportKey("spki", keyPair.publicKey);
+const bridgeProofKey = (() => {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { format: "der", type: "spki" },
+    privateKeyEncoding: { format: "der", type: "pkcs8" },
+  });
   return {
-    privateKey: keyPair.privateKey,
+    privateKey,
     publicKeyB64: Buffer.from(publicKey).toString("base64"),
   };
 })();
@@ -29,11 +28,9 @@ function stableJsonValue(value) {
   return value;
 }
 
-async function signCheckinPayload(content) {
-  const { privateKey } = await bridgeProofKeyPromise;
-  const signature = await webcrypto.subtle.sign(
-    { name: "ECDSA", hash: "SHA-256" },
-    privateKey,
+function signCheckinPayload(content) {
+  const signer = createSign("sha256");
+  signer.update(
     Buffer.from(
       JSON.stringify(
         stableJsonValue({
@@ -49,7 +46,10 @@ async function signCheckinPayload(content) {
       "utf8",
     ),
   );
-  return Buffer.from(signature).toString("base64");
+  signer.end();
+  return signer
+    .sign({ key: bridgeProofKey.privateKey, format: "der", type: "pkcs8" })
+    .toString("base64");
 }
 
 test("renders the access page without auth seeding", async ({ page }) => {
@@ -172,7 +172,7 @@ test("does not repeat the username in principal rows", async ({ page }) => {
   });
 
   await page.route("**/docs/agentreg.m4-hermes", async (route) => {
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     await route.fulfill({
       status: 200,
       headers: { "content-type": "application/json" },

--- a/web-ui/tests/e2e/thread-detail.spec.js
+++ b/web-ui/tests/e2e/thread-detail.spec.js
@@ -1,15 +1,14 @@
 import { expect, test } from "@playwright/test";
-import { webcrypto } from "node:crypto";
+import { createSign, generateKeyPairSync } from "node:crypto";
 
-const bridgeProofKeyPromise = (async () => {
-  const keyPair = await webcrypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign", "verify"],
-  );
-  const publicKey = await webcrypto.subtle.exportKey("spki", keyPair.publicKey);
+const bridgeProofKey = (() => {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { format: "der", type: "spki" },
+    privateKeyEncoding: { format: "der", type: "pkcs8" },
+  });
   return {
-    privateKey: keyPair.privateKey,
+    privateKey,
     publicKeyB64: Buffer.from(publicKey).toString("base64"),
   };
 })();
@@ -29,11 +28,9 @@ function stableJsonValue(value) {
   return value;
 }
 
-async function signCheckinPayload(content) {
-  const { privateKey } = await bridgeProofKeyPromise;
-  const signature = await webcrypto.subtle.sign(
-    { name: "ECDSA", hash: "SHA-256" },
-    privateKey,
+function signCheckinPayload(content) {
+  const signer = createSign("sha256");
+  signer.update(
     Buffer.from(
       JSON.stringify(
         stableJsonValue({
@@ -49,14 +46,17 @@ async function signCheckinPayload(content) {
       "utf8",
     ),
   );
-  return Buffer.from(signature).toString("base64");
+  signer.end();
+  return signer
+    .sign({ key: bridgeProofKey.privateKey, format: "der", type: "pkcs8" })
+    .toString("base64");
 }
 
 test("thread detail separates messages from timeline and nests replies", async ({
   page,
 }) => {
   const actorId = "actor-thread-detail-e2e";
-  const { publicKeyB64 } = await bridgeProofKeyPromise;
+  const { publicKeyB64 } = bridgeProofKey;
   let postedEvents = 0;
   let streamLastEventId = "";
   let timelineRequests = 0;
@@ -527,12 +527,8 @@ test("thread detail separates messages from timeline and nests replies", async (
   await expect(page.locator("#message-mention-list")).toContainText(
     "@m4-hermes",
   );
-  await expect(page.locator("#message-mention-list")).not.toContainText(
-    "@jarvis",
-  );
-  await expect(page.locator("#message-mention-list")).not.toContainText(
-    "@clawd",
-  );
+  await expect(page.locator("#message-mention-list")).toContainText("@jarvis");
+  await expect(page.locator("#message-mention-list")).toContainText("@clawd");
   await expect(
     page.locator("#message-evt-1001").getByRole("button", { name: "Reply" }),
   ).toBeVisible();

--- a/web-ui/tests/unit/wakeRouting.test.js
+++ b/web-ui/tests/unit/wakeRouting.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { webcrypto } from "node:crypto";
+import { createSign, generateKeyPairSync } from "node:crypto";
 
 import {
   bridgeCheckinEventId,
@@ -7,15 +7,14 @@ import {
   registrationDocumentId,
 } from "../../src/lib/wakeRouting.js";
 
-const bridgeProofKeyPromise = (async () => {
-  const keyPair = await webcrypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign", "verify"],
-  );
-  const publicKey = await webcrypto.subtle.exportKey("spki", keyPair.publicKey);
+const bridgeProofKey = (() => {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { format: "der", type: "spki" },
+    privateKeyEncoding: { format: "der", type: "pkcs8" },
+  });
   return {
-    privateKey: keyPair.privateKey,
+    privateKey,
     publicKeyB64: Buffer.from(publicKey).toString("base64"),
   };
 })();
@@ -35,11 +34,9 @@ function stableJsonValue(value) {
   return value;
 }
 
-async function signCheckinPayload(content) {
-  const { privateKey } = await bridgeProofKeyPromise;
-  const signature = await webcrypto.subtle.sign(
-    { name: "ECDSA", hash: "SHA-256" },
-    privateKey,
+function signCheckinPayload(content) {
+  const signer = createSign("sha256");
+  signer.update(
     Buffer.from(
       JSON.stringify(
         stableJsonValue({
@@ -55,7 +52,10 @@ async function signCheckinPayload(content) {
       "utf8",
     ),
   );
-  return Buffer.from(signature).toString("base64");
+  signer.end();
+  return signer
+    .sign({ key: bridgeProofKey.privateKey, format: "der", type: "pkcs8" })
+    .toString("base64");
 }
 
 function registrationDoc(content) {
@@ -98,7 +98,7 @@ describe("wakeRouting", () => {
   };
 
   it("marks an agent online when the durable workspace id is bound", async () => {
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     const result = await describeWakeRouting(
       principal,
       registrationDoc({
@@ -166,7 +166,7 @@ describe("wakeRouting", () => {
       summary: "Registration status is unavailable right now.",
     });
 
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     await expect(
       describeWakeRouting(
         principal,
@@ -193,7 +193,7 @@ describe("wakeRouting", () => {
   });
 
   it("keeps healthy bridge registrations online when page workspace context is missing", async () => {
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     const result = await describeWakeRouting(
       principal,
       registrationDoc({
@@ -228,7 +228,7 @@ describe("wakeRouting", () => {
   });
 
   it("keeps registered agents taggable but offline until the bridge checks in", async () => {
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     const result = await describeWakeRouting(
       principal,
       registrationDoc({
@@ -255,7 +255,7 @@ describe("wakeRouting", () => {
   });
 
   it("treats stale bridge check-ins as offline", async () => {
-    const { publicKeyB64 } = await bridgeProofKeyPromise;
+    const { publicKeyB64 } = bridgeProofKey;
     const result = await describeWakeRouting(
       principal,
       registrationDoc({


### PR DESCRIPTION
## Summary
Fix the Access UI bridge readiness verifier so it accepts the DER-encoded ECDSA signatures emitted by the Python bridge runtime.

## Root Cause
The bridge signs readiness proofs using the Python/OpenSSL ECDSA path, which produces ASN.1 DER signatures. The web UI verifier used `crypto.subtle.verify` directly against those bytes, which only succeeded with the P1363-style signatures generated by the existing browser-based tests. That made healthy bridges appear offline with `Bridge readiness proof is invalid.` even though tagged agents responded immediately.

## What Changed
- Added DER-to-P1363 normalization in the web UI proof verifier before retrying WebCrypto verification.
- Updated wake-routing unit and e2e tests to generate DER signatures using Node's OpenSSL-backed signing path.
- Updated the thread-detail mention-picker expectation to match the current product rule that offline but registered agents remain taggable.

## Impact
- Access status now reflects the real bridge check-in proof instead of rejecting valid bridge signatures.
- Regression coverage now matches the real bridge/runtime signature format.

## Validation
- `make -C web-ui check`
- `pnpm exec playwright test tests/e2e/access.spec.js tests/e2e/thread-detail.spec.js --workers=1`

## Review
- Mini subagent review completed with no findings.