### PR TITLE
[codex] Fix self-hosted access copy public origin

### DIFF
--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -12,13 +12,16 @@ This package contains the SvelteKit web UI for Organization Autorunner.
 
 - Canonical config: `OAR_WORKSPACES`
   - JSON array or object mapping `workspace slug -> core base URL`
+  - Optional per-workspace `publicOrigin`/`public_origin` keeps copied links and
+    registration snippets pinned to the externally reachable workspace URL when
+    the UI itself is reverse-proxied or seen as loopback internally
   - Used directly for self-host and local/dev deployments
   - Example:
 
     ```bash
     export OAR_WORKSPACES='[
-      {"slug":"local","label":"Local","coreBaseUrl":"http://127.0.0.1:8000"},
-      {"slug":"ops","label":"Ops","coreBaseUrl":"http://127.0.0.1:8001"}
+      {"slug":"local","label":"Local","coreBaseUrl":"http://127.0.0.1:8000","publicOrigin":"https://oar.tailnet.ts.net/oar/local"},
+      {"slug":"ops","label":"Ops","coreBaseUrl":"http://127.0.0.1:8001","publicOrigin":"https://oar.tailnet.ts.net/oar/ops"}
     ]'
     export OAR_DEFAULT_WORKSPACE=local
     ```

--- a/web-ui/docs/runbook.md
+++ b/web-ui/docs/runbook.md
@@ -17,15 +17,19 @@ Canonical runtime config is `OAR_WORKSPACES`.
 
 - Accepts a JSON array or object.
 - Each entry needs a workspace slug and a core base URL.
-- Optional fields: `label`, `description`.
+- Optional fields: `label`, `description`, `publicOrigin`/`public_origin`.
+- Set `publicOrigin` to the externally reachable workspace URL when the UI is
+  reverse-proxied, mounted under a base path, or otherwise sees loopback
+  origins internally. Access-page copy and registration snippets use it as the
+  fallback public URL.
 - This is the authoritative routing source for self-host and local/dev.
 
 Example:
 
 ```bash
 export OAR_WORKSPACES='[
-  {"slug":"dtrinity","label":"DTrinity","coreBaseUrl":"http://127.0.0.1:8000"},
-  {"slug":"scalingforever","label":"Scaling Forever","coreBaseUrl":"http://127.0.0.1:8001"}
+  {"slug":"dtrinity","label":"DTrinity","coreBaseUrl":"http://127.0.0.1:8000","publicOrigin":"https://oar.tailnet.ts.net/oar/dtrinity"},
+  {"slug":"scalingforever","label":"Scaling Forever","coreBaseUrl":"http://127.0.0.1:8001","publicOrigin":"https://oar.tailnet.ts.net/oar/scalingforever"}
 ]'
 export OAR_DEFAULT_WORKSPACE=dtrinity
 ```

--- a/web-ui/src/lib/server/workspaceCatalog.js
+++ b/web-ui/src/lib/server/workspaceCatalog.js
@@ -24,6 +24,7 @@ function normalizeWorkspaceEntry(entry, index) {
     label: String(entry.label ?? slug).trim() || slug,
     description: String(entry.description ?? "").trim(),
     coreBaseUrl: normalizeBaseUrl(entry.coreBaseUrl ?? entry.core_base_url),
+    publicOrigin: normalizeBaseUrl(entry.publicOrigin ?? entry.public_origin),
   };
 }
 

--- a/web-ui/tests/unit/workspaceCatalog.test.js
+++ b/web-ui/tests/unit/workspaceCatalog.test.js
@@ -30,6 +30,21 @@ describe("workspaceCatalog", () => {
     expect(catalog.defaultWorkspace.slug).toBe("ws2");
   });
 
+  it("should preserve public origin metadata from OAR_WORKSPACES entries", () => {
+    const env = {
+      OAR_WORKSPACES:
+        '[{"slug":"ws1","label":"Workspace 1","coreBaseUrl":"http://localhost:8000","publicOrigin":"https://ws1.tailnet.ts.net/oar/ws1"},{"slug":"ws2","label":"Workspace 2","coreBaseUrl":"http://localhost:8001","public_origin":"https://ws2.tailnet.ts.net/oar/ws2"}]',
+    };
+    const catalog = loadWorkspaceCatalog(env);
+
+    expect(catalog.workspaces[0].publicOrigin).toBe(
+      "https://ws1.tailnet.ts.net/oar/ws1",
+    );
+    expect(catalog.workspaces[1].publicOrigin).toBe(
+      "https://ws2.tailnet.ts.net/oar/ws2",
+    );
+  });
+
   it("should parse legacy OAR_PROJECTS env var", () => {
     const env = {
       OAR_PROJECTS:


### PR DESCRIPTION
## What changed
- preserve `publicOrigin` and `public_origin` on static `OAR_WORKSPACES` entries in the web UI workspace catalog
- keep access-page copy and wake registration snippets pinned to the external workspace URL instead of falling back to loopback when the UI sees `127.0.0.1` or `localhost`
- document the self-hosted `publicOrigin` setting in the `web-ui` README and runbook

## Why
Self-hosted deployments behind Tailscale or other reverse proxies can have the UI resolve its request origin as loopback internally. The access page already knows how to fall back to a configured public workspace URL, but static `OAR_WORKSPACES` parsing dropped that metadata. As a result, both the copied access-page message and the wake registration message could show localhost URLs even when a public host was configured.

## Impact
Operators using self-hosted `oar-core` and `oar-ui` can set `publicOrigin` in `OAR_WORKSPACES` and get correct sendable registration/access copy for remote agents.

## Validation
- `pnpm vitest run tests/unit/workspaceCatalog.test.js tests/unit/accessRoute.test.js tests/unit/wakeRegistrationMessage.test.js`
- `make -C web-ui check`
