### PR TITLE
feat(web-ui): mobile bottom navigation and More hub

### DIFF
--- a/web-ui/docs/style-guide.md
+++ b/web-ui/docs/style-guide.md
@@ -333,6 +333,51 @@ Destructive operations (delete, permanently delete, archive) follow escalating p
 
 Never nest focusable/clickable elements. A `<button>` inside an `<a>`, or an `<a>` inside a `<button>`, breaks screen reader announcements and causes unpredictable focus behavior. If a list row is clickable as a whole, use a single interactive wrapper and place child controls outside the click target, or use event delegation with `stopPropagation` on nested controls.
 
+## Mobile Patterns
+
+The UI uses a **mobile-first responsive shell**. Breakpoints:
+
+| Breakpoint | Value | Notes |
+|---|---|---|
+| Mobile | `< 640px` | Bottom nav only, no sidebar |
+| Tablet | `640px–1023px` | Bottom nav only, no sidebar |
+| Desktop | `≥ 1024px` | Sidebar visible, bottom nav hidden |
+
+### Bottom Navigation Bar (mobile/tablet)
+
+On screens narrower than 1024px a fixed bottom tab bar (`.shell-bottom-nav`) replaces the sidebar for primary navigation. It shows the five primary destinations (Home, Inbox, Topics, Boards, Docs) plus a **More** tab (icon + short label on each).
+
+- `z-index: 20` — below overlays that use higher z-index (for example modals and the command palette), above normal page content.
+- Respects `env(safe-area-inset-bottom)` for notched devices.
+- `.shell-main-scroll` bottom padding is `5rem` on mobile/tablet to clear the bar; it resets to `2.5rem` at the 1024px breakpoint.
+
+**Do not add a second bottom bar** or position fixed elements at `bottom: 0` without accounting for this bar. Reserve `z-index: 20+` for shell chrome only.
+
+### Mobile Header
+
+The sticky top bar (`.shell-mobile-header`) is minimal: **OAR** wordmark and an identity control (initials + **Switch** or **Sign out**). Secondary destinations (Artifacts, Trash, Access), multi-workspace switching when applicable, and full identity copy live on the **`/more`** page, linked from the bottom tab bar.
+
+### Page Header Toolbars on Mobile
+
+List pages have a `flex flex-wrap items-start justify-between gap-4` header row. On mobile:
+
+- **Hide keyboard-only hints** — the ⌘K shortcut indicator must use `hidden sm:inline-flex`.
+- **Hide descriptive subtitles** — the one-liner description below the page heading should use `hidden sm:block` so it doesn't consume 2–3 lines on a 390px screen.
+- The action buttons (`Filters`, `New topic`, `Create board`, etc.) wrap naturally and remain visible.
+
+```svelte
+<!-- Page heading + description (hide description on mobile) -->
+<h1 class="text-lg font-semibold text-gray-900">Topics</h1>
+<p class="mt-1 hidden text-[12px] text-gray-500 sm:block">
+  Primary organizational surface...
+</p>
+
+<!-- ⌘K shortcut — keyboard-only, hide on mobile -->
+<span class="hidden items-center gap-1 rounded border border-gray-200 ... sm:inline-flex">
+  <kbd>⌘K</kbd>
+</span>
+```
+
 ## Spacing Conventions
 
 - Page padding: handled by `.shell-main-scroll` in `app.css`.
@@ -341,6 +386,7 @@ Never nest focusable/clickable elements. A `<button>` inside an `<a>`, or an `<a
 - Inside cards: `px-4 py-3` (content), `px-4 py-2.5` (headers/footers).
 - Form field gaps: `gap-2` or `gap-3`.
 - Border radius: `rounded-md` for everything. Avoid `rounded-xl` or `rounded-lg`.
+- **Bottom clearance on mobile:** reserve `pb-5` (or `5rem`) at the end of scrollable page content — the bottom nav occupies this space.
 
 ## Data Relationships & Navigation
 
@@ -396,6 +442,9 @@ When displaying counts that exclude certain items, label them explicitly. Exampl
 
 ## Anti-Patterns
 
+- **No keyboard-only UI on mobile** — `⌘K` shortcut indicators, keyboard hints, and similar controls must use `hidden sm:inline-flex` so they don't waste space on touch devices.
+- **No page description on mobile without `hidden sm:block`** — the subtitle copy below a list-page heading (`text-[12px] text-gray-500`) should be hidden on mobile; it crowds the action toolbar.
+- **No fixed bottom elements without bottom-nav clearance** — if you add `position: fixed; bottom: 0` at z-index < 20, it will be hidden under the bottom nav. Always account for `5rem` bottom clearance on mobile.
 - **No `bg-white`** — always `bg-gray-100` for surfaces.
 - **No `text-white` on gray buttons** — gray-900 is the "bright" text; `text-white` is only for accent-colored buttons (`bg-indigo-*`).
 - **No `-50` semantic backgrounds** — use `*-500/10` opacity pattern instead.

--- a/web-ui/src/app.css
+++ b/web-ui/src/app.css
@@ -298,7 +298,8 @@ a:focus-visible {
 }
 
 .shell-frame {
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   display: flex;
   min-width: 0;
   max-width: 100%;
@@ -730,6 +731,7 @@ a:focus-visible {
 .shell-main {
   flex: 1 1 0%;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -753,7 +755,6 @@ a:focus-visible {
   font-size: 0.8125rem;
 }
 
-.shell-mobile-menu,
 .shell-mobile-identity {
   border: 1px solid var(--ui-border);
   background: var(--ui-panel);
@@ -764,11 +765,6 @@ a:focus-visible {
   align-items: center;
   gap: 0.25rem;
   font-size: 0.75rem;
-}
-
-.shell-mobile-menu svg {
-  width: 0.875rem;
-  height: 0.875rem;
 }
 
 .shell-mobile-identity span {
@@ -783,98 +779,12 @@ a:focus-visible {
   font-weight: 700;
 }
 
-.shell-mobile-drawer {
-  position: fixed;
-  inset: 0;
-  z-index: 35;
-  display: flex;
-  flex-direction: row-reverse; /* panel on left to match hamburger position */
-}
-
-.shell-mobile-backdrop {
-  border: 0;
-  flex: 1;
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.shell-mobile-panel {
-  width: min(80vw, 16rem);
-  border-right: 1px solid var(--ui-border);
-  background: var(--ui-panel);
-  padding: 0.625rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.625rem;
-}
-
-.shell-mobile-panel-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.shell-mobile-panel-top p {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.8125rem;
-}
-
-.shell-mobile-panel-top button {
-  border: 1px solid var(--ui-border);
-  background: var(--ui-panel);
-  border-radius: var(--ui-radius-sm);
-  width: 1.75rem;
-  height: 1.75rem;
-  display: inline-grid;
-  place-items: center;
-  color: var(--ui-text);
-}
-
-.shell-mobile-panel-top button svg {
-  width: 0.875rem;
-  height: 0.875rem;
-}
-
-.shell-mobile-nav {
-  display: grid;
-  gap: 1px;
-}
-
-.shell-mobile-nav .shell-nav-link {
-  align-items: center;
-}
-
-.shell-mobile-nav .shell-nav-icon {
-  margin-top: 0;
-}
-
-.shell-mobile-nav .shell-nav-copy,
-.shell-mobile-nav .shell-nav-hint {
-  display: none;
-}
-
-.shell-mobile-nav-divider {
-  margin: 0.5rem 0 0;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--ui-border);
-}
-
-.shell-mobile-switch {
-  margin-top: auto;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-panel);
-  border-radius: var(--ui-radius-sm);
-  padding: 0.375rem 0.5rem;
-  font-size: 0.75rem;
-  color: var(--ui-text-muted);
-}
-
 .shell-main-scroll {
   flex: 1;
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 1.25rem 1rem 2rem;
+  padding: 1.25rem 1rem 5rem;
 }
 
 .shell-content {
@@ -1097,7 +1007,51 @@ a:focus-visible {
   }
 
   .shell-main-scroll {
-    padding: 1.5rem 1.25rem 2rem;
+    padding: 1.5rem 1.25rem 5rem;
+  }
+}
+
+.shell-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  border-top: 1px solid var(--ui-border);
+  background: var(--ui-bg-soft);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.shell-bottom-nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.5rem 0.25rem 0.4rem;
+  text-decoration: none;
+  color: var(--ui-text-muted);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: color 120ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.shell-bottom-nav-item svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.shell-bottom-nav-item--active {
+  color: var(--ui-text);
+}
+
+@media (min-width: 1024px) {
+  .shell-bottom-nav {
+    display: none;
   }
 }
 

--- a/web-ui/src/lib/navigation.js
+++ b/web-ui/src/lib/navigation.js
@@ -104,6 +104,11 @@ const SHELL_CONTENT_RULES = [
     mode: "wide",
     maxWidth: "84rem",
   },
+  {
+    match: /^\/more$/,
+    mode: "standard",
+    maxWidth: "42rem",
+  },
 ];
 
 const DEFAULT_SHELL_CONTENT = {

--- a/web-ui/src/lib/navigation.js
+++ b/web-ui/src/lib/navigation.js
@@ -136,6 +136,17 @@ export function isKnownSection(pathname) {
   );
 }
 
+/** When true, the mobile bottom "More" tab should read as active (hub + settings destinations). */
+export function isMoreHubActivePath(pathname) {
+  const p = normalizePathname(pathname);
+  if (p === "/more" || p.startsWith("/more/")) {
+    return true;
+  }
+  return settingsNavItems.some(
+    (item) => p === item.href || p.startsWith(`${item.href}/`),
+  );
+}
+
 export function getShellContentConfig(pathname) {
   const normalizedPathname = normalizePathname(pathname);
 

--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -29,6 +29,7 @@
   import { coreClient } from "$lib/coreClient";
   import {
     getShellContentConfig,
+    isMoreHubActivePath,
     navigationItems,
     settingsNavItems,
   } from "$lib/navigation";
@@ -143,6 +144,7 @@
       : "?",
   );
   let shellContentConfig = $derived(getShellContentConfig(currentAppPath));
+  let moreBottomNavActive = $derived(isMoreHubActivePath(currentAppPath));
   const shellNavForTitle = [...navigationItems, ...settingsNavItems];
 
   let pageTitle = $derived(() => {
@@ -853,11 +855,11 @@
         </a>
       {/each}
       <a
-        class="shell-bottom-nav-item {currentAppPath.startsWith('/more')
+        class="shell-bottom-nav-item {moreBottomNavActive
           ? 'shell-bottom-nav-item--active'
           : ''}"
         href={workspaceHref("/more")}
-        aria-current={currentAppPath.startsWith("/more") ? "page" : undefined}
+        aria-current={moreBottomNavActive ? "page" : undefined}
       >
         <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="5" cy="12" r="1.5" />

--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -70,7 +70,6 @@
   let loadingActors = $state(false);
   let creatingActor = $state(false);
   let newActorName = $state("");
-  let mobileNavOpen = $state(false);
   let hydratedWorkspaceSlug = $state("");
   let workspacePickerOpen = $state(false);
   let commandPaletteOpen = $state(false);
@@ -154,11 +153,6 @@
     const workspaceLabel = activeWorkspace?.label;
     const parts = [section, workspaceLabel, "OAR"].filter(Boolean);
     return parts.join(" · ");
-  });
-
-  $effect(() => {
-    $page.url.pathname;
-    mobileNavOpen = false;
   });
 
   $effect(() => {
@@ -360,7 +354,6 @@
       return;
     }
     clearSelectedActor(localStorage, activeWorkspaceSlug);
-    closeMobileNav();
   }
 
   function buildActorId(displayName) {
@@ -420,20 +413,11 @@
     }
 
     const destination = `${workspacePath(nextWorkspaceSlug, currentAppPath)}${$page.url.search}${$page.url.hash}`;
-    closeMobileNav();
     await goto(destination);
   }
 
   function iconPath(iconType) {
     return navIconPathByType[iconType] || navIconPathByType.inbox;
-  }
-
-  function closeMobileNav() {
-    mobileNavOpen = false;
-  }
-
-  function toggleMobileNav() {
-    mobileNavOpen = !mobileNavOpen;
   }
 
   function workspaceInitials(label) {
@@ -469,7 +453,6 @@
     handleModEnterFormSubmit(event, { commandPaletteOpen });
     if (event.key === "Escape") {
       if (workspacePickerOpen) closeWorkspacePicker();
-      if (mobileNavOpen) closeMobileNav();
     }
   }
 
@@ -821,26 +804,6 @@
 
       <div class="shell-main">
         <header class="shell-mobile-header">
-          <button
-            aria-label="Open navigation menu"
-            class="shell-mobile-menu"
-            onclick={toggleMobileNav}
-            type="button"
-          >
-            <svg
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M4 7h16M4 12h16M4 17h16"
-              />
-            </svg>
-          </button>
           <p>OAR</p>
           <button
             class="shell-mobile-identity"
@@ -852,148 +815,6 @@
           </button>
         </header>
 
-        {#if mobileNavOpen}
-          <div
-            class="shell-mobile-drawer"
-            aria-label="Navigation menu"
-            aria-modal="true"
-            role="dialog"
-          >
-            <button
-              aria-label="Close navigation menu"
-              class="shell-mobile-backdrop"
-              onclick={closeMobileNav}
-              type="button"
-            ></button>
-            <aside class="shell-mobile-panel">
-              <div class="shell-mobile-panel-top">
-                <p>Navigate</p>
-                <button
-                  aria-label="Close navigation menu"
-                  onclick={closeMobileNav}
-                  type="button"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    aria-hidden="true"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <nav class="shell-mobile-nav" aria-label="Primary mobile">
-                {#if hasMultipleWorkspaces}
-                  <div class="mobile-workspace-list">
-                    {#each data.workspaces ?? [] as workspace}
-                      {@const isCurrent =
-                        workspace.slug === activeWorkspaceSlug}
-                      <button
-                        class="workspace-switcher-option"
-                        class:workspace-switcher-option--active={isCurrent}
-                        onclick={() => {
-                          pickWorkspace(workspace.slug);
-                          closeMobileNav();
-                        }}
-                        type="button"
-                      >
-                        <span
-                          class="workspace-switcher-option-icon"
-                          aria-hidden="true"
-                        >
-                          {workspaceInitials(workspace.label)}
-                        </span>
-                        <span class="workspace-switcher-option-label">
-                          <span>{workspace.label}</span>
-                        </span>
-                        {#if isCurrent}
-                          <svg
-                            class="workspace-switcher-check"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            aria-hidden="true"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>
-                        {/if}
-                      </button>
-                    {/each}
-                  </div>
-                {/if}
-                <div class="mobile-workspace-divider"></div>
-                {#each navigationItems as item}
-                  {@const active = isActive(item.href)}
-                  <a
-                    class={`shell-nav-link ${active ? "shell-nav-link--active" : ""}`}
-                    href={workspaceHref(item.href)}
-                    onclick={closeMobileNav}
-                    aria-label={item.label}
-                  >
-                    <svg
-                      class="shell-nav-icon"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      aria-hidden="true"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d={iconPath(item.icon)}
-                      />
-                    </svg>
-                    <span>{item.label}</span>
-                  </a>
-                {/each}
-                <div class="shell-mobile-nav-divider" role="presentation"></div>
-                {#each settingsNavItems as item}
-                  {@const active = isActive(item.href)}
-                  <a
-                    class={`shell-nav-link ${active ? "shell-nav-link--active" : ""}`}
-                    href={workspaceHref(item.href)}
-                    onclick={closeMobileNav}
-                    aria-label={item.label}
-                  >
-                    <svg
-                      class="shell-nav-icon"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      aria-hidden="true"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d={iconPath(item.icon)}
-                      />
-                    </svg>
-                    <span>{item.label}</span>
-                  </a>
-                {/each}
-              </nav>
-              <button
-                class="shell-mobile-switch"
-                onclick={switchIdentity}
-                type="button"
-              >
-                Switch identity
-              </button>
-            </aside>
-          </div>
-        {/if}
-
         <main class="shell-main-scroll">
           <div
             class={`shell-content shell-content--${shellContentConfig.mode}`}
@@ -1004,6 +825,48 @@
         </main>
       </div>
     </div>
+
+    <nav class="shell-bottom-nav" aria-label="Primary navigation">
+      {#each navigationItems as item}
+        {@const active = isActive(item.href)}
+        <a
+          class="shell-bottom-nav-item {active
+            ? 'shell-bottom-nav-item--active'
+            : ''}"
+          href={workspaceHref(item.href)}
+          aria-current={active ? "page" : undefined}
+        >
+          <svg
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.75"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d={iconPath(item.icon)}
+            />
+          </svg>
+          <span>{item.label}</span>
+        </a>
+      {/each}
+      <a
+        class="shell-bottom-nav-item {currentAppPath.startsWith('/more')
+          ? 'shell-bottom-nav-item--active'
+          : ''}"
+        href={workspaceHref("/more")}
+        aria-current={currentAppPath.startsWith("/more") ? "page" : undefined}
+      >
+        <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="5" cy="12" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="19" cy="12" r="1.5" />
+        </svg>
+        <span>More</span>
+      </a>
+    </nav>
   {/if}
 
   {#if activeWorkspaceSlug}

--- a/web-ui/src/routes/[workspace]/boards/+page.svelte
+++ b/web-ui/src/routes/[workspace]/boards/+page.svelte
@@ -234,7 +234,7 @@
 <div class="mb-4 flex flex-wrap items-start justify-between gap-4">
   <div>
     <h1 class="text-lg font-semibold text-[var(--ui-text)]">Boards</h1>
-    <p class="mt-1 text-[12px] text-[var(--ui-text-muted)]">
+    <p class="mt-1 hidden text-[12px] text-[var(--ui-text-muted)] sm:block">
       Canonical visual progress maps over live work. Use them as a trusted scan
       surface, not a disposable kanban layer.
     </p>
@@ -574,7 +574,7 @@
           </div>
         </div>
         <div
-          class="flex shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2"
+          class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
         >
           {#if isBoardArchived(board)}
             <button

--- a/web-ui/src/routes/[workspace]/docs/+page.svelte
+++ b/web-ui/src/routes/[workspace]/docs/+page.svelte
@@ -249,7 +249,7 @@
 <div class="flex items-center justify-between mb-4">
   <div>
     <h1 class="text-lg font-semibold text-[var(--ui-text)]">Docs</h1>
-    <p class="mt-1 text-[12px] text-[var(--ui-text-muted)]">
+    <p class="mt-1 hidden text-[12px] text-[var(--ui-text-muted)] sm:block">
       Canonical document lineages with a mutable head revision and auditable
       history.
     </p>
@@ -538,7 +538,7 @@
       </div>
     </a>
     <div
-      class="flex shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2"
+      class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
       role="presentation"
       onclick={(e) => e.stopPropagation()}
     >

--- a/web-ui/src/routes/[workspace]/inbox/+page.svelte
+++ b/web-ui/src/routes/[workspace]/inbox/+page.svelte
@@ -564,7 +564,7 @@
 <div class="flex items-center justify-between mb-4">
   <div>
     <h1 class="text-lg font-semibold text-[var(--ui-text)]">Inbox</h1>
-    <p class="text-[13px] text-[var(--ui-text-muted)]">
+    <p class="hidden text-[13px] text-[var(--ui-text-muted)] sm:block">
       Sorted by urgency. Oldest items bubble up.
     </p>
   </div>

--- a/web-ui/src/routes/[workspace]/more/+page.svelte
+++ b/web-ui/src/routes/[workspace]/more/+page.svelte
@@ -1,0 +1,239 @@
+<script>
+  import { browser } from "$app/environment";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
+
+  import {
+    actorRegistry,
+    clearSelectedActor,
+    lookupActorDisplayName,
+    principalRegistry,
+    selectedActorId,
+  } from "$lib/actorSession";
+  import { authenticatedAgent, logoutAuthSession } from "$lib/authSession";
+  import { settingsNavItems } from "$lib/navigation";
+  import { workspacePath } from "$lib/workspacePaths";
+
+  const navIconPathByType = {
+    artifacts:
+      "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z",
+    trash:
+      "M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0",
+    access:
+      "M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z",
+  };
+
+  let workspaceSlug = $derived($page.params.workspace);
+  let workspaces = $derived($page.data?.workspaces ?? []);
+  let hasMultipleWorkspaces = $derived(workspaces.length > 1);
+
+  function workspaceHref(path = "/") {
+    return workspacePath(workspaceSlug, path);
+  }
+
+  let selectedActorName = $derived.by(() => {
+    const resolvedName = lookupActorDisplayName(
+      $authenticatedAgent?.actor_id || $selectedActorId,
+      $actorRegistry,
+      $principalRegistry,
+    );
+    if ($authenticatedAgent?.username) return $authenticatedAgent.username;
+    return resolvedName || "Unknown identity";
+  });
+
+  let initials = $derived(
+    selectedActorName
+      ? selectedActorName
+          .split(/\s+/)
+          .map((w) => w[0])
+          .join("")
+          .slice(0, 2)
+          .toUpperCase()
+      : "?",
+  );
+
+  function workspaceInitials(label) {
+    return (label || "?")
+      .split(/[\s-]+/)
+      .map((w) => w[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }
+
+  async function switchIdentity() {
+    if (!workspaceSlug) return;
+    if ($authenticatedAgent) {
+      await logoutAuthSession({ workspaceSlug, clearActor: true });
+      window.location.assign(workspaceHref("/login"));
+      return;
+    }
+    if (browser) clearSelectedActor(localStorage, workspaceSlug);
+  }
+
+  async function switchWorkspace(slug) {
+    if (!slug || slug === workspaceSlug) return;
+    await goto(workspacePath(slug, "/"));
+  }
+</script>
+
+<div class="space-y-4">
+  <!-- Settings navigation -->
+  <section>
+    <p
+      class="mb-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ui-text-muted)]"
+    >
+      Settings
+    </p>
+    <div
+      class="overflow-hidden rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)]"
+    >
+      {#each settingsNavItems as item, i}
+        <a
+          class="flex items-center gap-3 px-4 py-3 text-[13px] font-medium text-[var(--ui-text)] transition-colors hover:bg-[var(--ui-border-subtle)] {i >
+          0
+            ? 'border-t border-[var(--ui-border)]'
+            : ''}"
+          href={workspaceHref(item.href)}
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-[var(--ui-text-muted)]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.75"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d={navIconPathByType[item.icon] ?? ""}
+            />
+          </svg>
+          <span class="flex-1">{item.label}</span>
+          {#if item.hint}
+            <span class="text-[11px] text-[var(--ui-text-muted)]"
+              >{item.hint}</span
+            >
+          {/if}
+          <svg
+            class="h-4 w-4 shrink-0 text-[var(--ui-text-muted)]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 4.5l7.5 7.5-7.5 7.5"
+            />
+          </svg>
+        </a>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Workspace switcher (multi-workspace only) -->
+  {#if hasMultipleWorkspaces}
+    <section>
+      <p
+        class="mb-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ui-text-muted)]"
+      >
+        Workspace
+      </p>
+      <div
+        class="overflow-hidden rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)]"
+      >
+        {#each workspaces as ws, i}
+          {@const isCurrent = ws.slug === workspaceSlug}
+          <button
+            class="flex w-full items-center gap-3 px-4 py-3 text-left text-[13px] transition-colors hover:bg-[var(--ui-border-subtle)] {i >
+            0
+              ? 'border-t border-[var(--ui-border)]'
+              : ''} {isCurrent
+              ? 'font-medium text-[var(--ui-text)]'
+              : 'text-[var(--ui-text-muted)]'}"
+            onclick={() => switchWorkspace(ws.slug)}
+            type="button"
+          >
+            <span
+              class="inline-grid h-6 w-6 shrink-0 place-items-center rounded bg-[var(--ui-accent-strong)] text-[0.5625rem] font-bold text-white"
+              aria-hidden="true"
+            >
+              {workspaceInitials(ws.label)}
+            </span>
+            <span class="flex-1 truncate">{ws.label}</span>
+            {#if isCurrent}
+              <svg
+                class="h-3.5 w-3.5 shrink-0 text-[var(--ui-accent)]"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            {/if}
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Identity -->
+  <section>
+    <p
+      class="mb-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ui-text-muted)]"
+    >
+      Identity
+    </p>
+    <div
+      class="overflow-hidden rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)]"
+    >
+      <div
+        class="flex items-center gap-3 border-b border-[var(--ui-border)] px-4 py-3"
+      >
+        <span
+          class="inline-grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[#4a5060] text-[0.625rem] font-bold text-white"
+          aria-hidden="true"
+        >
+          {initials}
+        </span>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-[13px] font-medium text-[var(--ui-text)]">
+            {selectedActorName}
+          </p>
+          <p class="text-[11px] text-[var(--ui-text-muted)]">
+            {$authenticatedAgent ? "Authenticated principal" : "Dev actor mode"}
+          </p>
+        </div>
+      </div>
+      <button
+        class="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] hover:text-[var(--ui-text)]"
+        onclick={switchIdentity}
+        type="button"
+      >
+        <svg
+          class="h-4 w-4 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.75"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"
+          />
+        </svg>
+        {$authenticatedAgent ? "Sign out" : "Switch identity"}
+      </button>
+    </div>
+  </section>
+</div>

--- a/web-ui/src/routes/[workspace]/threads/+page.svelte
+++ b/web-ui/src/routes/[workspace]/threads/+page.svelte
@@ -410,12 +410,12 @@
       {listSurface === "topics" ? "Topics" : "Threads"}
     </h1>
     {#if listSurface === "topics"}
-      <p class="mt-1 text-[12px] text-[var(--ui-text-muted)]">
+      <p class="mt-1 hidden text-[12px] text-[var(--ui-text-muted)] sm:block">
         Primary organizational surface. Each topic has a backing thread for
         events and provenance.
       </p>
     {:else}
-      <p class="mt-1 text-[12px] text-[var(--ui-text-muted)]">
+      <p class="mt-1 hidden text-[12px] text-[var(--ui-text-muted)] sm:block">
         Diagnostic list of append-only backing threads (timelines). Not every
         thread is a topic; prefer
         <a
@@ -439,7 +439,7 @@
         Show archived
       </label>
       <span
-        class="inline-flex items-center gap-1 rounded border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] text-[var(--ui-text-muted)]"
+        class="hidden items-center gap-1 rounded border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] text-[var(--ui-text-muted)] sm:inline-flex"
       >
         <svg
           class="h-3 w-3"
@@ -848,7 +848,7 @@
             </div>
           </a>
           <div
-            class="flex shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2"
+            class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
           >
             {#if isTopicArchived(topic)}
               <button

--- a/web-ui/tests/unit/navigation.test.js
+++ b/web-ui/tests/unit/navigation.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getShellContentConfig,
   isKnownSection,
+  isMoreHubActivePath,
   navigationItems,
   settingsNavItems,
 } from "../../src/lib/navigation.js";
@@ -41,5 +42,16 @@ describe("navigation model", () => {
     const config = getShellContentConfig("/access");
     expect(config.mode).toBe("wide");
     expect(config.maxWidth).toBe("84rem");
+  });
+
+  it("marks mobile More tab active for hub and settings routes", () => {
+    expect(isMoreHubActivePath("/more")).toBe(true);
+    expect(isMoreHubActivePath("/more/")).toBe(true);
+    expect(isMoreHubActivePath("/artifacts")).toBe(true);
+    expect(isMoreHubActivePath("/artifacts/abc")).toBe(true);
+    expect(isMoreHubActivePath("/trash")).toBe(true);
+    expect(isMoreHubActivePath("/access")).toBe(true);
+    expect(isMoreHubActivePath("/inbox")).toBe(false);
+    expect(isMoreHubActivePath("/")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Shell:** Viewport-locked `.shell-frame` with scroll confined to `.shell-main-scroll`; `min-height: 0` on flex children for correct overflow.
- **Mobile navigation:** Fixed bottom tab bar below 1024px (five primary routes + **More**); safe-area inset; extra bottom padding on main scroll until the desktop breakpoint restores `2.5rem` bottom padding.
- **More hub:** New `[workspace]/more` page aggregates settings links (Artifacts, Trash, Access), optional workspace switcher, and identity / sign-out, replacing the removed slide-out drawer.
- **Mobile header:** Compact OAR + identity control only.
- **List pages:** Subtitles hidden on narrow viewports; ⌘K shortcut chip and narrow row action rails deferred to `sm+`.

## Review notes

- **Semantics:** Bottom `<nav>` uses `aria-label="Primary navigation"` but includes **More** (settings-adjacent). Consider a broader label or split if a11y review flags it.
- **Sidebar parity:** Desktop unchanged; secondary nav remains in the sidebar footer.

## Validation

- `make -C web-ui check` (lint, Prettier, unit tests, core proxy path audit)
