### PR TITLE
feat(cli): default empty list fields to [] for card/board/topic creation

### DIFF
--- a/cli/internal/app/id_resolution.go
+++ b/cli/internal/app/id_resolution.go
@@ -193,6 +193,21 @@ func shouldResolveDisplayedShortID(raw string) bool {
 	return len(strings.TrimSpace(raw)) == shortIDLength
 }
 
+func ensureEmptyListDefaults(body map[string]any, nestKey string, fields []string) {
+	if body == nil {
+		return
+	}
+	nested, _ := body[nestKey].(map[string]any)
+	if nested == nil {
+		return
+	}
+	for _, field := range fields {
+		if _, exists := nested[field]; !exists {
+			nested[field] = []any{}
+		}
+	}
+}
+
 func deepCloneJSONValue(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:

--- a/cli/internal/app/import_commands.go
+++ b/cli/internal/app/import_commands.go
@@ -401,10 +401,12 @@ func (a *App) runImportApply(ctx context.Context, args []string, cfg config.Reso
 			var err error
 			switch kind {
 			case "thread":
+				ensureEmptyListDefaults(payload, "topic", []string{"owner_refs", "document_refs", "board_refs", "related_refs"})
 				result, err = a.invokeTypedJSON(ctx, cfg, "topics create", "topics.create", nil, nil, payload)
 			case "artifact":
 				result, err = a.invokeTypedJSON(ctx, cfg, "artifacts create", "artifacts.create", nil, nil, payload)
 			case "doc":
+				ensureEmptyListDefaults(payload, "document", []string{"refs"})
 				result, err = a.invokeTypedJSON(ctx, cfg, "docs create", "docs.create", nil, nil, payload)
 			default:
 				return nil, errnorm.Usage("invalid_request", fmt.Sprintf("unsupported import object kind %q", kind))

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -1495,6 +1495,9 @@ func (a *App) runBoardsCommand(ctx context.Context, args []string, cfg config.Re
 		if err != nil {
 			return nil, "boards create", err
 		}
+		if bodyMap, ok := body.(map[string]any); ok {
+			ensureEmptyListDefaults(bodyMap, "board", []string{"document_refs", "pinned_refs"})
+		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "boards create", "boards.create", nil, nil, body)
 		return result, "boards create", callErr
 	case "get":

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -1815,6 +1815,9 @@ func (a *App) runBoardCardsCommand(ctx context.Context, args []string, cfg confi
 		if err != nil {
 			return nil, "boards cards create", err
 		}
+		if bodyMap, ok := body.(map[string]any); ok {
+			ensureEmptyListDefaults(bodyMap, "card", []string{"assignee_refs", "resolution_refs", "related_refs"})
+		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "boards cards create", "boards.cards.create", map[string]string{"board_id": boardID}, nil, body)
 		return result, "boards cards create", callErr
 	case "get":

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -5007,6 +5007,38 @@ func TestCreateCommandsDefaultEmptyListFields(t *testing.T) {
 		}
 	})
 
+	t.Run("boards_cards_create", func(t *testing.T) {
+		t.Parallel()
+		var receivedBody map[string]any
+		boardID := "board_1"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/boards/"+boardID+"/cards" {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"board":{"id":"` + boardID + `","updated_at":"2026-04-12T00:00:00Z"},"card":{"id":"c1","board_id":"` + boardID + `","title":"C","column_key":"backlog","assignee_refs":[],"resolution_refs":[],"related_refs":[],"provenance":{"sources":[]}}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		home := t.TempDir()
+		env := map[string]string{}
+		input := `{"card":{"title":"C","column_key":"backlog","provenance":{"sources":[]}}}`
+		result := runCLIForTest(t, home, env, strings.NewReader(input), []string{"--json", "--base-url", server.URL, "boards", "cards", "create", "--board-id", boardID})
+		assertEnvelopeOK(t, result)
+
+		card := receivedBody["card"].(map[string]any)
+		for _, field := range []string{"assignee_refs", "resolution_refs", "related_refs"} {
+			val, ok := card[field].([]any)
+			if !ok || len(val) != 0 {
+				t.Fatalf("expected %s to be empty slice, got %#v", field, card[field])
+			}
+		}
+	})
+
 	t.Run("explicit_values_preserved", func(t *testing.T) {
 		t.Parallel()
 		var receivedBody map[string]any

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -4853,3 +4853,191 @@ func anyBoolValue(raw any) bool {
 	value, _ := raw.(bool)
 	return value
 }
+
+func TestEnsureEmptyListDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("injects_missing_fields", func(t *testing.T) {
+		t.Parallel()
+		body := map[string]any{
+			"topic": map[string]any{
+				"title": "test",
+			},
+		}
+		ensureEmptyListDefaults(body, "topic", []string{"owner_refs", "document_refs", "board_refs", "related_refs"})
+		topic := body["topic"].(map[string]any)
+		for _, field := range []string{"owner_refs", "document_refs", "board_refs", "related_refs"} {
+			val, ok := topic[field].([]any)
+			if !ok || len(val) != 0 {
+				t.Fatalf("expected %s to be empty slice, got %#v", field, topic[field])
+			}
+		}
+	})
+
+	t.Run("preserves_existing_values", func(t *testing.T) {
+		t.Parallel()
+		body := map[string]any{
+			"card": map[string]any{
+				"title":         "test",
+				"assignee_refs": []any{"actor:abc"},
+				"related_refs":  []any{},
+			},
+		}
+		ensureEmptyListDefaults(body, "card", []string{"assignee_refs", "resolution_refs", "related_refs"})
+		card := body["card"].(map[string]any)
+		if got := card["assignee_refs"].([]any); len(got) != 1 || got[0] != "actor:abc" {
+			t.Fatalf("expected assignee_refs preserved, got %#v", got)
+		}
+		if got := card["related_refs"].([]any); len(got) != 0 {
+			t.Fatalf("expected related_refs preserved as empty, got %#v", got)
+		}
+		if got := card["resolution_refs"].([]any); len(got) != 0 {
+			t.Fatalf("expected resolution_refs defaulted to empty, got %#v", got)
+		}
+	})
+
+	t.Run("no_op_when_nest_missing", func(t *testing.T) {
+		t.Parallel()
+		body := map[string]any{"title": "test"}
+		ensureEmptyListDefaults(body, "topic", []string{"owner_refs"})
+		if _, exists := body["owner_refs"]; exists {
+			t.Fatal("should not inject at root level")
+		}
+	})
+
+	t.Run("no_op_when_nil", func(t *testing.T) {
+		t.Parallel()
+		ensureEmptyListDefaults(nil, "topic", []string{"owner_refs"})
+	})
+}
+
+func TestCreateCommandsDefaultEmptyListFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("topics_create", func(t *testing.T) {
+		t.Parallel()
+		var receivedBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/topics" {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"topic":{"id":"t1","type":"case","status":"active","title":"T","summary":"S","owner_refs":[],"document_refs":[],"board_refs":[],"related_refs":[],"provenance":{"sources":[]}}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		home := t.TempDir()
+		env := map[string]string{}
+		input := `{"topic":{"type":"case","status":"active","title":"T","summary":"S","provenance":{"sources":[]}}}`
+		result := runCLIForTest(t, home, env, strings.NewReader(input), []string{"--json", "--base-url", server.URL, "topics", "create"})
+		assertEnvelopeOK(t, result)
+
+		topic := receivedBody["topic"].(map[string]any)
+		for _, field := range []string{"owner_refs", "document_refs", "board_refs", "related_refs"} {
+			val, ok := topic[field].([]any)
+			if !ok || len(val) != 0 {
+				t.Fatalf("expected %s to be empty slice, got %#v", field, topic[field])
+			}
+		}
+	})
+
+	t.Run("boards_create", func(t *testing.T) {
+		t.Parallel()
+		var receivedBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/boards" {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"board":{"id":"b1","title":"B","status":"active","document_refs":[],"pinned_refs":[],"provenance":{"sources":[]}}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		home := t.TempDir()
+		env := map[string]string{}
+		input := `{"board":{"title":"B","status":"active","provenance":{"sources":[]}}}`
+		result := runCLIForTest(t, home, env, strings.NewReader(input), []string{"--json", "--base-url", server.URL, "boards", "create"})
+		assertEnvelopeOK(t, result)
+
+		board := receivedBody["board"].(map[string]any)
+		for _, field := range []string{"document_refs", "pinned_refs"} {
+			val, ok := board[field].([]any)
+			if !ok || len(val) != 0 {
+				t.Fatalf("expected %s to be empty slice, got %#v", field, board[field])
+			}
+		}
+	})
+
+	t.Run("cards_create", func(t *testing.T) {
+		t.Parallel()
+		var receivedBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/cards" {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"card":{"id":"c1","board_id":"board_1","title":"C","summary":"S","column_key":"backlog","assignee_refs":[],"resolution_refs":[],"related_refs":[],"provenance":{"sources":[]}}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		home := t.TempDir()
+		env := map[string]string{}
+		input := `{"board_ref":"board:board_1","card":{"title":"C","summary":"S","column_key":"backlog","provenance":{"sources":[]}}}`
+		result := runCLIForTest(t, home, env, strings.NewReader(input), []string{"--json", "--base-url", server.URL, "cards", "create"})
+		assertEnvelopeOK(t, result)
+
+		card := receivedBody["card"].(map[string]any)
+		for _, field := range []string{"assignee_refs", "resolution_refs", "related_refs"} {
+			val, ok := card[field].([]any)
+			if !ok || len(val) != 0 {
+				t.Fatalf("expected %s to be empty slice, got %#v", field, card[field])
+			}
+		}
+	})
+
+	t.Run("explicit_values_preserved", func(t *testing.T) {
+		t.Parallel()
+		var receivedBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/topics" {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"topic":{"id":"t1"}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		home := t.TempDir()
+		env := map[string]string{}
+		input := `{"topic":{"type":"case","status":"active","title":"T","summary":"S","owner_refs":["actor:x"],"document_refs":[],"board_refs":["board:y"],"related_refs":[],"provenance":{"sources":[]}}}`
+		result := runCLIForTest(t, home, env, strings.NewReader(input), []string{"--json", "--base-url", server.URL, "topics", "create"})
+		assertEnvelopeOK(t, result)
+
+		topic := receivedBody["topic"].(map[string]any)
+		if refs := topic["owner_refs"].([]any); len(refs) != 1 || refs[0] != "actor:x" {
+			t.Fatalf("expected owner_refs preserved, got %#v", refs)
+		}
+		if refs := topic["document_refs"].([]any); len(refs) != 0 {
+			t.Fatalf("expected document_refs preserved as empty, got %#v", refs)
+		}
+		if refs := topic["board_refs"].([]any); len(refs) != 1 || refs[0] != "board:y" {
+			t.Fatalf("expected board_refs preserved, got %#v", refs)
+		}
+	})
+}

--- a/cli/internal/app/resource_topics_cards.go
+++ b/cli/internal/app/resource_topics_cards.go
@@ -58,6 +58,9 @@ func (a *App) runTopicsCommand(ctx context.Context, args []string, cfg config.Re
 		if err != nil {
 			return nil, "topics create", err
 		}
+		if bodyMap, ok := body.(map[string]any); ok {
+			ensureEmptyListDefaults(bodyMap, "topic", []string{"owner_refs", "document_refs", "board_refs", "related_refs"})
+		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "topics create", "topics.create", nil, nil, body)
 		return result, "topics create", callErr
 	case "patch":
@@ -130,6 +133,9 @@ func (a *App) runCardsCommand(ctx context.Context, args []string, cfg config.Res
 		body, err := a.parseJSONBodyInput(args[1:], "cards create")
 		if err != nil {
 			return nil, "cards create", err
+		}
+		if bodyMap, ok := body.(map[string]any); ok {
+			ensureEmptyListDefaults(bodyMap, "card", []string{"assignee_refs", "resolution_refs", "related_refs"})
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "cards create", "cards.create", nil, nil, body)
 		return result, "cards create", callErr


### PR DESCRIPTION
Closes #178

## Summary

Eliminates boilerplate when creating cards, boards, and topics via the CLI. Required list fields are now automatically defaulted to `[]` when omitted from the JSON body.

## Before

Every card creation required 3 empty lists:
```json
{
  "card": {
    "title": "Do the thing",
    "summary": "...",
    "column_key": "backlog",
    "assignee_refs": [],
    "related_refs": [],
    "resolution_refs": []
  }
}
```

## After

```json
{
  "card": {
    "title": "Do the thing",
    "summary": "...",
    "column_key": "backlog"
  }
}
```

## Changes

- **`cli/internal/app/id_resolution.go`** — New `ensureEmptyListDefaults` helper
- **`cli/internal/app/resource_topics_cards.go`** — Topics/cards create handlers inject defaults
- **`cli/internal/app/resource_commands.go`** — Boards create handler injects defaults
- **`cli/internal/app/resource_commands_test.go`** — Unit + integration tests

## Validation

- `make cli-check` — all tests pass
- `make -C core check` — passes
- Explicit `[]` values still work (no regression)