### PR TITLE
Inbox triage refactor, seed updates, and standardized archive/trash controls

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -243,11 +243,9 @@ draft
 - Read next: oar draft create ; oar draft list ; oar draft commit
 
 Inbox categories:
-- `decision_needed`: A human must choose among multiple viable paths.
-- `intervention_needed`: The next step is clear, but a human must act because the agent cannot execute it.
-- `work_item_risk`: A card or work item is at risk or overdue and needs follow-up.
-- `stale_topic`: A topic appears stale; review cadence or recent activity.
-- `document_attention`: A document needs human review or follow-up.
+- `action_needed`: A human must decide, take direct action, or own the next step (includes prior decision and intervention queue signals).
+- `risk_exception`: Exceptions, stale cadence, or at-risk work items that need follow-up.
+- `attention`: Review or lighter operator focus (for example document attention).
 
 For the fuller operating model, read `oar meta doc agent-guide`.
 ```
@@ -3426,11 +3424,9 @@ View scoping:
   - Switch perspective with `--agent <profile>` or `OAR_AGENT` before reading or acting.
 
 Inbox categories:
-  - `decision_needed`: A human must choose among multiple viable paths.
-  - `intervention_needed`: The next step is clear, but a human must act because the agent cannot execute it.
-  - `work_item_risk`: A card or work item is at risk or overdue and needs follow-up.
-  - `stale_topic`: A topic appears stale; review cadence or recent activity.
-  - `document_attention`: A document needs human review or follow-up.
+  - `action_needed`: A human must decide, take direct action, or own the next step (includes prior decision and intervention queue signals).
+  - `risk_exception`: Exceptions, stale cadence, or at-risk work items that need follow-up.
+  - `attention`: Review or lighter operator focus (for example document attention).
 
 Global flags:
   Global flags can appear before or after the command path.

--- a/cli/internal/app/concepts_guide.go
+++ b/cli/internal/app/concepts_guide.go
@@ -79,11 +79,9 @@ var conceptsGuidePrimitives = []conceptsPrimitive{
 }
 
 var inboxCategoryReference = []namedDescription{
-	{Name: "decision_needed", Description: "A human must choose among multiple viable paths."},
-	{Name: "intervention_needed", Description: "The next step is clear, but a human must act because the agent cannot execute it."},
-	{Name: "work_item_risk", Description: "A card or work item is at risk or overdue and needs follow-up."},
-	{Name: "stale_topic", Description: "A topic appears stale; review cadence or recent activity."},
-	{Name: "document_attention", Description: "A document needs human review or follow-up."},
+	{Name: "action_needed", Description: "A human must decide, take direct action, or own the next step (includes prior decision and intervention queue signals)."},
+	{Name: "risk_exception", Description: "Exceptions, stale cadence, or at-risk work items that need follow-up."},
+	{Name: "attention", Description: "Review or lighter operator focus (for example document attention)."},
 }
 
 func inboxCategoryReferenceMap() map[string]string {

--- a/cli/internal/app/draft_commands_test.go
+++ b/cli/internal/app/draft_commands_test.go
@@ -198,7 +198,7 @@ func TestValidateDraftBodySupportsInboxAcknowledge(t *testing.T) {
 	errors := validateDraftBody("inbox.acknowledge", map[string]any{
 		"actor_id":      "actor_1",
 		"subject_ref":   "thread:thread_1",
-		"inbox_item_id": "inbox:decision_needed:thread_1:none:event_1",
+		"inbox_item_id": "inbox:action_needed:thread_1:none:event_1",
 	})
 	if len(errors) != 0 {
 		t.Fatalf("expected inbox.acknowledge draft validation to pass, got %#v", errors)

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -849,11 +849,9 @@ Note: by default, archived and trashed events are excluded from the timeline out
   - Switch perspective with ` + "`--agent <profile>`" + ` or ` + "`OAR_AGENT`" + ` before reading or acting.
 
 Inbox categories:
-  - ` + "`decision_needed`" + `: A human must choose among multiple viable paths.
-  - ` + "`intervention_needed`" + `: The next step is clear, but a human must act because the agent cannot execute it.
-  - ` + "`work_item_risk`" + `: A card or work item is at risk or overdue and needs follow-up.
-  - ` + "`stale_topic`" + `: A topic appears stale; review cadence or recent activity.
-  - ` + "`document_attention`" + `: A document needs human review or follow-up.`)
+  - ` + "`action_needed`" + `: A human must decide, take direct action, or own the next step (includes prior decision and intervention queue signals).
+  - ` + "`risk_exception`" + `: Exceptions, stale cadence, or at-risk work items that need follow-up.
+  - ` + "`attention`" + `: Review or lighter operator focus (for example document attention).`)
 	case "inbox.acknowledge":
 		return strings.TrimSpace(`CLI flags (` + "`inbox acknowledge`" + ` / ` + "`inbox ack`" + `):
   --inbox-item-id <id>   Inbox item id or list alias (see ` + "`inbox list`" + `).

--- a/cli/internal/app/meta_help_test.go
+++ b/cli/internal/app/meta_help_test.go
@@ -285,7 +285,7 @@ func TestInboxListHelpMentionsViewingAsAndCategories(t *testing.T) {
 	if !strings.Contains(output, "viewing_as") {
 		t.Fatalf("expected viewing_as scoping guidance output=%s", output)
 	}
-	if !strings.Contains(output, "`decision_needed`") || !strings.Contains(output, "`work_item_risk`") {
+	if !strings.Contains(output, "`action_needed`") || !strings.Contains(output, "`risk_exception`") {
 		t.Fatalf("expected inbox category reference output=%s", output)
 	}
 }

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -879,7 +879,7 @@ func (a *App) runThreadsRecommendationsCommand(ctx context.Context, args []strin
 	}
 	inboxData := asMap(inboxResult.Data)
 	inboxBody := extractNestedMap(inboxData, "body")
-	pendingDecisions := filteredInboxItems(asSlice(inboxBody["items"]), []string{resolvedThreadID}, []string{"decision_needed"})
+	pendingDecisions := filteredInboxItems(asSlice(inboxBody["items"]), []string{resolvedThreadID}, []string{"action_needed"})
 	relatedThreadReview, err := a.collectRelatedThreadRecommendationReview(ctx, cfg, resolvedThreadID, body, selection.threadContextSelection, selection.includeRelatedEventContent)
 	if err != nil {
 		return nil, err
@@ -2852,7 +2852,7 @@ func (a *App) runInboxList(ctx context.Context, args []string, cfg config.Resolv
 		}
 		threadIDs = resolvedThreadIDs
 	}
-	typeFilters := normalizeStringFilters(typeFlags.values)
+	typeFilters := normalizeInboxListTypeFilters(normalizeStringFilters(typeFlags.values))
 
 	result, err := a.invokeTypedJSON(ctx, cfg, "inbox list", "inbox.list", nil, nil, nil)
 	if err != nil {
@@ -4600,6 +4600,45 @@ func normalizeIDFilters(rawIDs []string) []string {
 	return out
 }
 
+// normalizeInboxCategoryForCLIFilter maps legacy inbox category/type strings onto the
+// canonical contract enum so `inbox list --type` stays usable after API normalization.
+// Mirrors core normalizeInboxCategoryForContract.
+func normalizeInboxCategoryForCLIFilter(category string) string {
+	category = strings.TrimSpace(category)
+	switch category {
+	case "action_needed", "risk_exception", "attention":
+		return category
+	case "decision_needed":
+		return "action_needed"
+	case "intervention_needed", "stale_topic", "work_item_risk", "risk_review":
+		return "risk_exception"
+	case "document_attention":
+		return "attention"
+	default:
+		return category
+	}
+}
+
+func normalizeInboxListTypeFilters(types []string) []string {
+	if len(types) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(types))
+	seen := make(map[string]struct{}, len(types))
+	for _, inboxType := range types {
+		canon := normalizeInboxCategoryForCLIFilter(inboxType)
+		if canon == "" {
+			continue
+		}
+		if _, ok := seen[canon]; ok {
+			continue
+		}
+		seen[canon] = struct{}{}
+		out = append(out, canon)
+	}
+	return out
+}
+
 func filteredInboxItems(items []any, threadIDs []string, types []string) []any {
 	if len(items) == 0 {
 		return []any{}
@@ -4618,7 +4657,7 @@ func filteredInboxItems(items []any, threadIDs []string, types []string) []any {
 		if inboxType == "" {
 			continue
 		}
-		typeFilter[inboxType] = struct{}{}
+		typeFilter[normalizeInboxCategoryForCLIFilter(inboxType)] = struct{}{}
 	}
 
 	filtered := make([]any, 0, len(items))
@@ -4634,7 +4673,8 @@ func filteredInboxItems(items []any, threadIDs []string, types []string) []any {
 			}
 		}
 		if len(typeFilter) > 0 {
-			if _, ok := typeFilter[inboxItemType(item)]; !ok {
+			canon := normalizeInboxCategoryForCLIFilter(inboxItemType(item))
+			if _, ok := typeFilter[canon]; !ok {
 				continue
 			}
 		}

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -214,7 +214,7 @@ func TestInboxGetAliasMapsToList(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"items":[{"id":"inbox:1","thread_id":"thread_1","category":"decision_needed"}]}`))
+		_, _ = w.Write([]byte(`{"items":[{"id":"inbox:1","thread_id":"thread_1","category":"action_needed"}]}`))
 	}))
 	defer server.Close()
 
@@ -231,7 +231,7 @@ func TestInboxGetAliasMapsToList(t *testing.T) {
 		t.Fatalf("expected viewing_as actor_id actor_123, got %#v", payload)
 	}
 	categoryReference, _ := data["category_reference"].(map[string]any)
-	if got := anyStringValue(categoryReference["decision_needed"]); !strings.Contains(got, "multiple viable paths") {
+	if got := anyStringValue(categoryReference["action_needed"]); !strings.Contains(got, "must decide") {
 		t.Fatalf("expected category reference in alias response, got %#v", payload)
 	}
 	items, _ := data["items"].([]any)
@@ -239,7 +239,7 @@ func TestInboxGetAliasMapsToList(t *testing.T) {
 		t.Fatalf("expected one inbox item, got %#v", payload)
 	}
 	item, _ := items[0].(map[string]any)
-	if got := anyStringValue(item["category_description"]); !strings.Contains(got, "multiple viable paths") {
+	if got := anyStringValue(item["category_description"]); !strings.Contains(got, "must decide") {
 		t.Fatalf("expected per-item category_description in alias response, got %#v", payload)
 	}
 }
@@ -247,7 +247,7 @@ func TestInboxGetAliasMapsToList(t *testing.T) {
 func TestInboxListIncludesAliasesAndLinkedShortIDs(t *testing.T) {
 	t.Parallel()
 
-	const inboxID = "inbox:decision_needed:thread_1234567890:none:event_1234567890"
+	const inboxID = "inbox:action_needed:thread_1234567890:none:event_1234567890"
 	const threadID = "thread_1234567890"
 	const eventID = "event_1234567890"
 
@@ -288,7 +288,7 @@ func TestInboxListIncludesAliasesAndLinkedShortIDs(t *testing.T) {
 func TestInboxListSupportsClientSideThreadAndTypeFilters(t *testing.T) {
 	t.Parallel()
 
-	const matchingID = "inbox:decision_needed:thread_1234567890:none:event_1234567890"
+	const matchingID = "inbox:action_needed:thread_1234567890:none:event_1234567890"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/inbox" {
@@ -297,8 +297,8 @@ func TestInboxListSupportsClientSideThreadAndTypeFilters(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[
-			{"id":"` + matchingID + `","thread_id":"thread_1234567890","type":"decision_needed","summary":"needs approval"},
-			{"id":"inbox:decision_needed:thread_other:none:event_other","thread_id":"thread_other","type":"decision_needed","summary":"other thread"},
+			{"id":"` + matchingID + `","thread_id":"thread_1234567890","type":"action_needed","summary":"needs approval"},
+			{"id":"inbox:action_needed:thread_other:none:event_other","thread_id":"thread_other","type":"action_needed","summary":"other thread"},
 			{"id":"inbox:review:thread_1234567890:none:event_review","thread_id":"thread_1234567890","type":"review_needed","summary":"other type"}
 		]}`))
 	}))
@@ -310,7 +310,7 @@ func TestInboxListSupportsClientSideThreadAndTypeFilters(t *testing.T) {
 		"--base-url", server.URL,
 		"inbox", "list",
 		"--thread-id", "thread_1234567890",
-		"--type", "decision_needed",
+		"--type", "action_needed",
 		"--full-id",
 	})
 	payload := assertEnvelopeOK(t, raw)
@@ -323,7 +323,7 @@ func TestInboxListSupportsClientSideThreadAndTypeFilters(t *testing.T) {
 		t.Fatalf("expected full_id=true, got %#v", data)
 	}
 	types := stringList(data["types"])
-	if len(types) != 1 || types[0] != "decision_needed" {
+	if len(types) != 1 || types[0] != "action_needed" {
 		t.Fatalf("expected filtered types, got %#v", data)
 	}
 	items, _ := data["items"].([]any)
@@ -339,17 +339,17 @@ func TestInboxListSupportsClientSideThreadAndTypeFilters(t *testing.T) {
 		"--base-url", server.URL,
 		"inbox", "list",
 		"--thread-id", "thread_1234567890",
-		"--type", "decision_needed",
+		"--type", "action_needed",
 	})
 	if !strings.Contains(human, "total_items: 3") || !strings.Contains(human, "returned_items: 1") {
 		t.Fatalf("expected rendered inbox counts in human output, got:\n%s", human)
 	}
 }
 
-func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
+func TestInboxListTypeFilterAcceptsLegacyCategoryAliases(t *testing.T) {
 	t.Parallel()
 
-	const inboxID = "inbox:decision_needed:thread_123:none:event_123"
+	const matchingID = "inbox:action_needed:thread_1234567890:none:event_1234567890"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/inbox" {
@@ -357,7 +357,49 @@ func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"items":[{"id":"` + inboxID + `","thread_id":"thread_123","category":"decision_needed","title":"Choose launch date"}]}`))
+		_, _ = w.Write([]byte(`{"items":[
+			{"id":"` + matchingID + `","thread_id":"thread_1234567890","category":"action_needed","summary":"needs approval"},
+			{"id":"inbox:risk_exception:thread_1234567890:none:event_other","thread_id":"thread_1234567890","category":"risk_exception","summary":"risk"}
+		]}`))
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{
+		"--json",
+		"--base-url", server.URL,
+		"inbox", "list",
+		"--thread-id", "thread_1234567890",
+		"--type", "decision_needed",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	types := stringList(data["types"])
+	if len(types) != 1 || types[0] != "action_needed" {
+		t.Fatalf("expected normalized types in response, got %#v", data)
+	}
+	items, _ := data["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("expected one filtered inbox item, got %#v", data)
+	}
+	item, _ := items[0].(map[string]any)
+	if got := anyStringValue(item["id"]); got != matchingID {
+		t.Fatalf("expected matching inbox item %q, got %#v", matchingID, data)
+	}
+}
+
+func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
+	t.Parallel()
+
+	const inboxID = "inbox:action_needed:thread_123:none:event_123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/inbox" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"` + inboxID + `","thread_id":"thread_123","category":"action_needed","title":"Choose launch date"}]}`))
 	}))
 	defer server.Close()
 
@@ -383,15 +425,15 @@ func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
 		t.Fatalf("expected viewing_as actor_id actor_123, got %#v", data)
 	}
 	categoryReference, _ := data["category_reference"].(map[string]any)
-	if got := anyStringValue(categoryReference["decision_needed"]); !strings.Contains(got, "multiple viable paths") {
-		t.Fatalf("expected decision_needed category description, got %#v", data)
+	if got := anyStringValue(categoryReference["action_needed"]); !strings.Contains(got, "must decide") {
+		t.Fatalf("expected action_needed category description, got %#v", data)
 	}
 	items, _ := data["items"].([]any)
 	if len(items) != 1 {
 		t.Fatalf("expected one inbox item, got %#v", data)
 	}
 	item, _ := items[0].(map[string]any)
-	if got := anyStringValue(item["category_description"]); !strings.Contains(got, "multiple viable paths") {
+	if got := anyStringValue(item["category_description"]); !strings.Contains(got, "must decide") {
 		t.Fatalf("expected item category_description, got %#v", item)
 	}
 
@@ -403,7 +445,7 @@ func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
 	if !strings.Contains(human, "viewing_as: profile=agent-a :: username=agent.alpha :: actor_id=actor_123") {
 		t.Fatalf("expected viewing_as summary in human output, got:\n%s", human)
 	}
-	if !strings.Contains(human, "category_reference:") || !strings.Contains(human, "decision_needed: A human must choose among multiple viable paths.") {
+	if !strings.Contains(human, "category_reference:") || !strings.Contains(human, "action_needed: A human must decide") {
 		t.Fatalf("expected category reference in human output, got:\n%s", human)
 	}
 }
@@ -411,8 +453,8 @@ func TestInboxListIncludesViewingAsAndCategoryReference(t *testing.T) {
 func TestInboxAliasStableAcrossListMembershipChanges(t *testing.T) {
 	t.Parallel()
 
-	const targetID = "inbox:decision_needed:thread_target:none:event_target"
-	const otherID = "inbox:decision_needed:thread_other:none:event_other"
+	const targetID = "inbox:action_needed:thread_target:none:event_target"
+	const otherID = "inbox:action_needed:thread_other:none:event_other"
 
 	aliasSingle := inboxAliasByID([]string{targetID})[targetID]
 	aliasWithOther := inboxAliasByID([]string{targetID, otherID})[targetID]
@@ -430,7 +472,7 @@ func TestInboxAliasStableAcrossListMembershipChanges(t *testing.T) {
 func TestInboxAckAliasUsesSubjectRefFromInboxList(t *testing.T) {
 	t.Parallel()
 
-	const inboxID = "inbox:decision_needed:thread_42:none:event_42"
+	const inboxID = "inbox:action_needed:thread_42:none:event_42"
 	alias := inboxAliasByID([]string{inboxID})[inboxID]
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1710,7 +1752,7 @@ func TestNormalizeMutationBodyIDsResolvesInboxAcknowledgeSubjectRef(t *testing.T
 
 	body := map[string]any{
 		"subject_ref":   "thread:thread_12345",
-		"inbox_item_id": "inbox:decision_needed:thread_1234567890:none:event_1",
+		"inbox_item_id": "inbox:action_needed:thread_1234567890:none:event_1",
 	}
 
 	normalizedAny, err := app.normalizeMutationBodyIDs(
@@ -2615,7 +2657,7 @@ func TestThreadsInspectBuildsCoordinationView(t *testing.T) {
 	t.Parallel()
 
 	const eventID = "event_1234567890abcdef"
-	const inboxID = "inbox:decision_needed:thread_1:none:event_1234567890abcdef"
+	const inboxID = "inbox:action_needed:thread_1:none:event_1234567890abcdef"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2632,8 +2674,8 @@ func TestThreadsInspectBuildsCoordinationView(t *testing.T) {
 			}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
 			_, _ = w.Write([]byte(`{"items":[
-				{"id":"` + inboxID + `","thread_id":"thread_1","type":"decision_needed","summary":"launch date still needs acknowledgement"},
-				{"id":"inbox:decision_needed:thread_2:none:event_other","thread_id":"thread_2","type":"decision_needed","summary":"other thread"}
+				{"id":"` + inboxID + `","thread_id":"thread_1","type":"action_needed","summary":"launch date still needs acknowledgement"},
+				{"id":"inbox:action_needed:thread_2:none:event_other","thread_id":"thread_2","type":"action_needed","summary":"other thread"}
 			]}`))
 		default:
 			http.NotFound(w, r)
@@ -2757,7 +2799,7 @@ func TestThreadsRecommendationsBuildsFocusedReview(t *testing.T) {
 	const recommendationID = "event_rec_1234567890abcdef"
 	const decisionNeededID = "event_need_1"
 	const decisionMadeID = "event_done_1"
-	const inboxID = "inbox:decision_needed:thread_1:none:event_need_1"
+	const inboxID = "inbox:action_needed:thread_1:none:event_need_1"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2775,8 +2817,8 @@ func TestThreadsRecommendationsBuildsFocusedReview(t *testing.T) {
 			}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
 			_, _ = w.Write([]byte(`{"items":[
-				{"id":"` + inboxID + `","thread_id":"thread_1","type":"decision_needed","summary":"launch date still needs acknowledgement"},
-				{"id":"inbox:decision_needed:thread_2:none:event_other","thread_id":"thread_2","type":"decision_needed","summary":"other thread"}
+				{"id":"` + inboxID + `","thread_id":"thread_1","type":"action_needed","summary":"launch date still needs acknowledgement"},
+				{"id":"inbox:action_needed:thread_2:none:event_other","thread_id":"thread_2","type":"action_needed","summary":"other thread"}
 			]}`))
 		default:
 			http.NotFound(w, r)
@@ -3385,7 +3427,7 @@ func TestThreadsRecommendationsFullSummaryToggle(t *testing.T) {
 func TestThreadsRecommendationsCountsPendingDecisionsInTotalWhenRecentWindowExcludesReviewEvents(t *testing.T) {
 	t.Parallel()
 
-	const pendingInboxID = "inbox:decision_needed:thread_1:none:event_pending_1"
+	const pendingInboxID = "inbox:action_needed:thread_1:none:event_pending_1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -3400,7 +3442,7 @@ func TestThreadsRecommendationsCountsPendingDecisionsInTotalWhenRecentWindowExcl
 			}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
 			_, _ = w.Write([]byte(`{"items":[
-				{"id":"` + pendingInboxID + `","thread_id":"thread_1","type":"decision_needed","summary":"pending approval remains"}
+				{"id":"` + pendingInboxID + `","thread_id":"thread_1","type":"action_needed","summary":"pending approval remains"}
 			]}`))
 		default:
 			http.NotFound(w, r)
@@ -3969,7 +4011,7 @@ func TestInboxAckPositionalInboxItemIDRequiresSubjectRefFromInboxList(t *testing
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/inbox":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"items":[{"id":"inbox:decision_needed:thread_42:none:event_1","thread_id":"thread_42"}],"generated_at":"2026-03-05T00:00:00Z"}`))
+			_, _ = w.Write([]byte(`{"items":[{"id":"inbox:action_needed:thread_42:none:event_1","thread_id":"thread_42"}],"generated_at":"2026-03-05T00:00:00Z"}`))
 			return
 		default:
 			http.NotFound(w, r)
@@ -3983,7 +4025,7 @@ func TestInboxAckPositionalInboxItemIDRequiresSubjectRefFromInboxList(t *testing
 		"--json",
 		"--base-url", server.URL,
 		"inbox", "ack",
-		"inbox:decision_needed:thread_42:none:event_1",
+		"inbox:action_needed:thread_42:none:event_1",
 	})
 	payload := assertEnvelopeError(t, raw)
 	errObj, _ := payload["error"].(map[string]any)
@@ -4322,14 +4364,14 @@ func TestMachineFacingTargetedCommandGoldens(t *testing.T) {
 					"inbox":{
 						"thread_id":"thread_123",
 						"items":[
-							{"id":"inbox:decision_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"decision_needed","summary":"confirm canonical command labels"}
+							{"id":"inbox:action_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"action_needed","summary":"confirm canonical command labels"}
 						],
 						"count":1
 					},
 					"pending_decisions":{
 						"thread_id":"thread_123",
 						"items":[
-							{"id":"inbox:decision_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"decision_needed","summary":"confirm canonical command labels"}
+							{"id":"inbox:action_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"action_needed","summary":"confirm canonical command labels"}
 						],
 						"count":1
 					},
@@ -4385,7 +4427,7 @@ func TestMachineFacingTargetedCommandGoldens(t *testing.T) {
 					"count":1
 				},
 				"documents":{"items":[{"id":"doc_ctx_1","title":"Runbook","state":"active"}],"count":1},
-				"inbox":{"items":[{"id":"inbox:decision_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"decision_needed"}],"count":1},
+				"inbox":{"items":[{"id":"inbox:action_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"action_needed"}],"count":1},
 				"board_summary":{
 					"card_count":1,
 					"cards_by_column":{"backlog":0,"ready":0,"in_progress":1,"blocked":0,"review":0,"done":0},
@@ -4402,8 +4444,8 @@ func TestMachineFacingTargetedCommandGoldens(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
 					"items":[
-					{"id":"inbox:decision_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"decision_needed","summary":"confirm canonical command labels"},
-					{"id":"inbox:decision_needed:thread_other:none:event_other","thread_id":"thread_other","type":"decision_needed","summary":"ignore other thread"}
+					{"id":"inbox:action_needed:thread_123:none:event_ctx_2","thread_id":"thread_123","type":"action_needed","summary":"confirm canonical command labels"},
+					{"id":"inbox:action_needed:thread_other:none:event_other","thread_id":"thread_other","type":"action_needed","summary":"ignore other thread"}
 				]
 			}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/events/stream":

--- a/cli/internal/app/testdata/boards_workspace_machine.golden.json
+++ b/cli/internal/app/testdata/boards_workspace_machine.golden.json
@@ -73,9 +73,9 @@
       "count": 1,
       "items": [
         {
-          "id": "inbox:decision_needed:thread_123:none:event_ctx_2",
+          "id": "inbox:action_needed:thread_123:none:event_ctx_2",
           "thread_id": "thread_123",
-          "type": "decision_needed"
+          "type": "action_needed"
         }
       ]
     },

--- a/cli/internal/app/testdata/threads_inspect_machine.golden.json
+++ b/cli/internal/app/testdata/threads_inspect_machine.golden.json
@@ -98,12 +98,12 @@
       "items": [
         {
           "alias": "ibx_483c273add26",
-          "id": "inbox:decision_needed:thread_123:none:event_ctx_2",
-          "short_id": "inbox:decisi",
+          "id": "inbox:action_needed:thread_123:none:event_ctx_2",
+          "short_id": "inbox:action",
           "summary": "confirm canonical command labels",
           "thread_id": "thread_123",
           "thread_short_id": "thread_123",
-          "type": "decision_needed"
+          "type": "action_needed"
         }
       ],
       "thread_id": "thread_123"

--- a/cli/internal/app/testdata/threads_recommendations_machine.golden.json
+++ b/cli/internal/app/testdata/threads_recommendations_machine.golden.json
@@ -39,12 +39,12 @@
       "items": [
         {
           "alias": "ibx_483c273add26",
-          "id": "inbox:decision_needed:thread_123:none:event_ctx_2",
-          "short_id": "inbox:decisi",
+          "id": "inbox:action_needed:thread_123:none:event_ctx_2",
+          "short_id": "inbox:action",
           "summary": "confirm canonical command labels",
           "thread_id": "thread_123",
           "thread_short_id": "thread_123",
-          "type": "decision_needed"
+          "type": "action_needed"
         }
       ]
     },

--- a/cli/internal/app/testdata/threads_workspace_machine.golden.json
+++ b/cli/internal/app/testdata/threads_workspace_machine.golden.json
@@ -100,10 +100,10 @@
       "full_id": false,
       "items": [
         {
-          "id": "inbox:decision_needed:thread_123:none:event_ctx_2",
+          "id": "inbox:action_needed:thread_123:none:event_ctx_2",
           "summary": "confirm canonical command labels",
           "thread_id": "thread_123",
-          "type": "decision_needed"
+          "type": "action_needed"
         }
       ],
       "thread_id": "thread_123"
@@ -113,10 +113,10 @@
       "count": 1,
       "items": [
         {
-          "id": "inbox:decision_needed:thread_123:none:event_ctx_2",
+          "id": "inbox:action_needed:thread_123:none:event_ctx_2",
           "summary": "confirm canonical command labels",
           "thread_id": "thread_123",
-          "type": "decision_needed"
+          "type": "action_needed"
         }
       ],
       "thread_id": "thread_123"

--- a/contracts/oar-openapi.yaml
+++ b/contracts/oar-openapi.yaml
@@ -4143,18 +4143,17 @@ components:
         id: { type: string }
         category:
           type: string
-          enum: [decision_needed, intervention_needed, stale_topic, work_item_risk, document_attention]
+          enum: [action_needed, risk_exception, attention]
         thread_id:
           type: string
           description: Backing thread id for the inbox item and decision actions.
         subject_ref: { $ref: '#/components/schemas/TypedRef' }
         source_event_ref: { $ref: '#/components/schemas/TypedRef' }
         title: { type: string }
-        recommended_action: { type: string }
         related_refs:
           type: array
           items: { $ref: '#/components/schemas/TypedRef' }
-      required: [id, category, subject_ref, title, recommended_action, related_refs]
+      required: [id, category, subject_ref, title, related_refs]
 
     TopicWriteInput:
       type: object

--- a/contracts/oar-schema.yaml
+++ b/contracts/oar-schema.yaml
@@ -41,7 +41,11 @@ enums:
 
   inbox_category:
     enum_policy: strict
-    values: [decision_needed, intervention_needed, stale_topic, work_item_risk, document_attention]
+    description: >
+      Three operator-facing inbox buckets. `attention` is reserved for document-review
+      and similar signals when core surfaces them; v0 derivation primarily emits
+      `action_needed` and `risk_exception`.
+    values: [action_needed, risk_exception, attention]
 
   agent_notification_status:
     enum_policy: strict
@@ -500,7 +504,6 @@ derived:
       subject_ref: { type: typed_ref, required: true }
       source_event_ref: { type: typed_ref, required: false }
       title: { type: string, required: true }
-      recommended_action: { type: string, required: true }
       related_refs: { type: "list<typed_ref>", required: true }
 
   agent_notification:
@@ -560,4 +563,4 @@ staleness:
     observed inside its expected operating window.
   on_stale:
     - "Emit exception_raised with subtype stale_topic"
-    - "Surface a derived inbox item in category stale_topic"
+    - "Surface a derived inbox item in category risk_exception (subtype stale_topic identifies the exception shape)"

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -3,6 +3,8 @@
 
 # Runtime workspace
 .oar-workspace/
+# Ephemeral workspace roots from seed/verify scripts (unique path per run; same artifacts as above)
+.oar-workspace-seed-verify-*/
 
 # Go build/test artifacts
 bin/

--- a/core/docs/oar-core-spec.md
+++ b/core/docs/oar-core-spec.md
@@ -310,7 +310,7 @@ Topics define work freshness; staleness is evaluated against topic activity and 
 When staleness is detected by background maintenance or a deterministic derived
 rebuild, oar-core MUST:
 - Emit an `exception_raised` event with subtype `stale_topic`.
-- Surface the topic as an inbox item with category `stale_topic`.
+- Surface the topic as an inbox item with category `risk_exception` (the exception subtype remains `stale_topic` on the event).
 
 Read handlers MUST NOT mint stale-topic exceptions as a side effect of GET
 requests.

--- a/core/internal/primitives/derived_store.go
+++ b/core/internal/primitives/derived_store.go
@@ -198,7 +198,9 @@ func (s *Store) ListDerivedInboxItems(ctx context.Context, filter DerivedInboxLi
 		if leftOrder != rightOrder {
 			return leftOrder < rightOrder
 		}
-		if left.Category == "work_item_risk" && right.Category == "work_item_risk" && left.HasDueAt && right.HasDueAt && left.DueAt != right.DueAt {
+		if (left.Category == "risk_exception" || left.Category == "work_item_risk") &&
+			(right.Category == "risk_exception" || right.Category == "work_item_risk") &&
+			left.HasDueAt && right.HasDueAt && left.DueAt != right.DueAt {
 			return left.DueAt < right.DueAt
 		}
 		if left.TriggerAt != right.TriggerAt {
@@ -581,16 +583,12 @@ func boolToInt(value bool) int {
 
 func derivedInboxCategoryOrder(category string) int {
 	switch strings.TrimSpace(category) {
-	case "decision_needed":
+	case "action_needed", "decision_needed":
 		return 0
-	case "intervention_needed":
+	case "risk_exception", "intervention_needed", "stale_topic", "work_item_risk":
 		return 1
-	case "stale_topic":
+	case "attention", "document_attention":
 		return 2
-	case "work_item_risk":
-		return 3
-	case "document_attention":
-		return 4
 	default:
 		return 99
 	}

--- a/core/internal/server/api_comprehensive_integration_test.go
+++ b/core/internal/server/api_comprehensive_integration_test.go
@@ -226,15 +226,15 @@ func TestComprehensiveHTTPAPIFlow(t *testing.T) {
 	for _, item := range inboxItems {
 		categories[asString(item["category"])] = true
 	}
-	if !categories["work_item_risk"] || !categories["stale_topic"] || !categories["decision_needed"] {
-		t.Fatalf("expected inbox categories work_item_risk/stale_topic/decision_needed, got %#v", categories)
+	if !categories["risk_exception"] || !categories["action_needed"] {
+		t.Fatalf("expected inbox categories risk_exception and action_needed, got %#v", categories)
 	}
 
 	decisionItem, ok := findInboxItem(inboxItems, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == threadID
 	})
 	if !ok {
-		t.Fatalf("expected decision_needed item for thread %s, got %#v", threadID, inboxItems)
+		t.Fatalf("expected action_needed item for thread %s, got %#v", threadID, inboxItems)
 	}
 	decisionItemID := asString(decisionItem["id"])
 
@@ -272,7 +272,7 @@ func TestComprehensiveHTTPAPIFlow(t *testing.T) {
 
 	inboxAfterRetrigger := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(inboxAfterRetrigger, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["source_event_id"]) == newDecisionEventID
+		return asString(item["category"]) == "action_needed" && asString(item["source_event_id"]) == newDecisionEventID
 	}); !ok {
 		t.Fatalf("expected retriggered decision item, got %#v", inboxAfterRetrigger)
 	}

--- a/core/internal/server/derived_projections.go
+++ b/core/internal/server/derived_projections.go
@@ -68,7 +68,7 @@ func refreshDerivedTopicProjection(ctx context.Context, opts handlerOptions, thr
 	rawKeyArtifacts, _ := extractStringSlice(thread["key_artifacts"])
 	pendingDecisions := 0
 	for _, item := range inboxItems {
-		if item.Category == "decision_needed" {
+		if item.Category == "action_needed" {
 			pendingDecisions++
 		}
 	}

--- a/core/internal/server/inbox_handlers.go
+++ b/core/internal/server/inbox_handlers.go
@@ -116,9 +116,21 @@ func typedRefStringsToAnyList(refs []string) []any {
 	return out
 }
 
+func isWorkItemRiskStyleCategory(category string) bool {
+	switch strings.TrimSpace(category) {
+	case "risk_exception", "work_item_risk":
+		return true
+	default:
+		return false
+	}
+}
+
 func isEventSourcedInboxCategory(category string) bool {
 	switch strings.TrimSpace(category) {
-	case "decision_needed", "intervention_needed", "stale_topic":
+	case "action_needed", "risk_exception", "attention":
+		return true
+	// Legacy stored rows may still use pre-simplification category strings.
+	case "decision_needed", "intervention_needed", "stale_topic", "document_attention":
 		return true
 	default:
 		return false
@@ -187,7 +199,7 @@ func backfillInboxRelatedRefsFromStoredData(m map[string]any, h inboxContractHin
 			merged = append(merged, strings.TrimSpace(r))
 		}
 	}
-	if cat == "work_item_risk" {
+	if cat == "risk_exception" || cat == "work_item_risk" {
 		if bid := strings.TrimSpace(anyString(m["board_id"])); bid != "" {
 			merged = append(merged, "board:"+bid)
 		}
@@ -195,7 +207,7 @@ func backfillInboxRelatedRefsFromStoredData(m map[string]any, h inboxContractHin
 	if tid != "" {
 		merged = append(merged, "thread:"+tid)
 	}
-	if cat == "work_item_risk" {
+	if cat == "risk_exception" || cat == "work_item_risk" {
 		if docRef := strings.TrimSpace(anyString(m["document_ref"])); docRef != "" {
 			if _, docID, err := schema.SplitTypedRef(docRef); err == nil && docID != "" {
 				merged = append(merged, "document:"+docID)
@@ -205,9 +217,28 @@ func backfillInboxRelatedRefsFromStoredData(m map[string]any, h inboxContractHin
 	return typedRefStringsToAnyList(mergeUniqueSortedRefs(merged...))
 }
 
+// normalizeInboxCategoryForContract maps legacy stored categories and pre-simplification
+// values onto enums.inbox_category so HTTP payloads stay OpenAPI-valid.
+func normalizeInboxCategoryForContract(category string) string {
+	category = strings.TrimSpace(category)
+	switch category {
+	case "action_needed", "risk_exception", "attention":
+		return category
+	case "decision_needed":
+		return "action_needed"
+	case "intervention_needed", "stale_topic", "work_item_risk", "risk_review":
+		return "risk_exception"
+	case "document_attention":
+		return "attention"
+	default:
+		return category
+	}
+}
+
 // applyInboxContractShape ensures OpenAPI-required InboxItem fields (subject_ref, related_refs)
 // and optional source_event_ref are present for list/get/stream payloads. Callers may rely on
-// this for legacy derived rows that predate contract-first shaping.
+// this for legacy derived rows that predate contract-first shaping. Drops deprecated
+// recommended_action so older stored rows do not leak removed contract fields.
 func applyInboxContractShape(m map[string]any, h inboxContractHint) {
 	if m == nil {
 		return
@@ -216,7 +247,7 @@ func applyInboxContractShape(m map[string]any, h inboxContractHint) {
 	tid := strings.TrimSpace(h.ThreadID)
 
 	if strings.TrimSpace(anyString(m["subject_ref"])) == "" {
-		if cat == "work_item_risk" {
+		if cat == "risk_exception" || cat == "work_item_risk" {
 			if cid := strings.TrimSpace(h.SourceCardID); cid != "" {
 				m["subject_ref"] = "card:" + cid
 			}
@@ -241,6 +272,16 @@ func applyInboxContractShape(m map[string]any, h inboxContractHint) {
 			}
 		}
 	}
+
+	rawCat := strings.TrimSpace(anyString(m["category"]))
+	if rawCat == "" {
+		rawCat = cat
+	}
+	if rawCat != "" {
+		m["category"] = normalizeInboxCategoryForContract(rawCat)
+	}
+
+	delete(m, "recommended_action")
 }
 
 const defaultInboxRiskHorizon = 7 * 24 * time.Hour
@@ -382,8 +423,12 @@ func handleGetInboxItem(w http.ResponseWriter, r *http.Request, opts handlerOpti
 			return
 		}
 
+		wantedIDs := make(map[string]struct{})
+		for _, id := range inboxItemIDVariants(inboxItemID) {
+			wantedIDs[id] = struct{}{}
+		}
 		for _, item := range items {
-			if strings.TrimSpace(item.ID) != inboxItemID {
+			if _, ok := wantedIDs[item.ID]; !ok {
 				continue
 			}
 			writeJSON(w, http.StatusOK, map[string]any{
@@ -411,13 +456,19 @@ func handleGetInboxItem(w http.ResponseWriter, r *http.Request, opts handlerOpti
 		return
 	}
 
-	item, err := opts.primitiveStore.GetDerivedInboxItem(r.Context(), inboxItemID)
-	if err != nil {
-		if errors.Is(err, primitives.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "not_found", "inbox item not found")
+	var item primitives.DerivedInboxItem
+	for _, candidate := range inboxItemIDVariants(inboxItemID) {
+		item, err = opts.primitiveStore.GetDerivedInboxItem(r.Context(), candidate)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, primitives.ErrNotFound) {
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load inbox projections")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "internal_error", "failed to load inbox projections")
+	}
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "inbox item not found")
 		return
 	}
 
@@ -715,7 +766,9 @@ func decidedInboxItemIDs(events []map[string]any) map[string]struct{} {
 			if err != nil || prefix != "inbox" {
 				continue
 			}
-			out[value] = struct{}{}
+			for _, variantID := range inboxItemIDVariants(value) {
+				out[variantID] = struct{}{}
+			}
 		}
 	}
 	return out
@@ -754,28 +807,58 @@ func latestInboxAcknowledgments(events []map[string]any) map[string]time.Time {
 	return ackedAt
 }
 
-func inboxAckSuppressionIDs(inboxItemID string) []string {
+// equivalentInboxCategories lists category strings that share the same inbox id tuple
+// (thread, subject, source event) across contract renames, so acks and decision_made
+// refs remain correlated after category enum changes.
+func equivalentInboxCategories(category string) []string {
+	category = strings.TrimSpace(category)
+	switch category {
+	case "action_needed", "decision_needed":
+		return []string{"action_needed", "decision_needed"}
+	case "risk_exception", "intervention_needed", "stale_topic", "work_item_risk", "risk_review":
+		return []string{"risk_exception", "intervention_needed", "stale_topic", "work_item_risk", "risk_review"}
+	case "attention", "document_attention":
+		return []string{"attention", "document_attention"}
+	default:
+		return []string{category}
+	}
+}
+
+func inboxItemIDVariants(inboxItemID string) []string {
 	inboxItemID = strings.TrimSpace(inboxItemID)
 	if inboxItemID == "" {
 		return nil
 	}
-	ids := []string{inboxItemID}
-	parts := strings.SplitN(inboxItemID, ":", 6)
+	parts := strings.SplitN(inboxItemID, ":", 5)
 	if len(parts) != 5 || parts[0] != "inbox" {
-		return ids
+		return []string{inboxItemID}
 	}
 	category := strings.TrimSpace(parts[1])
 	threadID := strings.TrimSpace(parts[2])
 	subjectID := strings.TrimSpace(parts[3])
 	sourceEventID := strings.TrimSpace(parts[4])
-	switch category {
-	case "risk_review":
-		ids = append(ids, makeInboxItemID("work_item_risk", threadID, subjectID, sourceEventID))
-	case "work_item_risk":
-		// Preserve suppression across rebuilds in either direction while the rename settles.
-		ids = append(ids, makeInboxItemID("risk_review", threadID, subjectID, sourceEventID))
+
+	out := make([]string, 0, 8)
+	seen := map[string]struct{}{}
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
-	return ids
+	for _, cat := range equivalentInboxCategories(category) {
+		add(makeInboxItemID(cat, threadID, subjectID, sourceEventID))
+	}
+	return out
+}
+
+func inboxAckSuppressionIDs(inboxItemID string) []string {
+	return inboxItemIDVariants(inboxItemID)
 }
 
 func deriveEventBackedInboxItem(event map[string]any) (derivedInboxItem, bool) {
@@ -788,25 +871,19 @@ func deriveEventBackedInboxItem(event map[string]any) (derivedInboxItem, bool) {
 	}
 
 	category := ""
-	recommendedAction := ""
 	titleFallback := ""
 	switch eventType {
 	case "decision_needed":
-		category = "decision_needed"
-		recommendedAction = "make_decision"
+		category = "action_needed"
 		titleFallback = "Decision needed"
 	case "intervention_needed":
-		category = "intervention_needed"
-		recommendedAction = "take_action"
+		category = "risk_exception"
 		titleFallback = "Intervention needed"
 	case "exception_raised":
+		category = "risk_exception"
 		if isStaleTopicException(event) {
-			category = "stale_topic"
-			recommendedAction = "review_topic_cadence"
 			titleFallback = "Topic appears stale"
 		} else {
-			category = "intervention_needed"
-			recommendedAction = "investigate_exception"
 			titleFallback = "Exception raised"
 		}
 	default:
@@ -825,14 +902,13 @@ func deriveEventBackedInboxItem(event map[string]any) (derivedInboxItem, bool) {
 
 	id := makeInboxItemID(category, threadID, "", sourceEventID)
 	data := map[string]any{
-		"id":                 id,
-		"category":           category,
-		"thread_id":          threadID,
-		"source_event_id":    sourceEventID,
-		"subject_ref":        subjectRef,
-		"related_refs":       typedRefStringsToAnyList(related),
-		"title":              title,
-		"recommended_action": recommendedAction,
+		"id":              id,
+		"category":        category,
+		"thread_id":       threadID,
+		"source_event_id": sourceEventID,
+		"subject_ref":     subjectRef,
+		"related_refs":    typedRefStringsToAnyList(related),
+		"title":           title,
 	}
 	if strings.TrimSpace(sourceEventID) != "" {
 		data["source_event_ref"] = "event:" + strings.TrimSpace(sourceEventID)
@@ -873,29 +949,20 @@ func deriveWorkItemRiskInboxItem(card map[string]any, now time.Time, riskHorizon
 		title = "Work item risk"
 	}
 
-	recommendedAction := "follow_up_work_item"
-	switch riskState {
-	case "overdue":
-		recommendedAction = "resolve_overdue_work_item"
-	case "blocked":
-		recommendedAction = "unblock_work_item"
-	}
-
 	subjectRef := "card:" + cardID
 	related := workItemRiskInboxRelatedRefs(card, threadID)
 
-	id := makeInboxItemID("work_item_risk", threadID, cardID, "")
+	id := makeInboxItemID("risk_exception", threadID, cardID, "")
 	data := map[string]any{
-		"id":                 id,
-		"category":           "work_item_risk",
-		"thread_id":          threadID,
-		"card_id":            cardID,
-		"board_id":           nullableStringValue(anyString(card["board_id"])),
-		"subject_ref":        subjectRef,
-		"related_refs":       typedRefStringsToAnyList(related),
-		"title":              title,
-		"risk_state":         riskState,
-		"recommended_action": recommendedAction,
+		"id":           id,
+		"category":     "risk_exception",
+		"thread_id":    threadID,
+		"card_id":      cardID,
+		"board_id":     nullableStringValue(anyString(card["board_id"])),
+		"subject_ref":  subjectRef,
+		"related_refs": typedRefStringsToAnyList(related),
+		"title":        title,
+		"risk_state":   riskState,
 	}
 	if hasDueAt {
 		data["due_at"] = dueAt.Format(time.RFC3339)
@@ -906,7 +973,7 @@ func deriveWorkItemRiskInboxItem(card map[string]any, now time.Time, riskHorizon
 
 	return derivedInboxItem{
 		Data:      data,
-		Category:  "work_item_risk",
+		Category:  "risk_exception",
 		ID:        id,
 		TriggerAt: triggerAt,
 		DueAt:     dueAt,
@@ -1007,11 +1074,14 @@ func parseOptionalRFC3339(raw string) (time.Time, bool) {
 
 func sortInboxItems(items []derivedInboxItem) {
 	categoryOrder := map[string]int{
+		"action_needed":       0,
 		"decision_needed":     0,
+		"risk_exception":      1,
 		"intervention_needed": 1,
-		"stale_topic":         2,
-		"work_item_risk":      3,
-		"document_attention":  4,
+		"stale_topic":         1,
+		"work_item_risk":      1,
+		"attention":           2,
+		"document_attention":  2,
 	}
 
 	sort.Slice(items, func(i int, j int) bool {
@@ -1030,7 +1100,7 @@ func sortInboxItems(items []derivedInboxItem) {
 			return leftOrder < rightOrder
 		}
 
-		if left.Category == "work_item_risk" && right.Category == "work_item_risk" {
+		if isWorkItemRiskStyleCategory(left.Category) && isWorkItemRiskStyleCategory(right.Category) {
 			if left.HasDueAt && right.HasDueAt && !left.DueAt.Equal(right.DueAt) {
 				return left.DueAt.Before(right.DueAt)
 			}

--- a/core/internal/server/inbox_integration_test.go
+++ b/core/internal/server/inbox_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -50,10 +51,10 @@ func TestInboxDerivationAndAcknowledgmentSuppression(t *testing.T) {
 
 	items := getInboxItems(t, h.baseURL)
 	decisionItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["source_event_id"]) == firstDecisionEventID
+		return asString(item["category"]) == "action_needed" && asString(item["source_event_id"]) == firstDecisionEventID
 	})
 	if !ok {
-		t.Fatalf("expected decision_needed inbox item for source_event_id=%s, got %#v", firstDecisionEventID, items)
+		t.Fatalf("expected action_needed inbox item for source_event_id=%s, got %#v", firstDecisionEventID, items)
 	}
 	firstDecisionItemID := asString(decisionItem["id"])
 	if firstDecisionItemID == "" {
@@ -103,7 +104,7 @@ func TestInboxDerivationAndAcknowledgmentSuppression(t *testing.T) {
 
 	itemsAfterNewDecision := getInboxItems(t, h.baseURL)
 	secondDecisionItem, ok := findInboxItem(itemsAfterNewDecision, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["source_event_id"]) == secondDecisionEventID
+		return asString(item["category"]) == "action_needed" && asString(item["source_event_id"]) == secondDecisionEventID
 	})
 	if !ok {
 		t.Fatalf("expected new decision item after retrigger, got %#v", itemsAfterNewDecision)
@@ -161,10 +162,10 @@ func TestInboxDerivationAndAcknowledgmentSuppression(t *testing.T) {
 
 	itemsWithRisk := getInboxItems(t, h.baseURL)
 	riskItem, ok := findInboxItem(itemsWithRisk, func(item map[string]any) bool {
-		return asString(item["category"]) == "work_item_risk" && asString(item["card_id"]) == cardID
+		return asString(item["category"]) == "risk_exception" && asString(item["card_id"]) == cardID
 	})
 	if !ok {
-		t.Fatalf("expected work_item_risk inbox item, got %#v", itemsWithRisk)
+		t.Fatalf("expected risk_exception inbox item, got %#v", itemsWithRisk)
 	}
 	riskItemID := asString(riskItem["id"])
 
@@ -177,7 +178,7 @@ func TestInboxDerivationAndAcknowledgmentSuppression(t *testing.T) {
 	if _, exists := findInboxItem(itemsAfterRiskAck, func(item map[string]any) bool {
 		return asString(item["id"]) == riskItemID
 	}); exists {
-		t.Fatalf("expected acknowledged work_item_risk item to be suppressed, got %#v", itemsAfterRiskAck)
+		t.Fatalf("expected acknowledged risk_exception item to be suppressed, got %#v", itemsAfterRiskAck)
 	}
 
 	patchResp := patchJSONExpectStatus(t, h.baseURL+"/cards/"+cardID, `{
@@ -192,9 +193,9 @@ func TestInboxDerivationAndAcknowledgmentSuppression(t *testing.T) {
 		return asString(item["id"]) == riskItemID
 	})
 	if !ok {
-		t.Fatalf("expected work_item_risk item to reappear after new trigger, got %#v", itemsAfterStatusChange)
+		t.Fatalf("expected risk_exception item to reappear after new trigger, got %#v", itemsAfterStatusChange)
 	}
-	if asString(reappearedRisk["category"]) != "work_item_risk" {
+	if asString(reappearedRisk["category"]) != "risk_exception" {
 		t.Fatalf("unexpected reappeared risk item: %#v", reappearedRisk)
 	}
 }
@@ -251,7 +252,7 @@ func TestInboxAcknowledgmentResolvesTopicSubjectRefToBackingThread(t *testing.T)
 
 	items := getInboxItems(t, h.baseURL)
 	decisionItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == backingThreadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == backingThreadID
 	})
 	if !ok {
 		t.Fatalf("expected decision inbox item, got %#v", items)
@@ -328,10 +329,10 @@ func TestInboxAcknowledgmentResolvesCardSubjectRefViaCardRelatedThread(t *testin
 
 	items := getInboxItems(t, h.baseURL)
 	riskItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "work_item_risk" && asString(item["card_id"]) == cardID
+		return asString(item["category"]) == "risk_exception" && asString(item["card_id"]) == cardID
 	})
 	if !ok {
-		t.Fatalf("expected work_item_risk inbox item, got %#v", items)
+		t.Fatalf("expected risk_exception inbox item, got %#v", items)
 	}
 	inboxItemID := asString(riskItem["id"])
 
@@ -412,10 +413,10 @@ func TestLegacyRiskReviewAckStillSuppressesWorkItemRiskAfterRebuild(t *testing.T
 
 	itemsWithRisk := getInboxItems(t, h.baseURL)
 	riskItem, ok := findInboxItem(itemsWithRisk, func(item map[string]any) bool {
-		return asString(item["category"]) == "work_item_risk" && asString(item["card_id"]) == cardID
+		return asString(item["category"]) == "risk_exception" && asString(item["card_id"]) == cardID
 	})
 	if !ok {
-		t.Fatalf("expected work_item_risk inbox item, got %#v", itemsWithRisk)
+		t.Fatalf("expected risk_exception inbox item, got %#v", itemsWithRisk)
 	}
 	canonicalRiskID := asString(riskItem["id"])
 	legacyRiskID := makeInboxItemID("risk_review", threadID, cardID, "")
@@ -429,9 +430,9 @@ func TestLegacyRiskReviewAckStillSuppressesWorkItemRiskAfterRebuild(t *testing.T
 
 	itemsAfterAckAndRebuild := getInboxItems(t, h.baseURL)
 	if _, exists := findInboxItem(itemsAfterAckAndRebuild, func(item map[string]any) bool {
-		return asString(item["id"]) == canonicalRiskID || (asString(item["category"]) == "work_item_risk" && asString(item["card_id"]) == cardID)
+		return asString(item["id"]) == canonicalRiskID || (asString(item["category"]) == "risk_exception" && asString(item["card_id"]) == cardID)
 	}); exists {
-		t.Fatalf("expected legacy risk_review ack to suppress canonical work_item_risk item after rebuild, got %#v", itemsAfterAckAndRebuild)
+		t.Fatalf("expected legacy risk_review ack to suppress canonical risk_exception item after rebuild, got %#v", itemsAfterAckAndRebuild)
 	}
 }
 
@@ -469,7 +470,7 @@ func TestInboxAcknowledgmentRejectsTopicSubjectRefWhenNoTopicRow(t *testing.T) {
 
 	items := getInboxItems(t, h.baseURL)
 	decisionItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == threadID
 	})
 	if !ok {
 		t.Fatalf("expected decision inbox item, got %#v", items)
@@ -518,7 +519,7 @@ func TestInboxAcknowledgmentRejectsLegacyThreadIDBody(t *testing.T) {
 
 	items := getInboxItems(t, h.baseURL)
 	decisionItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == threadID
 	})
 	if !ok {
 		t.Fatalf("expected decision inbox item, got %#v", items)
@@ -620,14 +621,11 @@ func TestInterventionNeededDerivesInboxItem(t *testing.T) {
 	}
 
 	items := getInboxItems(t, h.baseURL)
-	item, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "intervention_needed" && asString(item["source_event_id"]) == eventID
+	_, ok := findInboxItem(items, func(item map[string]any) bool {
+		return asString(item["category"]) == "risk_exception" && asString(item["source_event_id"]) == eventID
 	})
 	if !ok {
-		t.Fatalf("expected intervention_needed inbox item for source_event_id=%s, got %#v", eventID, items)
-	}
-	if got := asString(item["recommended_action"]); got != "take_action" {
-		t.Fatalf("expected recommended_action take_action, got %#v", item)
+		t.Fatalf("expected risk_exception inbox item for source_event_id=%s, got %#v", eventID, items)
 	}
 }
 
@@ -667,10 +665,10 @@ func TestDecisionNeedeSuppressedByDecisionMade(t *testing.T) {
 
 	items := getInboxItems(t, h.baseURL)
 	decisionItem, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == threadID
 	})
 	if !ok {
-		t.Fatalf("expected decision_needed inbox item, got %#v", items)
+		t.Fatalf("expected action_needed inbox item, got %#v", items)
 	}
 	inboxItemID := asString(decisionItem["id"])
 	if inboxItemID == "" {
@@ -695,7 +693,7 @@ func TestDecisionNeedeSuppressedByDecisionMade(t *testing.T) {
 	if _, stillThere := findInboxItem(itemsAfterDecision, func(item map[string]any) bool {
 		return asString(item["id"]) == inboxItemID
 	}); stillThere {
-		t.Fatalf("expected decision_needed inbox item to be suppressed after decision_made, got %#v", itemsAfterDecision)
+		t.Fatalf("expected action_needed inbox item to be suppressed after decision_made, got %#v", itemsAfterDecision)
 	}
 
 	// A new decision_needed on the same thread should still appear (no over-suppression).
@@ -714,9 +712,9 @@ func TestDecisionNeedeSuppressedByDecisionMade(t *testing.T) {
 
 	itemsAfterRetrigger := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(itemsAfterRetrigger, func(item map[string]any) bool {
-		return asString(item["category"]) == "decision_needed" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "action_needed" && asString(item["thread_id"]) == threadID
 	}); !ok {
-		t.Fatalf("expected new decision_needed inbox item after retrigger, got %#v", itemsAfterRetrigger)
+		t.Fatalf("expected new action_needed inbox item after retrigger, got %#v", itemsAfterRetrigger)
 	}
 }
 
@@ -832,7 +830,7 @@ func TestInboxCustomRiskHorizonRetainsStaleExceptions(t *testing.T) {
 	}
 
 	staleItem, ok := findInboxItem(payload.Items, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	})
 	if !ok {
 		t.Fatalf("expected stale exception on custom-horizon inbox read, got %#v", payload.Items)
@@ -860,6 +858,29 @@ func TestInboxCustomRiskHorizonRetainsStaleExceptions(t *testing.T) {
 	}
 	if got := asString(detailPayload.Item["id"]); got != inboxItemID {
 		t.Fatalf("expected stale inbox item id %q, got %q payload=%#v", inboxItemID, got, detailPayload)
+	}
+
+	parts := strings.SplitN(inboxItemID, ":", 5)
+	if len(parts) != 5 || parts[0] != "inbox" {
+		t.Fatalf("unexpected inbox id shape %q", inboxItemID)
+	}
+	legacyID := strings.Join([]string{parts[0], "intervention_needed", parts[2], parts[3], parts[4]}, ":")
+	legacyDetailResp, err := http.Get(h.baseURL + "/inbox/" + url.PathEscape(legacyID) + "?risk_horizon_days=30")
+	if err != nil {
+		t.Fatalf("GET /inbox/{legacy-id}?risk_horizon_days=30: %v", err)
+	}
+	defer legacyDetailResp.Body.Close()
+	if legacyDetailResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected GET /inbox/{legacy-id}?risk_horizon_days=30 status: %d", legacyDetailResp.StatusCode)
+	}
+	var legacyDetail struct {
+		Item map[string]any `json:"item"`
+	}
+	if err := json.NewDecoder(legacyDetailResp.Body).Decode(&legacyDetail); err != nil {
+		t.Fatalf("decode legacy-id inbox item response: %v", err)
+	}
+	if got := asString(legacyDetail.Item["id"]); got != inboxItemID {
+		t.Fatalf("expected legacy id lookup to return canonical id %q, got %q", inboxItemID, got)
 	}
 }
 

--- a/core/internal/server/inbox_logic_test.go
+++ b/core/internal/server/inbox_logic_test.go
@@ -11,13 +11,13 @@ import (
 func TestMakeInboxItemIDDeterministic(t *testing.T) {
 	t.Parallel()
 
-	first := makeInboxItemID("decision_needed", "thread-1", "", "event-1")
-	second := makeInboxItemID("decision_needed", "thread-1", "", "event-1")
+	first := makeInboxItemID("action_needed", "thread-1", "", "event-1")
+	second := makeInboxItemID("action_needed", "thread-1", "", "event-1")
 	if first != second {
 		t.Fatalf("expected deterministic inbox id, got %q and %q", first, second)
 	}
 
-	want := "inbox:decision_needed:thread-1:none:event-1"
+	want := "inbox:action_needed:thread-1:none:event-1"
 	if first != want {
 		t.Fatalf("unexpected inbox id: got %q want %q", first, want)
 	}
@@ -26,8 +26,8 @@ func TestMakeInboxItemIDDeterministic(t *testing.T) {
 func TestMakeInboxItemIDDefaultsNone(t *testing.T) {
 	t.Parallel()
 
-	got := makeInboxItemID("work_item_risk", "thread-1", "", "")
-	want := "inbox:work_item_risk:thread-1:none:none"
+	got := makeInboxItemID("risk_exception", "thread-1", "", "")
+	want := "inbox:risk_exception:thread-1:none:none"
 	if got != want {
 		t.Fatalf("unexpected inbox id defaults: got %q want %q", got, want)
 	}
@@ -44,10 +44,10 @@ func TestLatestInboxAcknowledgmentsMapsLegacyRiskReviewIDs(t *testing.T) {
 		},
 	})
 
-	canonicalID := makeInboxItemID("work_item_risk", "thread-1", "card-1", "")
+	canonicalID := makeInboxItemID("risk_exception", "thread-1", "card-1", "")
 	acked, ok := ackedAt[canonicalID]
 	if !ok {
-		t.Fatalf("expected canonical work_item_risk id %q to be ack-suppressed, got %#v", canonicalID, ackedAt)
+		t.Fatalf("expected canonical risk_exception id %q to be ack-suppressed, got %#v", canonicalID, ackedAt)
 	}
 	if !acked.Equal(time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)) {
 		t.Fatalf("unexpected acknowledgment time: %#v", acked)
@@ -93,7 +93,7 @@ func TestDeriveEventBackedInboxItemSubjectFallsBackToThread(t *testing.T) {
 		"id":        "evt-int-2",
 		"thread_id": "thr-z",
 		"ts":        "2026-04-05T12:00:00Z",
-		"refs":      []any{"inbox:inbox:decision_needed:thr-z:none:e1"},
+		"refs":      []any{"inbox:inbox:action_needed:thr-z:none:e1"},
 		"summary":   "Act",
 	}
 	item, ok := deriveEventBackedInboxItem(ev)
@@ -153,16 +153,18 @@ func TestPayloadFromDerivedInboxItemBackfillsLegacyShape(t *testing.T) {
 		TriggerAt:     "2026-04-05T00:00:00Z",
 		SourceEventID: "",
 		Data: map[string]any{
-			"id":                 "inbox:work_item_risk:thr-1:card-9:none",
-			"category":           "work_item_risk",
-			"thread_id":          "thr-1",
-			"card_id":            "card-9",
-			"board_id":           "brd-9",
-			"title":              "Legacy row",
-			"recommended_action": "follow_up_work_item",
+			"id":        "inbox:work_item_risk:thr-1:card-9:none",
+			"category":  "work_item_risk",
+			"thread_id": "thr-1",
+			"card_id":   "card-9",
+			"board_id":  "brd-9",
+			"title":     "Legacy row",
 		},
 	}
 	out := payloadFromDerivedInboxItem(item)
+	if got := out["category"]; got != "risk_exception" {
+		t.Fatalf("category: got %#v want risk_exception (legacy row normalized for contract)", got)
+	}
 	if got := out["subject_ref"]; got != "card:card-9" {
 		t.Fatalf("subject_ref: got %#v", got)
 	}
@@ -181,15 +183,17 @@ func TestPayloadFromDerivedInboxItemBackfillsLegacyShape(t *testing.T) {
 		SourceEventID: "evt-old",
 		TriggerAt:     "2026-04-05T01:00:00Z",
 		Data: map[string]any{
-			"id":                 "inbox:decision_needed:thr-x:none:evt-old",
-			"category":           "decision_needed",
-			"thread_id":          "thr-x",
-			"source_event_id":    "evt-old",
-			"title":              "Old",
-			"recommended_action": "make_decision",
+			"id":              "inbox:decision_needed:thr-x:none:evt-old",
+			"category":        "decision_needed",
+			"thread_id":       "thr-x",
+			"source_event_id": "evt-old",
+			"title":           "Old",
 		},
 	}
 	out2 := payloadFromDerivedInboxItem(evItem)
+	if got := out2["category"]; got != "action_needed" {
+		t.Fatalf("category: got %#v want action_needed (legacy row normalized for contract)", got)
+	}
 	if got := out2["subject_ref"]; got != "thread:thr-x" {
 		t.Fatalf("event legacy subject_ref: got %#v", got)
 	}

--- a/core/internal/server/projection_maintenance_integration_test.go
+++ b/core/internal/server/projection_maintenance_integration_test.go
@@ -151,7 +151,7 @@ func TestProjectionMaintainerEmitsStaleExceptionsAndRefreshesInbox(t *testing.T)
 	}
 	items := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); !ok {
 		t.Fatalf("expected stale exception inbox item after worker step, got %#v", items)
 	}
@@ -204,7 +204,7 @@ func TestProjectionMaintainerSuppressesStaleInboxAfterNewActivity(t *testing.T) 
 	}
 	items := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); ok {
 		t.Fatalf("expected stale inbox item to be suppressed after new activity, got %#v", items)
 	}

--- a/core/internal/server/staleness_integration_test.go
+++ b/core/internal/server/staleness_integration_test.go
@@ -40,7 +40,7 @@ func TestStalenessRebuildEmitsSingleStaleExceptionAndInboxException(t *testing.T
 
 	items := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); !ok {
 		t.Fatalf("expected stale exception inbox item, got %#v", items)
 	}
@@ -66,7 +66,7 @@ func TestStalenessRebuildEmitsSingleStaleExceptionAndInboxException(t *testing.T
 
 	itemsAfterDecision := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(itemsAfterDecision, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); ok {
 		t.Fatalf("expected stale exception inbox item to be suppressed after new decision activity, got %#v", itemsAfterDecision)
 	}
@@ -114,7 +114,7 @@ func TestStalenessClearsAfterActorStatementAndDocumentActivity(t *testing.T) {
 	}
 	itemsAfterStatement := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(itemsAfterStatement, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); ok {
 		t.Fatalf("expected stale exception inbox item to be suppressed after actor_statement, got %#v", itemsAfterStatement)
 	}
@@ -157,7 +157,7 @@ func TestStalenessClearsAfterActorStatementAndDocumentActivity(t *testing.T) {
 	}
 	itemsAfterDoc := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(itemsAfterDoc, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); ok {
 		t.Fatalf("expected stale exception inbox item to stay suppressed after document update, got %#v", itemsAfterDoc)
 	}
@@ -215,7 +215,7 @@ func TestStalenessRebuildTreatsRecentCardActivityAsFresh(t *testing.T) {
 	}
 	items := getInboxItems(t, h.baseURL)
 	if _, ok := findInboxItem(items, func(item map[string]any) bool {
-		return asString(item["category"]) == "stale_topic" && asString(item["thread_id"]) == threadID
+		return asString(item["category"]) == "risk_exception" && asString(item["thread_id"]) == threadID
 	}); ok {
 		t.Fatalf("expected no stale exception inbox item after recent card activity, got %#v", items)
 	}

--- a/core/internal/server/thread_workspace_handlers.go
+++ b/core/internal/server/thread_workspace_handlers.go
@@ -138,7 +138,7 @@ func buildThreadWorkspacePayload(ctx context.Context, opts handlerOptions, threa
 	if err != nil {
 		return nil, err
 	}
-	pendingDecisions := filterThreadWorkspaceInboxItems(inboxItems, []string{"decision_needed"})
+	pendingDecisions := filterThreadWorkspaceInboxItems(inboxItems, []string{"action_needed"})
 
 	relatedThreadReview := buildEmptyRelatedThreadReview()
 	if related, err := buildThreadWorkspaceRelatedThreadReview(ctx, opts, threadID, contextBody, options); err != nil {

--- a/web-ui/docs/oar-ui-spec.md
+++ b/web-ui/docs/oar-ui-spec.md
@@ -130,9 +130,9 @@ A dedicated surface showing items that need operator attention.
 
 **Display:**
 
-- Inbox items grouped by category: `decision_needed`, `intervention_needed`, `exception`, `stale_topic`.
-- Within each category, sorted by time or due date (no ranking engine in v0).
-- Each item shows: title, category, recommended action, and a link to the relevant topic/board/card/thread.
+- Inbox items grouped by **`category`** using `enums.inbox_category`: `action_needed`, `risk_exception`, and `attention` (aligned with core and OpenAPI). Core v0 derivation mainly emits the first two; `attention` is the canonical bucket for document-review-style items when surfaced. Unknown categories MUST still appear in their own groups (forward compatibility).
+- Within each group, sorted by inferred **urgency** (from category plus trigger/source recency) and then by **source or trigger time**; v0 does not add a separate ranking engine beyond that ordering.
+- Each item shows: title, category, and a link to the relevant topic/board/card/thread.
 - Inbox item IDs are deterministic (see schema) and stable across rebuilds.
 
 **Actions:**

--- a/web-ui/docs/style-guide.md
+++ b/web-ui/docs/style-guide.md
@@ -116,13 +116,11 @@ Urgency escalation follows a fixed hue ladder. Apply these consistently across i
 
 Inbox categories use a fixed color assignment. Use these whenever a category label or count is rendered as a signal (summary cards, badges, section headers):
 
-| Category              | Text              | Badge background     |
-|-----------------------|-------------------|----------------------|
-| `intervention_needed` | `text-red-400`    | `bg-red-500/10`      |
-| `decision_needed`     | `text-indigo-400` | `bg-indigo-500/10`   |
-| `work_item_risk`      | `text-amber-400`  | `bg-amber-500/10`    |
-| `stale_topic`         | `text-orange-400` | `bg-orange-500/10`   |
-| `document_attention`  | `text-sky-400`    | `bg-sky-500/10`      |
+| Category          | Text              | Badge background     |
+|-------------------|-------------------|----------------------|
+| `action_needed`   | `text-indigo-400` | `bg-indigo-500/10`   |
+| `risk_exception`  | `text-amber-400`  | `bg-amber-500/10`    |
+| `attention`       | `text-sky-400`    | `bg-sky-500/10`      |
 
 **Rule:** Color the count only when it is non-zero. Zero counts and category labels for empty queues stay muted. Never apply category color decoratively — only when it carries a live signal.
 

--- a/web-ui/scripts/seed-core-from-mock.mjs
+++ b/web-ui/scripts/seed-core-from-mock.mjs
@@ -327,13 +327,14 @@ async function hasExpectedIdentityRegistrations() {
   const principals = Array.isArray(principalsBody?.principals)
     ? principalsBody.principals
     : [];
+  // Match by actor_id: passkey dev registration derives usernames from display_name
+  // (passkey.*) while fixtures use stable dev.* labels — actor_id is authoritative.
   return seedPersonas.every((persona) =>
-    principals.some((principal) =>
-      String(principal?.username ?? "").trim() ===
-        String(persona?.auth_username ?? "").trim() &&
-      String(principal?.actor_id ?? "").trim() ===
-        String(persona?.actor_id ?? "").trim() &&
-      principal?.wake_routing?.taggable === true,
+    principals.some(
+      (principal) =>
+        String(principal?.actor_id ?? "").trim() ===
+          String(persona?.actor_id ?? "").trim() &&
+        principal?.wake_routing?.taggable === true,
     ),
   );
 }
@@ -1292,32 +1293,36 @@ async function seedDevFixtureIdentities() {
     }
     if (reg?.tokens?.access_token) {
       inviteIssuerAccess = reg.tokens.access_token;
+      const registration = {
+        status: "active",
+        workspace_bindings: [
+          {
+            workspace_id: workspaceID,
+            enabled: true,
+          },
+        ],
+      };
+      // Passkey dev register assigns a synthetic username from display_name; PATCH
+      // must not send fixture auth_username as handle (core requires handle == row username).
+      if (!usePasskeyDevHuman) {
+        registration.handle = p.auth_username;
+        registration.actor_id = p.actor_id;
+      }
       await requestAuthJson(
         "PATCH",
         "/agents/me",
-        {
-          registration: {
-            handle: p.auth_username,
-            actor_id: p.actor_id,
-            status: "active",
-            workspace_bindings: [
-              {
-                workspace_id: workspaceID,
-                enabled: true,
-              },
-            ],
-          },
-        },
+        { registration },
         inviteIssuerAccess,
         [200],
       );
     }
     const agent = reg.agent ?? {};
+    const coreUsername = String(agent.username ?? "").trim();
     bundle.push({
       persona_id: p.persona_id,
       actor_id: p.actor_id,
       agent_id: agent.agent_id,
-      auth_username: p.auth_username,
+      auth_username: coreUsername || p.auth_username,
       display_label: p.display_label,
       principal_kind: p.principal_kind,
       dev_bridge: p.dev_bridge,

--- a/web-ui/src/lib/components/ArchiveButton.svelte
+++ b/web-ui/src/lib/components/ArchiveButton.svelte
@@ -1,0 +1,51 @@
+<script>
+  /**
+   * Archive / Unarchive toggle button.
+   *
+   * When `archived` is false: renders an icon button that triggers the archive action.
+   * When `archived` is true: renders a text "Unarchive" button.
+   *
+   * size: 'sm' → p-1 / h-3.5 w-3.5  (list rows)
+   * size: 'md' → p-1.5 / h-4 w-4    (detail headers)
+   */
+  let {
+    archived = false,
+    busy = false,
+    size = "sm",
+    onarchive,
+    onunarchive,
+  } = $props();
+
+  let iconSize = $derived(size === "md" ? "h-4 w-4" : "h-3.5 w-3.5");
+  let padding = $derived(size === "md" ? "p-1.5" : "p-1");
+</script>
+
+{#if archived}
+  <button
+    class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
+    disabled={busy}
+    onclick={onunarchive}
+    type="button"
+  >
+    Unarchive
+  </button>
+{:else}
+  <button
+    class="cursor-pointer rounded-md {padding} text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+    disabled={busy}
+    onclick={onarchive}
+    title="Archive"
+    type="button"
+  >
+    <svg
+      class={iconSize}
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
+      />
+    </svg>
+  </button>
+{/if}

--- a/web-ui/src/lib/components/BoardCard.svelte
+++ b/web-ui/src/lib/components/BoardCard.svelte
@@ -96,7 +96,7 @@
   function threadStatusColor(status) {
     switch (status) {
       case "done":
-        return "text-emerald-400";
+        return "text-[var(--ui-text)]";
       case "canceled":
         return "text-[var(--ui-text-muted)]";
       case "paused":

--- a/web-ui/src/lib/components/TrashButton.svelte
+++ b/web-ui/src/lib/components/TrashButton.svelte
@@ -1,0 +1,35 @@
+<script>
+  /**
+   * Trash icon button — triggers the move-to-trash action.
+   *
+   * size: 'sm' → p-1 / h-3.5 w-3.5  (list rows)
+   * size: 'md' → p-1.5 / h-4 w-4    (detail headers)
+   */
+  let { busy = false, size = "sm", ontrash } = $props();
+
+  let iconSize = $derived(size === "md" ? "h-4 w-4" : "h-3.5 w-3.5");
+  let padding = $derived(size === "md" ? "p-1.5" : "p-1");
+</script>
+
+<button
+  class="cursor-pointer rounded-md {padding} text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+  disabled={busy}
+  onclick={ontrash}
+  title="Move to trash"
+  type="button"
+>
+  <svg
+    class={iconSize}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    stroke-width="2"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+    />
+  </svg>
+</button>

--- a/web-ui/src/lib/components/timeline/MessageItem.svelte
+++ b/web-ui/src/lib/components/timeline/MessageItem.svelte
@@ -1,7 +1,9 @@
 <script>
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import Self from "$lib/components/timeline/MessageItem.svelte";
   import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
   import RefLink from "$lib/components/RefLink.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import { formatTimestamp } from "$lib/formatDate";
 
   const MAX_REPLY_DEPTH = 48;
@@ -34,68 +36,16 @@
       </p>
     </div>
     <div class="flex shrink-0 items-center gap-0.5">
-      {#if onArchive && !message.archived_at && !message.trashed_at}
-        <button
-          aria-label="Archive message"
-          class="cursor-pointer rounded p-1 text-[var(--ui-text-muted)] hover:bg-[var(--ui-bg-soft)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-          disabled={lifecycleBusy}
-          onclick={() => onArchive(message.id)}
-          type="button"
-        >
-          <svg
-            class="h-3.5 w-3.5"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-            />
-          </svg>
-        </button>
-      {/if}
-      {#if onUnarchive && message.archived_at && !message.trashed_at}
-        <button
-          aria-label="Unarchive message"
-          class="cursor-pointer rounded p-1 text-amber-400 hover:bg-[var(--ui-bg-soft)] hover:text-amber-300 disabled:opacity-50"
-          disabled={lifecycleBusy}
-          onclick={() => onUnarchive(message.id)}
-          type="button"
-        >
-          <svg
-            class="h-3.5 w-3.5"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-            />
-          </svg>
-        </button>
+      {#if !message.trashed_at && ((!message.archived_at && onArchive) || (message.archived_at && onUnarchive))}
+        <ArchiveButton
+          archived={Boolean(message.archived_at)}
+          busy={lifecycleBusy}
+          onarchive={() => onArchive?.(message.id)}
+          onunarchive={() => onUnarchive?.(message.id)}
+        />
       {/if}
       {#if onTrash && !message.trashed_at}
-        <button
-          aria-label="Move message to trash"
-          class="cursor-pointer rounded p-1 text-[var(--ui-text-muted)] hover:bg-[var(--ui-bg-soft)] hover:text-red-400 disabled:opacity-50"
-          disabled={lifecycleBusy}
-          onclick={() => onTrash(message.id)}
-          type="button"
-        >
-          <svg
-            class="h-3.5 w-3.5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-            />
-          </svg>
-        </button>
+        <TrashButton busy={lifecycleBusy} ontrash={() => onTrash(message.id)} />
       {/if}
       {#if !message.archived_at && !message.trashed_at}
         <button

--- a/web-ui/src/lib/components/timeline/MessagesTab.svelte
+++ b/web-ui/src/lib/components/timeline/MessagesTab.svelte
@@ -385,7 +385,7 @@
     </p>
   {:else if !hasMessages}
     <p class="text-[13px] text-[var(--ui-text-muted)]">
-      No messages in view. Turn on Show archived to see archived topics.
+      No messages in view. Turn on Show archived to see archived messages.
     </p>
   {:else}
     {#if lifecycleError}

--- a/web-ui/src/lib/components/timeline/TimelineTab.svelte
+++ b/web-ui/src/lib/components/timeline/TimelineTab.svelte
@@ -8,8 +8,10 @@
     principalRegistry,
   } from "$lib/actorSession";
   import { formatTimestamp } from "$lib/formatDate";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
   import RefLink from "$lib/components/RefLink.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import { toTimelineView, eventTypeDotClass } from "$lib/timelineUtils";
 
   let { threadId } = $props();
@@ -148,7 +150,7 @@
     <div class="space-y-1">
       {#each filteredTimeline as event (event.id)}
         <div
-          class="group rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2.5 {event.archived_at
+          class="rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2.5 {event.archived_at
             ? 'opacity-60'
             : ''}"
           id={`event-${event.id}`}
@@ -173,79 +175,27 @@
                 </p>
               </div>
             </div>
-            <div
-              class="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
-            >
-              {#if event.archived_at}
-                <button
-                  aria-label="Unarchive"
-                  class="cursor-pointer rounded p-1 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-                  disabled={lifecycleBusy}
-                  onclick={() => unarchiveEvent(event.id)}
-                  type="button"
-                >
-                  <svg
-                    class="h-3.5 w-3.5"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                    />
-                  </svg>
-                </button>
-              {:else}
-                <button
-                  aria-label="Archive"
-                  class="cursor-pointer rounded p-1 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-                  disabled={lifecycleBusy}
-                  onclick={() =>
-                    (confirmModal = {
-                      open: true,
-                      action: "archive",
-                      eventId: event.id,
-                    })}
-                  type="button"
-                >
-                  <svg
-                    class="h-3.5 w-3.5"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                    />
-                  </svg>
-                </button>
-              {/if}
-              <button
-                aria-label="Move to trash"
-                class="cursor-pointer rounded p-1 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-red-400 disabled:opacity-50"
-                disabled={lifecycleBusy}
-                onclick={() =>
+            <div class="flex shrink-0 items-center gap-0.5">
+              <ArchiveButton
+                archived={Boolean(event.archived_at)}
+                busy={lifecycleBusy}
+                onarchive={() =>
+                  (confirmModal = {
+                    open: true,
+                    action: "archive",
+                    eventId: event.id,
+                  })}
+                onunarchive={() => unarchiveEvent(event.id)}
+              />
+              <TrashButton
+                busy={lifecycleBusy}
+                ontrash={() =>
                   (confirmModal = {
                     open: true,
                     action: "trash",
                     eventId: event.id,
                   })}
-                type="button"
-              >
-                <svg
-                  class="h-3.5 w-3.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                  />
-                </svg>
-              </button>
+              />
             </div>
           </div>
 

--- a/web-ui/src/lib/components/timeline/TimelineTab.svelte
+++ b/web-ui/src/lib/components/timeline/TimelineTab.svelte
@@ -30,7 +30,12 @@
   let hasAnyTimelineEvents = $derived(timelineView.length > 0);
 
   let showArchived = $state(false);
-  let confirmModal = $state({ open: false, action: "", eventId: "" });
+  let confirmModal = $state({
+    open: false,
+    action: "",
+    eventId: "",
+    eventRawType: "",
+  });
   let lifecycleBusy = $state(false);
   let lifecycleError = $state("");
 
@@ -52,9 +57,14 @@
 
   function handleConfirm() {
     const { action, eventId } = confirmModal;
-    confirmModal = { open: false, action: "", eventId: "" };
-    if (action === "archive") archiveEvent(eventId);
-    else if (action === "trash") trashEvent(eventId);
+    confirmModal = {
+      open: false,
+      action: "",
+      eventId: "",
+      eventRawType: "",
+    };
+    if (action === "archive") void archiveEvent(eventId);
+    else if (action === "trash") void trashEvent(eventId);
   }
 
   async function archiveEvent(eventId) {
@@ -184,6 +194,7 @@
                     open: true,
                     action: "archive",
                     eventId: event.id,
+                    eventRawType: event.rawType,
                   })}
                 onunarchive={() => unarchiveEvent(event.id)}
               />
@@ -194,6 +205,7 @@
                     open: true,
                     action: "trash",
                     eventId: event.id,
+                    eventRawType: event.rawType,
                   })}
               />
             </div>
@@ -242,14 +254,28 @@
 <ConfirmModal
   open={confirmModal.open}
   title={confirmModal.action === "trash"
-    ? "Move event to trash"
-    : "Archive event"}
+    ? confirmModal.eventRawType === "message_posted"
+      ? "Move message to trash"
+      : "Move event to trash"
+    : confirmModal.eventRawType === "message_posted"
+      ? "Archive message"
+      : "Archive event"}
   message={confirmModal.action === "trash"
-    ? "This event will be moved to trash. You can restore it later."
-    : "This event will be hidden from the timeline. You can show archived events to see it again."}
+    ? confirmModal.eventRawType === "message_posted"
+      ? "This message and all its replies will be moved to trash. You can restore them later."
+      : "This event will be moved to trash. You can restore it later."
+    : confirmModal.eventRawType === "message_posted"
+      ? "This message and all its replies will be archived. Toggle 'Show archived' to see them again."
+      : "This event will be hidden from the timeline. You can show archived events to see it again."}
   confirmLabel={confirmModal.action === "trash" ? "Trash" : "Archive"}
   variant={confirmModal.action === "trash" ? "danger" : "warning"}
   busy={lifecycleBusy}
   onconfirm={handleConfirm}
-  oncancel={() => (confirmModal = { open: false, action: "", eventId: "" })}
+  oncancel={() =>
+    (confirmModal = {
+      open: false,
+      action: "",
+      eventId: "",
+      eventRawType: "",
+    })}
 />

--- a/web-ui/src/lib/components/topic-detail/TopicDetailHeader.svelte
+++ b/web-ui/src/lib/components/topic-detail/TopicDetailHeader.svelte
@@ -7,7 +7,9 @@
     actorRegistry,
     principalRegistry,
   } from "$lib/actorSession";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import { coreClient } from "$lib/coreClient";
   import { formatTimestamp } from "$lib/formatDate";
   import { topicDetailStore } from "$lib/topicDetailStore";
@@ -208,46 +210,17 @@
       >
       {#if detailAsTopic && !topic.trashed_at && threadId}
         {#if !topic.archived_at}
-          <button
-            aria-label="Archive"
-            class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-            disabled={lifecycleBusy}
-            onclick={() => (confirmModal = { open: true, action: "archive" })}
-            type="button"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-              />
-            </svg>
-          </button>
+          <ArchiveButton
+            busy={lifecycleBusy}
+            size="md"
+            onarchive={() => (confirmModal = { open: true, action: "archive" })}
+          />
         {/if}
-        <button
-          aria-label="Move topic to trash"
-          class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-red-400 disabled:opacity-50"
-          disabled={lifecycleBusy}
-          onclick={() => (confirmModal = { open: true, action: "trash" })}
-          type="button"
-        >
-          <svg
-            class="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-            />
-          </svg>
-        </button>
+        <TrashButton
+          busy={lifecycleBusy}
+          size="md"
+          ontrash={() => (confirmModal = { open: true, action: "trash" })}
+        />
       {/if}
     </div>
   </div>

--- a/web-ui/src/lib/dashboardSummary.js
+++ b/web-ui/src/lib/dashboardSummary.js
@@ -185,17 +185,17 @@ export function inboxSummarySentence(categorySummary) {
     return "Inbox is clear.";
   }
 
-  const decisionEntry = categorySummary.find(
-    (entry) => entry.category === "decision_needed",
+  const actionEntry = categorySummary.find(
+    (entry) => entry.category === "action_needed",
   );
-  const decisions = decisionEntry ? decisionEntry.count : 0;
+  const actions = actionEntry ? actionEntry.count : 0;
 
   const itemWord = total === 1 ? "work item needs" : "work items need";
   const base = `${total} ${itemWord} your attention`;
 
-  if (decisions > 0) {
-    const decisionWord = decisions === 1 ? "decision" : "decisions";
-    return `${base}, including ${decisions} ${decisionWord}.`;
+  if (actions > 0) {
+    const actionWord = actions === 1 ? "action item" : "action items";
+    return `${base}, including ${actions} ${actionWord}.`;
   }
 
   return `${base}.`;

--- a/web-ui/src/lib/devWorkspaceFixtures.js
+++ b/web-ui/src/lib/devWorkspaceFixtures.js
@@ -732,6 +732,26 @@ const events = [
     provenance: { sources: ["actor_statement:evt-price-008"] },
   },
   {
+    id: "evt-price-008b",
+    ts: new Date(
+      now - 9 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000 + 5 * 60 * 1000,
+    ).toISOString(),
+    type: "inbox_item_acknowledged",
+    actor_id: "actor-ops-ai",
+    thread_id: "thread-pricing-glitch",
+    refs: [
+      "thread:thread-pricing-glitch",
+      "inbox:inbox:action_needed:thread-pricing-glitch:none:evt-price-003",
+    ],
+    summary:
+      "OpsAI acknowledged decision inbox item after decision was recorded.",
+    payload: {
+      inbox_item_id:
+        "inbox:action_needed:thread-pricing-glitch:none:evt-price-003",
+    },
+    provenance: { sources: ["actor_statement:evt-price-008b"] },
+  },
+  {
     id: "evt-price-009",
     ts: new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString(),
     type: "receipt_added",

--- a/web-ui/src/lib/inboxUtils.js
+++ b/web-ui/src/lib/inboxUtils.js
@@ -1,34 +1,19 @@
 import { parseTimestampMs } from "./dateUtils.js";
 
 export const INBOX_CATEGORY_ORDER = [
-  "decision_needed",
-  "intervention_needed",
-  "exception",
-  "work_item_risk",
-  "stale_topic",
-  "document_attention",
+  "action_needed",
+  "risk_exception",
+  "attention",
 ];
 
 export const INBOX_CATEGORY_LABELS = {
-  decision_needed: "Needs Decision",
-  intervention_needed: "Needs Intervention",
-  exception: "Exception",
-  work_item_risk: "Work item risk",
-  stale_topic: "Stale Topic",
-  document_attention: "Document Attention",
-};
-
-export const INBOX_CATEGORY_DESCRIPTIONS = {
-  decision_needed: "Decision event pending",
-  intervention_needed: "Human action required",
-  exception: "Operational or system exception",
-  work_item_risk: "Work item risk needs review",
-  stale_topic: "Topic appears stale",
-  document_attention: "Document needs attention",
+  action_needed: "Action needed",
+  risk_exception: "Risk / Exception",
+  attention: "Attention",
 };
 
 export function getInboxCategoryLabel(category) {
-  return INBOX_CATEGORY_LABELS[normalizeInboxCategory(category)] ?? category;
+  return INBOX_CATEGORY_LABELS[category] ?? category;
 }
 
 export const INBOX_URGENCY_LEVELS = ["immediate", "high", "normal"];
@@ -40,16 +25,9 @@ export const INBOX_URGENCY_LABELS = {
 };
 
 const INBOX_CATEGORY_URGENCY_BASE = {
-  decision_needed: 76,
-  intervention_needed: 74,
-  exception: 90,
-  work_item_risk: 66,
-  stale_topic: 90,
-  document_attention: 58,
-};
-
-const INBOX_CATEGORY_ALIASES = {
-  risk_review: "work_item_risk",
+  action_needed: 76,
+  risk_exception: 84,
+  attention: 58,
 };
 
 const INBOX_SUBJECT_LABELS = {
@@ -61,8 +39,7 @@ const INBOX_SUBJECT_LABELS = {
 };
 
 export function normalizeInboxCategory(category) {
-  const normalized = String(category ?? "").trim();
-  return INBOX_CATEGORY_ALIASES[normalized] ?? normalized;
+  return String(category ?? "").trim();
 }
 
 export function splitTypedRef(refValue) {

--- a/web-ui/src/lib/refLinkModel.js
+++ b/web-ui/src/lib/refLinkModel.js
@@ -40,8 +40,8 @@ function compactValue(value) {
 
 function humanizedLabelForPrefix(prefix, value) {
   const short = compactValue(value);
-  if (prefix === "artifact") return "Artifact";
-  if (prefix === "card") return "Card";
+  if (prefix === "artifact") return `Artifact ${short}`.trim();
+  if (prefix === "card") return `Card ${short}`.trim();
   if (prefix === "thread") return `Thread ${short}`.trim();
   if (prefix === "topic") return `Topic ${short}`.trim();
   if (prefix === "event") return "Event";

--- a/web-ui/src/routes/[workspace]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/+page.svelte
@@ -254,12 +254,6 @@
       >
         Refresh
       </button>
-      <a
-        class="rounded-md bg-[var(--ui-panel)] px-3 py-1.5 text-[13px] font-medium text-[var(--ui-text)] transition-colors hover:bg-[var(--ui-border)]"
-        href={workspaceHref("/inbox")}
-      >
-        Review inbox
-      </a>
     </div>
   </div>
 

--- a/web-ui/src/routes/[workspace]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/+page.svelte
@@ -210,34 +210,24 @@
 
   function inboxCategoryCountColor(category, count) {
     if (count === 0) return "text-[var(--ui-text)]";
-    if (category === "intervention_needed") return "text-red-400";
-    if (category === "decision_needed") return "text-indigo-400";
-    if (category === "exception") return "text-red-400";
-    if (category === "work_item_risk") return "text-amber-400";
-    if (category === "stale_topic") return "text-orange-400";
-    if (category === "document_attention") return "text-sky-400";
+    if (category === "action_needed") return "text-indigo-400";
+    if (category === "risk_exception") return "text-amber-400";
+    if (category === "attention") return "text-sky-400";
     return "text-[var(--ui-text)]";
   }
 
   function inboxCategoryLabelColor(category, count) {
     if (count === 0) return "text-[var(--ui-text-muted)]";
-    if (category === "intervention_needed") return "text-red-400";
-    if (category === "decision_needed") return "text-indigo-400";
-    if (category === "exception") return "text-red-400";
-    if (category === "work_item_risk") return "text-amber-400";
-    if (category === "stale_topic") return "text-orange-400";
-    if (category === "document_attention") return "text-sky-400";
+    if (category === "action_needed") return "text-indigo-400";
+    if (category === "risk_exception") return "text-amber-400";
+    if (category === "attention") return "text-sky-400";
     return "text-[var(--ui-text-muted)]";
   }
 
   function inboxCategoryBadgeClass(category) {
-    if (category === "intervention_needed") return "text-red-400 bg-red-500/10";
-    if (category === "decision_needed")
-      return "text-indigo-400 bg-indigo-500/10";
-    if (category === "exception") return "text-red-400 bg-red-500/10";
-    if (category === "work_item_risk") return "text-amber-400 bg-amber-500/10";
-    if (category === "stale_topic") return "text-orange-400 bg-orange-500/10";
-    if (category === "document_attention") return "text-sky-400 bg-sky-500/10";
+    if (category === "action_needed") return "text-indigo-400 bg-indigo-500/10";
+    if (category === "risk_exception") return "text-amber-400 bg-amber-500/10";
+    if (category === "attention") return "text-sky-400 bg-sky-500/10";
     return "text-[var(--ui-text-muted)] bg-[var(--ui-border)]";
   }
 </script>

--- a/web-ui/src/routes/[workspace]/artifacts/+page.svelte
+++ b/web-ui/src/routes/[workspace]/artifacts/+page.svelte
@@ -25,7 +25,9 @@
     actorRegistry,
     principalRegistry,
   } from "$lib/actorSession";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
 
   let artifacts = $state([]);
   let loading = $state(false);
@@ -363,56 +365,32 @@
               )}
             </p>
           </a>
-          <div class="flex shrink-0 items-center gap-2">
-            <span class="text-[11px] text-[var(--ui-text-muted)]">
+          <div class="flex shrink-0 items-center gap-1">
+            <span class="mr-1 text-[11px] text-[var(--ui-text-muted)]">
               {(artifact.refs ?? []).length} ref{(artifact.refs ?? [])
                 .length === 1
                 ? ""
                 : "s"}
             </span>
-            {#if isArtifactArchived(artifact)}
-              <button
-                class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-                onclick={(e) => {
-                  e.stopPropagation();
-                  void unarchiveArtifact(artifact.id);
-                }}
-                type="button"
-              >
-                Unarchive
-              </button>
-            {:else}
-              <button
-                class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-                onclick={(e) => {
-                  e.stopPropagation();
-                  confirmModal = {
-                    open: true,
-                    action: "archive",
-                    entityId: artifact.id,
-                  };
-                }}
-                title="Archive"
-                type="button"
-              >
-                <svg
-                  class="h-3.5 w-3.5"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                  />
-                </svg>
-              </button>
-            {/if}
-            <button
-              class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={Boolean(trashBusyId) || Boolean(archiveBusyId)}
-              onclick={(e) => {
+            <ArchiveButton
+              archived={isArtifactArchived(artifact)}
+              busy={Boolean(archiveBusyId) || Boolean(trashBusyId)}
+              onarchive={(e) => {
+                e.stopPropagation();
+                confirmModal = {
+                  open: true,
+                  action: "archive",
+                  entityId: artifact.id,
+                };
+              }}
+              onunarchive={(e) => {
+                e.stopPropagation();
+                void unarchiveArtifact(artifact.id);
+              }}
+            />
+            <TrashButton
+              busy={Boolean(trashBusyId) || Boolean(archiveBusyId)}
+              ontrash={(e) => {
                 e.stopPropagation();
                 confirmModal = {
                   open: true,
@@ -420,23 +398,7 @@
                   entityId: artifact.id,
                 };
               }}
-              title="Move to trash"
-              type="button"
-            >
-              <svg
-                class="h-3.5 w-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/web-ui/src/routes/[workspace]/artifacts/[artifactId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/artifacts/[artifactId]/+page.svelte
@@ -2,7 +2,9 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
 
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import GuidedTypedRefsInput from "$lib/components/GuidedTypedRefsInput.svelte";
   import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
   import { coreClient } from "$lib/coreClient";
@@ -516,48 +518,20 @@
         </p>
       </div>
       {#if !artifact.trashed_at}
-        <div class="flex shrink-0 items-center gap-1.5">
+        <div class="flex shrink-0 items-center gap-1">
           {#if !artifact.archived_at}
-            <button
-              aria-label="Archive"
-              class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-              disabled={lifecycleBusy}
-              onclick={() => (confirmModal = { open: true, action: "archive" })}
-              type="button"
-            >
-              <svg
-                class="h-4 w-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                />
-              </svg>
-            </button>
+            <ArchiveButton
+              busy={lifecycleBusy}
+              size="md"
+              onarchive={() =>
+                (confirmModal = { open: true, action: "archive" })}
+            />
           {/if}
-          <button
-            aria-label="Move artifact to trash"
-            class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-red-400 disabled:opacity-50"
-            disabled={lifecycleBusy}
-            onclick={() => (confirmModal = { open: true, action: "trash" })}
-            type="button"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-              />
-            </svg>
-          </button>
+          <TrashButton
+            busy={lifecycleBusy}
+            size="md"
+            ontrash={() => (confirmModal = { open: true, action: "trash" })}
+          />
         </div>
       {/if}
     </div>

--- a/web-ui/src/routes/[workspace]/boards/+page.svelte
+++ b/web-ui/src/routes/[workspace]/boards/+page.svelte
@@ -4,7 +4,9 @@
   import GuidedTypedRefsInput from "$lib/components/GuidedTypedRefsInput.svelte";
   import SearchableEntityPicker from "$lib/components/SearchableEntityPicker.svelte";
   import SearchableMultiEntityPicker from "$lib/components/SearchableMultiEntityPicker.svelte";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import { coreClient } from "$lib/coreClient";
   import { formatTimestamp } from "$lib/formatDate";
   import {
@@ -573,52 +575,26 @@
             </div>
           </div>
         </div>
-        <div
-          class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
-        >
-          {#if isBoardArchived(board)}
-            <button
-              class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] px-2 py-1 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-              onclick={(event) => {
-                event.stopPropagation();
-                void unarchiveBoard(board.id);
-              }}
-              type="button"
-            >
-              Unarchive
-            </button>
-          {:else}
-            <button
-              class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-              onclick={(event) => {
-                event.stopPropagation();
-                confirmModal = {
-                  open: true,
-                  action: "archive",
-                  entityId: board.id,
-                };
-              }}
-              title="Archive"
-              type="button"
-            >
-              <svg
-                class="h-3.5 w-3.5"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                />
-              </svg>
-            </button>
-          {/if}
-          <button
-            class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={Boolean(trashBusyId) || Boolean(archiveBusyId)}
-            onclick={(event) => {
+        <div class="hidden shrink-0 items-center gap-1 px-2 sm:flex">
+          <ArchiveButton
+            archived={isBoardArchived(board)}
+            busy={Boolean(archiveBusyId) || Boolean(trashBusyId)}
+            onarchive={(event) => {
+              event.stopPropagation();
+              confirmModal = {
+                open: true,
+                action: "archive",
+                entityId: board.id,
+              };
+            }}
+            onunarchive={(event) => {
+              event.stopPropagation();
+              void unarchiveBoard(board.id);
+            }}
+          />
+          <TrashButton
+            busy={Boolean(trashBusyId) || Boolean(archiveBusyId)}
+            ontrash={(event) => {
               event.stopPropagation();
               confirmModal = {
                 open: true,
@@ -626,23 +602,7 @@
                 entityId: board.id,
               };
             }}
-            title="Move to trash"
-            type="button"
-          >
-            <svg
-              class="h-3.5 w-3.5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-              />
-            </svg>
-          </button>
+          />
         </div>
       </div>
     {/each}

--- a/web-ui/src/routes/[workspace]/boards/[boardId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/boards/[boardId]/+page.svelte
@@ -92,12 +92,6 @@
   let enrichedInboxItems = $derived(
     (workspace?.inbox?.items ?? []).map((item) => enrichInboxItem(item)),
   );
-  let resolvedCards = $derived(
-    (workspace?.cards?.items ?? []).filter((card) => {
-      const r = String(card?.membership?.resolution ?? "").trim();
-      return r === "done" || r === "canceled";
-    }),
-  );
   let actorOptions = $derived(
     $actorRegistry.map((actor) => ({
       id: actor.id,
@@ -154,21 +148,6 @@
   function closeCardDetailModal() {
     detailModalCard = null;
     replaceState(withUpdatedSearchParams($page.url, { card: "" }), {});
-  }
-
-  function cardResolutionLabel(resolution) {
-    switch (String(resolution ?? "").trim()) {
-      case "done":
-      case "completed":
-        return "Done";
-      case "canceled":
-      case "cancelled":
-        return "Canceled";
-      case "superseded":
-        return "Superseded";
-      default:
-        return "Open";
-    }
   }
 
   function openBoardEditForm() {
@@ -1275,51 +1254,6 @@
             <p class="mt-2 text-[11px] text-[var(--ui-text-muted)]">
               Showing {BOARD_WORKSPACE_PANEL_PREVIEW_LIMIT} of {workspace
                 .documents.items.length}
-            </p>
-          {/if}
-        {/if}
-      </div>
-    </section>
-
-    <section
-      class="rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)]"
-    >
-      <div class="border-b border-[var(--ui-border)] px-4 py-2.5">
-        <h2 class="text-[13px] font-medium text-[var(--ui-text)]">
-          Resolved cards
-        </h2>
-        <p class="mt-1 text-[11px] text-[var(--ui-text-muted)]">
-          First-class cards with explicit resolution state and evidence refs.
-        </p>
-      </div>
-      <div class="px-4 py-3">
-        {#if resolvedCards.length === 0}
-          <p class="text-[12px] text-[var(--ui-text-muted)]">
-            No resolved cards in this board slice.
-          </p>
-        {:else}
-          <div class="space-y-2">
-            {#each resolvedCards.slice(0, BOARD_WORKSPACE_PANEL_PREVIEW_LIMIT) as cardItem}
-              {@const membership = cardItem.membership}
-              <div
-                class="rounded border border-[var(--ui-border)] bg-[var(--ui-panel-muted)] px-3 py-2"
-              >
-                <div class="text-[12px] font-medium text-[var(--ui-text)]">
-                  {membership.title || membership.id}
-                </div>
-                <div class="mt-1 text-[11px] text-[var(--ui-text-muted)]">
-                  {cardResolutionLabel(membership.resolution)} · Due
-                  {formatTimestamp(membership.due_at) || "—"}
-                  {#if Array.isArray(membership.resolution_refs) && membership.resolution_refs.length > 0}
-                    · {membership.resolution_refs.length} evidence refs
-                  {/if}
-                </div>
-              </div>
-            {/each}
-          </div>
-          {#if resolvedCards.length > BOARD_WORKSPACE_PANEL_PREVIEW_LIMIT}
-            <p class="mt-2 text-[11px] text-[var(--ui-text-muted)]">
-              Showing {BOARD_WORKSPACE_PANEL_PREVIEW_LIMIT} of {resolvedCards.length}
             </p>
           {/if}
         {/if}

--- a/web-ui/src/routes/[workspace]/boards/[boardId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/boards/[boardId]/+page.svelte
@@ -3,7 +3,9 @@
   import { page } from "$app/stores";
   import BoardCard from "$lib/components/BoardCard.svelte";
   import CardDetailModal from "$lib/components/CardDetailModal.svelte";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import GuidedTypedRefsInput from "$lib/components/GuidedTypedRefsInput.svelte";
   import SearchableEntityPicker from "$lib/components/SearchableEntityPicker.svelte";
   import SearchableMultiEntityPicker from "$lib/components/SearchableMultiEntityPicker.svelte";
@@ -634,26 +636,6 @@
 
       {#if !board.trashed_at}
         <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          {#if !board.archived_at}
-            <button
-              aria-label="Archive"
-              class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-              disabled={boardLifecycleBusy}
-              onclick={() => (confirmModal = { open: true, action: "archive" })}
-              type="button"
-            >
-              <svg
-                class="h-4 w-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                />
-              </svg>
-            </button>
-          {/if}
           <button
             class="rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] px-2.5 py-1.5 text-[12px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] hover:text-[var(--ui-text)]"
             onclick={openBoardEditForm}
@@ -668,27 +650,19 @@
           >
             {showAddCardForm ? "Close" : "Add card"}
           </button>
-          <button
-            aria-label="Move board to trash"
-            class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:opacity-50"
-            disabled={boardLifecycleBusy}
-            onclick={() => (confirmModal = { open: true, action: "trash" })}
-            type="button"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-              />
-            </svg>
-          </button>
+          {#if !board.archived_at}
+            <ArchiveButton
+              busy={boardLifecycleBusy}
+              size="md"
+              onarchive={() =>
+                (confirmModal = { open: true, action: "archive" })}
+            />
+          {/if}
+          <TrashButton
+            busy={boardLifecycleBusy}
+            size="md"
+            ontrash={() => (confirmModal = { open: true, action: "trash" })}
+          />
         </div>
       {/if}
     </div>

--- a/web-ui/src/routes/[workspace]/docs/+page.svelte
+++ b/web-ui/src/routes/[workspace]/docs/+page.svelte
@@ -11,7 +11,9 @@
     actorRegistry,
     principalRegistry,
   } from "$lib/actorSession";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
 
   const DOC_STATUS_LABELS = { draft: "Draft", active: "Active" };
 
@@ -486,122 +488,76 @@
 
 {#snippet docRow(doc, showBorderTop)}
   <div
-    class="flex items-stretch transition-colors hover:bg-[var(--ui-border-subtle)] {showBorderTop
+    class="flex items-start justify-between gap-3 px-4 py-3 transition-colors hover:bg-[var(--ui-border-subtle)] {showBorderTop
       ? 'border-t border-[var(--ui-border)]'
       : ''}"
   >
-    <a class="min-w-0 flex-1 px-4 py-3" href={workspaceHref(`/docs/${doc.id}`)}>
-      <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0 flex-1">
-          <div class="flex flex-wrap items-center gap-2">
-            {#if doc.status}
-              <span
-                class="inline-flex rounded px-1.5 py-0.5 text-[11px] font-semibold {statusColor(
-                  doc.status,
-                )}">{DOC_STATUS_LABELS[doc.status] ?? doc.status}</span
-              >
-            {/if}
-            {#if isDocArchived(doc)}
-              <span
-                class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[11px] font-medium text-amber-400"
-                >Archived</span
-              >
-            {/if}
-            {#each (doc.labels ?? []).slice(0, 3) as label}
-              <span
-                class="rounded bg-[var(--ui-border)] px-1.5 py-0.5 text-[10px] text-[var(--ui-text-muted)]"
-                >{label}</span
-              >
-            {/each}
-          </div>
-          <p
-            class="mt-1 truncate text-[13px] font-medium text-[var(--ui-text)]"
+    <a class="min-w-0 flex-1" href={workspaceHref(`/docs/${doc.id}`)}>
+      <div class="flex flex-wrap items-center gap-2">
+        {#if doc.status}
+          <span
+            class="inline-flex rounded px-1.5 py-0.5 text-[11px] font-semibold {statusColor(
+              doc.status,
+            )}">{DOC_STATUS_LABELS[doc.status] ?? doc.status}</span
           >
-            {doc.title || doc.id}
-          </p>
-          <p class="text-[11px] text-[var(--ui-text-muted)]">
-            Head v{doc.head_revision_number} · Updated {formatTimestamp(
-              doc.updated_at,
-            ) || "—"} by {actorName(doc.updated_by)}
-          </p>
-          {#if doc.thread_id && !scopedThreadId}
-            <p class="mt-0.5 text-[11px] text-[var(--ui-text-muted)]">
-              Backing thread (timeline): {doc.thread_id}
-            </p>
-          {/if}
-        </div>
-        <span class="shrink-0 text-[11px] text-[var(--ui-text-muted)]">
-          {doc.head_revision_number} revision{doc.head_revision_number === 1
-            ? ""
-            : "s"}
-        </span>
+        {/if}
+        {#if isDocArchived(doc)}
+          <span
+            class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[11px] font-medium text-amber-400"
+            >Archived</span
+          >
+        {/if}
+        {#each (doc.labels ?? []).slice(0, 3) as label}
+          <span
+            class="rounded bg-[var(--ui-border)] px-1.5 py-0.5 text-[10px] text-[var(--ui-text-muted)]"
+            >{label}</span
+          >
+        {/each}
       </div>
+      <p class="mt-1 truncate text-[13px] font-medium text-[var(--ui-text)]">
+        {doc.title || doc.id}
+      </p>
+      <p class="text-[11px] text-[var(--ui-text-muted)]">
+        Head v{doc.head_revision_number} · Updated {formatTimestamp(
+          doc.updated_at,
+        ) || "—"} by {actorName(doc.updated_by)}
+      </p>
+      {#if doc.thread_id && !scopedThreadId}
+        <p class="mt-0.5 text-[11px] text-[var(--ui-text-muted)]">
+          Backing thread (timeline): {doc.thread_id}
+        </p>
+      {/if}
     </a>
     <div
-      class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
+      class="hidden shrink-0 items-center gap-1 sm:flex"
       role="presentation"
       onclick={(e) => e.stopPropagation()}
     >
-      {#if isDocArchived(doc)}
-        <button
-          class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
-          disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-          onclick={() => void unarchiveDocument(doc.id)}
-          type="button"
-        >
-          Unarchive
-        </button>
-      {:else}
-        <button
-          class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:cursor-not-allowed disabled:opacity-50"
-          disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-          onclick={() =>
-            (confirmModal = {
-              open: true,
-              action: "archive",
-              entityId: doc.id,
-            })}
-          title="Archive"
-          type="button"
-        >
-          <svg
-            class="h-3.5 w-3.5"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-            />
-          </svg>
-        </button>
-      {/if}
-      <button
-        class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={Boolean(trashBusyId) || Boolean(archiveBusyId)}
-        onclick={() =>
+      <span class="mr-1 shrink-0 text-[11px] text-[var(--ui-text-muted)]">
+        {doc.head_revision_number} revision{doc.head_revision_number === 1
+          ? ""
+          : "s"}
+      </span>
+      <ArchiveButton
+        archived={isDocArchived(doc)}
+        busy={Boolean(archiveBusyId) || Boolean(trashBusyId)}
+        onarchive={() =>
+          (confirmModal = {
+            open: true,
+            action: "archive",
+            entityId: doc.id,
+          })}
+        onunarchive={() => void unarchiveDocument(doc.id)}
+      />
+      <TrashButton
+        busy={Boolean(trashBusyId) || Boolean(archiveBusyId)}
+        ontrash={() =>
           (confirmModal = {
             open: true,
             action: "trash",
             entityId: doc.id,
           })}
-        title="Move to trash"
-        type="button"
-      >
-        <svg
-          class="h-3.5 w-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-          />
-        </svg>
-      </button>
+      />
     </div>
   </div>
 {/snippet}

--- a/web-ui/src/routes/[workspace]/docs/[documentId]/+page.svelte
+++ b/web-ui/src/routes/[workspace]/docs/[documentId]/+page.svelte
@@ -1,7 +1,9 @@
 <script>
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
   import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
   import { coreClient } from "$lib/coreClient";
   import { formatTimestamp } from "$lib/formatDate";
@@ -557,25 +559,12 @@
               </span>
             {/if}
             {#if !document.archived_at}
-              <button
-                aria-label="Archive"
-                class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:opacity-50"
-                disabled={docLifecycleBusy}
-                onclick={() =>
+              <ArchiveButton
+                busy={docLifecycleBusy}
+                size="md"
+                onarchive={() =>
                   (confirmModal = { open: true, action: "archive" })}
-                type="button"
-              >
-                <svg
-                  class="h-4 w-4"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                  />
-                </svg>
-              </button>
+              />
             {/if}
             <button
               class="cursor-pointer shrink-0 inline-flex items-center gap-1.5 rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2.5 py-1.5 text-[12px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)]"
@@ -597,27 +586,11 @@
               </svg>
               Revision history
             </button>
-            <button
-              aria-label="Move document to trash"
-              class="cursor-pointer rounded-md p-1.5 text-[var(--ui-text-muted)] hover:bg-[var(--ui-border)] hover:text-red-400 disabled:opacity-50"
-              disabled={docLifecycleBusy}
-              onclick={() => (confirmModal = { open: true, action: "trash" })}
-              type="button"
-            >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                />
-              </svg>
-            </button>
+            <TrashButton
+              busy={docLifecycleBusy}
+              size="md"
+              ontrash={() => (confirmModal = { open: true, action: "trash" })}
+            />
           </div>
         {/if}
       </div>

--- a/web-ui/src/routes/[workspace]/inbox/+page.svelte
+++ b/web-ui/src/routes/[workspace]/inbox/+page.svelte
@@ -11,7 +11,6 @@
   import {
     INBOX_CATEGORY_ORDER,
     INBOX_CATEGORY_LABELS,
-    INBOX_CATEGORY_DESCRIPTIONS,
     INBOX_URGENCY_LEVELS,
     INBOX_URGENCY_LABELS,
     decisionGroundingRefForInboxItem,
@@ -80,9 +79,6 @@
         return false;
       }
       if (urgencyFilter === "all") return true;
-      if (urgencyFilter === "aging") {
-        return Number.isFinite(item.age_hours) && item.age_hours >= 24;
-      }
       return item.urgency_level === urgencyFilter;
     }),
   );
@@ -101,9 +97,7 @@
     if (categoryFilter !== "all") {
       parts.push(getInboxCategoryLabel(categoryFilter));
     }
-    if (urgencyFilter === "aging") {
-      parts.push("Aging 24h+");
-    } else if (urgencyFilter !== "all") {
+    if (urgencyFilter !== "all") {
       parts.push(getInboxUrgencyLabel(urgencyFilter));
     }
     return parts;
@@ -183,9 +177,10 @@
         ? normalizedCategory
         : "all";
 
-    const validUrgencies = [...INBOX_URGENCY_LEVELS, "aging"];
     urgencyFilter =
-      rawUrgency && validUrgencies.includes(rawUrgency) ? rawUrgency : "all";
+      rawUrgency && INBOX_URGENCY_LEVELS.includes(rawUrgency)
+        ? rawUrgency
+        : "all";
 
     if (rawCategory || rawUrgency) {
       filtersOpen = true;
@@ -468,8 +463,6 @@
         groundingRef,
       ]),
     );
-    const recommendedAction = item.recommended_action ?? "";
-
     items = items.filter((candidate) => candidate.id !== item.id);
     toggleDecisionForm(item, false);
     updateDecisionField(item.id, "summary", "");
@@ -491,7 +484,6 @@
             payload: {
               notes,
               inbox_item_id: item.id,
-              recommended_action: recommendedAction,
             },
             provenance: {
               sources: ["actor_statement:ui"],
@@ -551,26 +543,27 @@
   }
 
   function categoryBadgeClass(category) {
-    if (category === "decision_needed") return "text-indigo-400";
-    if (category === "intervention_needed") return "text-cyan-400";
-    if (category === "exception") return "text-red-400";
-    if (category === "work_item_risk") return "text-amber-400";
-    if (category === "stale_topic") return "text-orange-400";
-    if (category === "document_attention") return "text-sky-400";
+    if (category === "action_needed") return "text-indigo-400";
+    if (category === "risk_exception") return "text-amber-400";
+    if (category === "attention") return "text-sky-400";
     return "text-[var(--ui-text-muted)]";
   }
 </script>
 
-<div class="flex items-center justify-between mb-4">
+<div
+  class="flex items-center justify-between pb-4 mb-4 border-b border-[var(--ui-border)]"
+>
   <div>
     <h1 class="text-lg font-semibold text-[var(--ui-text)]">Inbox</h1>
     <p class="hidden text-[13px] text-[var(--ui-text-muted)] sm:block">
       Sorted by urgency. Oldest items bubble up.
     </p>
   </div>
-  <div class="flex items-center gap-1.5">
+  <div class="flex items-center gap-2">
     <button
-      class="cursor-pointer inline-flex items-center gap-1.5 rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2.5 py-1.5 text-[12px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)]"
+      class="cursor-pointer inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors {hasActiveFilters
+        ? 'border-[var(--ui-accent)]/40 bg-[var(--ui-accent)]/10 text-[var(--ui-accent)] hover:bg-[var(--ui-accent)]/15'
+        : 'border-[var(--ui-border)] bg-[var(--ui-bg-soft)] text-[var(--ui-text-muted)] hover:bg-[var(--ui-border-subtle)]'}"
       onclick={() => (filtersOpen = !filtersOpen)}
       type="button"
       data-testid="inbox-filters-toggle"
@@ -588,10 +581,13 @@
           d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
         />
       </svg>
-      Filters
+      {hasActiveFilters ? "Filtered" : "Filter"}
     </button>
     <span
-      class="inline-flex items-center gap-1.5 rounded-md bg-[var(--ui-panel)] px-2.5 py-1.5 text-[13px] font-semibold text-[var(--ui-text)]"
+      class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-semibold tabular-nums {totalItems >
+      0
+        ? 'bg-[var(--ui-accent)]/10 text-[var(--ui-accent)]'
+        : 'bg-[var(--ui-panel)] text-[var(--ui-text-muted)]'}"
       data-testid="inbox-triage-header"
     >
       {totalItems} open
@@ -614,7 +610,7 @@
 
 {#if filtersOpen}
   <div
-    class="mb-4 rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] p-3"
+    class="mb-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] p-3"
     data-testid="inbox-filter-panel"
   >
     <div class="grid gap-3 sm:grid-cols-2">
@@ -629,11 +625,9 @@
           }}
           data-testid="inbox-category-filter"
         >
-          <option value="all">All categories</option>
+          <option value="all">All</option>
           {#each INBOX_CATEGORY_ORDER as cat}
-            <option value={cat}>
-              {INBOX_CATEGORY_LABELS[cat]} — {INBOX_CATEGORY_DESCRIPTIONS[cat]}
-            </option>
+            <option value={cat}>{INBOX_CATEGORY_LABELS[cat]}</option>
           {/each}
         </select>
       </label>
@@ -648,11 +642,10 @@
           }}
           data-testid="inbox-urgency-filter"
         >
-          <option value="all">All urgency levels</option>
+          <option value="all">All</option>
           {#each INBOX_URGENCY_LEVELS as level}
             <option value={level}>{INBOX_URGENCY_LABELS[level]}</option>
           {/each}
-          <option value="aging">Aging 24h+</option>
         </select>
       </label>
     </div>
@@ -677,53 +670,57 @@
   </div>
 {/if}
 
-<div class="flex gap-2 mb-4" data-testid="urgency-summary-strip">
+<div class="flex gap-1.5 mb-4" data-testid="urgency-summary-strip">
   <button
-    class="cursor-pointer flex-1 rounded-md border bg-[var(--ui-bg-soft)] px-3 py-2 text-left transition-colors {urgencyCardClass(
+    class="cursor-pointer inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors {urgencyCardClass(
       'immediate',
-    )} {urgencySummary.immediate > 0 ? 'bg-red-500/5' : ''}"
+    )} {urgencySummary.immediate > 0
+      ? 'bg-red-500/5'
+      : 'bg-[var(--ui-bg-soft)]'}"
     onclick={() => setUrgencyFromCard("immediate")}
     type="button"
     data-testid="urgency-summary-immediate"
   >
-    <p class="text-[11px] font-medium text-red-400">Immediate</p>
-    <p
-      class="text-lg font-semibold {urgencySummary.immediate > 0
+    <span class="inline-block h-1.5 w-1.5 rounded-full bg-red-500 shrink-0"
+    ></span>
+    <span class="text-red-400">Immediate</span>
+    <span
+      class="tabular-nums {urgencySummary.immediate > 0
         ? 'text-red-400'
-        : 'text-[var(--ui-text)]'}"
+        : 'text-[var(--ui-text-subtle)]'}">{urgencySummary.immediate}</span
     >
-      {urgencySummary.immediate}
-    </p>
   </button>
   <button
-    class="cursor-pointer flex-1 rounded-md border bg-[var(--ui-bg-soft)] px-3 py-2 text-left transition-colors {urgencyCardClass(
+    class="cursor-pointer inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors {urgencyCardClass(
       'high',
-    )} {urgencySummary.high > 0 ? 'bg-amber-500/5' : ''}"
+    )} {urgencySummary.high > 0 ? 'bg-amber-500/5' : 'bg-[var(--ui-bg-soft)]'}"
     onclick={() => setUrgencyFromCard("high")}
     type="button"
     data-testid="urgency-summary-high"
   >
-    <p class="text-[11px] font-medium text-amber-400">High</p>
-    <p
-      class="text-lg font-semibold {urgencySummary.high > 0
+    <span class="inline-block h-1.5 w-1.5 rounded-full bg-amber-400 shrink-0"
+    ></span>
+    <span class="text-amber-400">High</span>
+    <span
+      class="tabular-nums {urgencySummary.high > 0
         ? 'text-amber-400'
-        : 'text-[var(--ui-text)]'}"
+        : 'text-[var(--ui-text-subtle)]'}">{urgencySummary.high}</span
     >
-      {urgencySummary.high}
-    </p>
   </button>
   <button
-    class="cursor-pointer flex-1 rounded-md border bg-[var(--ui-bg-soft)] px-3 py-2 text-left transition-colors {urgencyCardClass(
+    class="cursor-pointer inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors bg-[var(--ui-bg-soft)] {urgencyCardClass(
       'normal',
     )}"
     onclick={() => setUrgencyFromCard("normal")}
     type="button"
     data-testid="urgency-summary-normal"
   >
-    <p class="text-[11px] font-medium text-[var(--ui-text-muted)]">Normal</p>
-    <p class="text-lg font-semibold text-[var(--ui-text)]">
-      {urgencySummary.normal}
-    </p>
+    <span class="inline-block h-1.5 w-1.5 rounded-full bg-gray-500 shrink-0"
+    ></span>
+    <span class="text-[var(--ui-text-muted)]">Normal</span>
+    <span class="tabular-nums text-[var(--ui-text-subtle)]"
+      >{urgencySummary.normal}</span
+    >
   </button>
 </div>
 
@@ -796,8 +793,25 @@
     Loading inbox...
   </div>
 {:else if totalItems === 0}
-  <div class="mt-8 text-center py-8" data-testid="inbox-empty-state">
-    <h2 class="text-[13px] font-semibold text-[var(--ui-text)]">
+  <div class="mt-8 text-center py-12" data-testid="inbox-empty-state">
+    <div
+      class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--ui-panel)] mb-3"
+    >
+      <svg
+        class="h-6 w-6 text-[var(--ui-text-subtle)]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    </div>
+    <h2 class="text-[14px] font-semibold text-[var(--ui-text)]">
       Inbox is clear
     </h2>
     <p class="mt-1 text-[13px] text-[var(--ui-text-muted)]">
@@ -805,8 +819,25 @@
     </p>
   </div>
 {:else if !hasFilteredItems}
-  <div class="mt-8 text-center py-8" data-testid="inbox-filter-empty-state">
-    <h2 class="text-[13px] font-semibold text-[var(--ui-text)]">
+  <div class="mt-8 text-center py-12" data-testid="inbox-filter-empty-state">
+    <div
+      class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--ui-panel)] mb-3"
+    >
+      <svg
+        class="h-6 w-6 text-[var(--ui-text-subtle)]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"
+        />
+      </svg>
+    </div>
+    <h2 class="text-[14px] font-semibold text-[var(--ui-text)]">
       No items match this view
     </h2>
     <p class="mt-1 text-[13px] text-[var(--ui-text-muted)]">
@@ -814,7 +845,7 @@
       queue.
     </p>
     <button
-      class="cursor-pointer mt-3 rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-3 py-1.5 text-[13px] font-medium text-[var(--ui-text-muted)] hover:bg-[var(--ui-border-subtle)]"
+      class="cursor-pointer mt-4 rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-3 py-1.5 text-[13px] font-medium text-[var(--ui-text-muted)] hover:bg-[var(--ui-border-subtle)]"
       onclick={resetFilters}
       type="button"
     >
@@ -822,32 +853,32 @@
     </button>
   </div>
 {:else}
-  <div class="space-y-5">
+  <div class="space-y-4">
     {#each visibleGroups as group}
       <section data-testid={`inbox-group-${group.category}`}>
-        <div class="mb-2 flex items-center gap-2">
+        <div class="mb-1.5 flex items-center gap-1.5">
           <h2
-            class="text-[12px] font-semibold uppercase tracking-wide {categoryBadgeClass(
+            class="text-[11px] font-semibold uppercase tracking-wider {categoryBadgeClass(
               group.category,
             )}"
           >
             {getInboxCategoryLabel(group.category)}
           </h2>
-          <span class="text-[11px] text-[var(--ui-text-muted)]"
+          <span class="text-[11px] text-[var(--ui-text-subtle)] tabular-nums"
             >{group.items.length}</span
           >
         </div>
 
-        <div class="space-y-2">
+        <div class="space-y-1.5">
           {#each group.items as item}
             <article
-              class="rounded-md border border-[var(--ui-border)] border-l-[3px] bg-[var(--ui-bg-soft)] px-4 py-3 {urgencyBorderClass(
+              class="rounded-md border border-[var(--ui-border)] border-l-[3px] bg-[var(--ui-bg-soft)] px-3 py-2.5 transition-colors hover:bg-[var(--ui-panel)] {urgencyBorderClass(
                 item.urgency_level,
               )}"
               data-testid={`inbox-card-${item.id}`}
             >
               <div class="flex items-center justify-between gap-2 text-[11px]">
-                <div class="flex min-w-0 items-center gap-2">
+                <div class="flex min-w-0 items-center gap-1.5">
                   <span
                     class="inline-flex h-1.5 w-1.5 shrink-0 rounded-full {urgencyDot(
                       item.urgency_level,
@@ -857,14 +888,14 @@
                     >{item.urgency_label}</span
                   >
                   {#if item.age_label}
-                    <span class="text-[var(--ui-text-muted)]"
-                      >{item.age_label}</span
+                    <span class="text-[var(--ui-text-subtle)]"
+                      >&middot; {item.age_label}</span
                     >
                   {/if}
                 </div>
                 {#if item.has_source_event_time}
                   <span
-                    class="shrink-0 tabular-nums text-[var(--ui-text-muted)]"
+                    class="shrink-0 tabular-nums text-[var(--ui-text-subtle)]"
                     title={item.source_event_time}
                   >
                     {formatAbsoluteDateTime(item.source_event_time)}
@@ -872,7 +903,7 @@
                 {/if}
               </div>
 
-              <div class="mt-1.5 flex flex-wrap items-start gap-2">
+              <div class="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
                 <h3
                   class="text-[13px] font-semibold text-[var(--ui-text)] leading-snug"
                 >
@@ -880,7 +911,7 @@
                 </h3>
                 {#if getInboxSubjectLabel(item)}
                   <a
-                    class="rounded bg-[var(--ui-border)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] hover:text-[var(--ui-text)]"
+                    class="shrink-0 rounded bg-[var(--ui-border)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] hover:text-[var(--ui-text)]"
                     href={inboxItemHref(item)}
                   >
                     {getInboxSubjectLabel(item)}
@@ -888,51 +919,41 @@
                 {/if}
               </div>
 
-              {#if item.recommended_action}
-                <div class="mt-2 rounded bg-[var(--ui-bg-soft)] px-3 py-2">
-                  <p
-                    class="text-[11px] font-medium text-indigo-400 uppercase tracking-wide"
-                  >
-                    Recommended
-                  </p>
-                  <MarkdownRenderer
-                    source={item.recommended_action}
-                    class="mt-0.5 text-[13px] text-[var(--ui-text)]"
-                  />
+              {#if getInboxSubjectRef(item) || (item.related_refs ?? []).length > 0}
+                <div
+                  class="mt-1.5 flex flex-wrap items-center gap-1 text-[11px]"
+                >
+                  {#if getInboxSubjectRef(item)}
+                    {@const subjectId = getInboxSubjectId(item)}
+                    <span
+                      class="inline-flex items-center gap-1 rounded bg-[var(--ui-panel)] px-1.5 py-0.5 font-medium text-[var(--ui-text-subtle)]"
+                      title={getInboxSubjectRef(item)}
+                    >
+                      <span>
+                        {getInboxSubjectKind(item)
+                          ? `${getInboxSubjectKind(item)}:`
+                          : "Subject:"}
+                      </span>
+                      <span
+                        >{subjectId.length > 12
+                          ? `${subjectId.slice(0, 8)}…`
+                          : subjectId}</span
+                      >
+                    </span>
+                  {/if}
+                  {#each item.related_refs ?? [] as refValue}
+                    <RefLink
+                      {refValue}
+                      threadId={inboxActionThreadId(item)}
+                      humanize
+                    />
+                  {/each}
                 </div>
               {/if}
 
-              <div class="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
-                {#if getInboxSubjectRef(item)}
-                  {@const subjectId = getInboxSubjectId(item)}
-                  <span
-                    class="inline-flex items-center gap-1 rounded bg-[var(--ui-panel)] px-1.5 py-0.5 font-medium text-[var(--ui-text-muted)]"
-                    title={getInboxSubjectRef(item)}
-                  >
-                    <span class="text-[var(--ui-text-muted)]">
-                      {getInboxSubjectKind(item)
-                        ? `${getInboxSubjectKind(item)}:`
-                        : "Subject:"}
-                    </span>
-                    <span
-                      >{subjectId.length > 12
-                        ? `${subjectId.slice(0, 8)}…`
-                        : subjectId}</span
-                    >
-                  </span>
-                {/if}
-                {#each item.related_refs ?? [] as refValue}
-                  <RefLink
-                    {refValue}
-                    threadId={inboxActionThreadId(item)}
-                    humanize
-                  />
-                {/each}
-              </div>
-
-              <div class="mt-3 flex items-center gap-2">
+              <div class="mt-2 flex flex-wrap items-center gap-1.5">
                 <button
-                  class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-3 py-1.5 text-[12px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:opacity-50"
+                  class="cursor-pointer rounded border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2.5 py-1 text-[12px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:opacity-50"
                   disabled={Boolean(ackInFlightById[item.id])}
                   onclick={() => acknowledgeItem(item)}
                   type="button"
@@ -942,7 +963,7 @@
                     : "Acknowledge"}
                 </button>
                 <button
-                  class="cursor-pointer rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors {getDecisionForm(
+                  class="cursor-pointer rounded px-2.5 py-1 text-[12px] font-medium transition-colors {getDecisionForm(
                     item.id,
                   ).open
                     ? 'border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] text-[var(--ui-text-muted)] hover:bg-[var(--ui-border-subtle)]'
@@ -992,7 +1013,7 @@
                   {#if getInboxSubjectRef(item)}
                     {@const subjectRef = getInboxSubjectRef(item)}
                     <div
-                      class="rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel)] p-3 min-w-0"
+                      class="rounded-lg border border-[var(--ui-border)] bg-[var(--ui-panel)] p-3 min-w-0"
                     >
                       {#if subjectContextLoading[subjectRef]}
                         <div
@@ -1112,7 +1133,7 @@
                             >
                               Related refs
                             </p>
-                            <div class="space-y-1.5">
+                            <div class="flex flex-wrap gap-1.5">
                               {#each subject.related_refs as refValue}
                                 <RefLink
                                   {refValue}
@@ -1140,7 +1161,7 @@
                   {/if}
 
                   <form
-                    class="rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] p-3 {inboxActionThreadId(
+                    class="rounded-lg border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] p-3 {inboxActionThreadId(
                       item,
                     )
                       ? ''

--- a/web-ui/src/routes/[workspace]/threads/+page.svelte
+++ b/web-ui/src/routes/[workspace]/threads/+page.svelte
@@ -23,7 +23,9 @@
   } from "$lib/topicFilters";
   import { workspacePath } from "$lib/workspacePaths";
   import { describeCron } from "$lib/topicPatch";
+  import ArchiveButton from "$lib/components/ArchiveButton.svelte";
   import ConfirmModal from "$lib/components/ConfirmModal.svelte";
+  import TrashButton from "$lib/components/TrashButton.svelte";
 
   /** Virtual filter: non-closed topics (matches dashboard "Open"); distinct from status=active|paused. */
   const STATUS_OPEN_NOT_CLOSED = "__open__";
@@ -847,69 +849,27 @@
               >
             </div>
           </a>
-          <div
-            class="hidden shrink-0 items-center gap-1 border-l border-[var(--ui-border)] px-2 sm:flex"
-          >
-            {#if isTopicArchived(topic)}
-              <button
-                class="cursor-pointer rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg-soft)] px-2 py-1 text-[11px] font-medium text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-                onclick={() => void unarchiveTopicRow(topic.id)}
-                type="button"
-              >
-                Unarchive
-              </button>
-            {:else}
-              <button
-                class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-[var(--ui-accent)] disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={Boolean(archiveBusyId) || Boolean(trashBusyId)}
-                onclick={() =>
-                  void (confirmModal = {
-                    open: true,
-                    action: "archive",
-                    entityId: topic.id,
-                  })}
-                title="Archive"
-                type="button"
-              >
-                <svg
-                  class="h-3.5 w-3.5"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"
-                  />
-                </svg>
-              </button>
-            {/if}
-            <button
-              class="cursor-pointer rounded-md p-1 text-[var(--ui-text-muted)] transition-colors hover:bg-[var(--ui-border)] hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={Boolean(trashBusyId) || Boolean(archiveBusyId)}
-              onclick={() =>
+          <div class="hidden shrink-0 items-center gap-1 px-2 sm:flex">
+            <ArchiveButton
+              archived={isTopicArchived(topic)}
+              busy={Boolean(archiveBusyId) || Boolean(trashBusyId)}
+              onarchive={() =>
+                void (confirmModal = {
+                  open: true,
+                  action: "archive",
+                  entityId: topic.id,
+                })}
+              onunarchive={() => void unarchiveTopicRow(topic.id)}
+            />
+            <TrashButton
+              busy={Boolean(trashBusyId) || Boolean(archiveBusyId)}
+              ontrash={() =>
                 (confirmModal = {
                   open: true,
                   action: "trash",
                   entityId: topic.id,
                 })}
-              title="Move to trash"
-              type="button"
-            >
-              <svg
-                class="h-3.5 w-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                />
-              </svg>
-            </button>
+            />
           </div>
         </div>
       {/each}

--- a/web-ui/tests/e2e/boards.spec.js
+++ b/web-ui/tests/e2e/boards.spec.js
@@ -164,7 +164,7 @@ function buildWorkspace(
             decision_request_count: workspaceInbox.filter(
               (item) =>
                 item.thread_id === card.thread_id &&
-                item.category === "decision_needed",
+                item.category === "action_needed",
             ).length,
             decision_count: 0,
             recommendation_count: 0,
@@ -315,7 +315,7 @@ test("board UI supports create/edit and card mutation flows", async ({
     {
       id: "inbox-review-1",
       thread_id: "thread-review",
-      category: "decision_needed",
+      category: "action_needed",
       title: "Need sign-off on review prep",
       refs: ["thread:thread-review"],
       source_event_time: "2026-03-05T05:30:00.000Z",

--- a/web-ui/tests/e2e/headless-smoke.spec.js
+++ b/web-ui/tests/e2e/headless-smoke.spec.js
@@ -54,9 +54,8 @@ test("mocked core smoke flow: inbox -> threads -> thread detail -> post message 
         items: [
           {
             id: "inbox-100",
-            category: "decision_needed",
+            category: "action_needed",
             title: "Approve onboarding exception handling",
-            recommended_action: "Record a decision on escalation path.",
             thread_id: "thread-onboarding",
             refs: ["thread:thread-onboarding"],
           },

--- a/web-ui/tests/e2e/inbox.spec.js
+++ b/web-ui/tests/e2e/inbox.spec.js
@@ -12,27 +12,24 @@ test("inbox triage shows urgency summary and acknowledging removes an item", asy
   let inboxItems = [
     {
       id: "inbox-001",
-      category: "decision_needed",
+      category: "action_needed",
       title: "Approve onboarding exception handling",
-      recommended_action: "Record a decision on escalation path.",
       thread_id: "thread-onboarding",
       related_refs: ["thread:thread-onboarding"],
       source_event_time: hoursAgo(30),
     },
     {
       id: "inbox-002",
-      category: "exception",
+      category: "risk_exception",
       title: "Missing legal signer",
-      recommended_action: "Acknowledge and assign owner.",
       thread_id: "thread-onboarding",
       related_refs: ["event:evt-1001"],
       source_event_time: hoursAgo(1),
     },
     {
       id: "inbox-003",
-      category: "work_item_risk",
-      title: "Work item risk",
-      recommended_action: "Adjust due date.",
+      category: "attention",
+      title: "Review updated runbook draft",
       thread_id: "thread-incident-42",
       related_refs: ["thread:thread-incident-42"],
       source_event_time: hoursAgo(60),
@@ -112,30 +109,27 @@ test("inbox urgency filters reduce visible cards", async ({ page }) => {
   const inboxItems = [
     {
       id: "inbox-001",
-      category: "decision_needed",
+      category: "action_needed",
       title: "Approve onboarding exception handling",
-      recommended_action: "Record a decision on escalation path.",
       thread_id: "thread-onboarding",
       related_refs: ["thread:thread-onboarding"],
       source_event_time: hoursAgo(30),
     },
     {
       id: "inbox-002",
-      category: "exception",
+      category: "risk_exception",
       title: "Missing legal signer",
-      recommended_action: "Acknowledge and assign owner.",
       thread_id: "thread-onboarding",
       related_refs: ["event:evt-1001"],
-      source_event_time: hoursAgo(1),
+      source_event_time: hoursAgo(9), // 9h old → 84+6=90 → immediate
     },
     {
       id: "inbox-003",
-      category: "work_item_risk",
-      title: "Work item risk",
-      recommended_action: "Adjust due date.",
+      category: "attention",
+      title: "Needs attention",
       thread_id: "thread-incident-42",
       related_refs: ["thread:thread-incident-42"],
-      source_event_time: hoursAgo(60),
+      source_event_time: hoursAgo(1),
     },
   ];
 
@@ -183,11 +177,6 @@ test("inbox urgency filters reduce visible cards", async ({ page }) => {
   await expect(page.getByTestId("inbox-card-inbox-002")).toBeVisible();
   await expect(page.getByTestId("inbox-card-inbox-001")).toHaveCount(0);
   await expect(page.getByTestId("inbox-card-inbox-003")).toHaveCount(0);
-
-  await urgencySelect.selectOption("aging");
-  await expect(page.getByTestId("inbox-card-inbox-003")).toBeVisible();
-  await expect(page.getByTestId("inbox-card-inbox-001")).toBeVisible();
-  await expect(page.getByTestId("inbox-card-inbox-002")).toHaveCount(0);
 });
 
 test("recording a decision marks only the selected inbox item", async ({
@@ -202,18 +191,16 @@ test("recording a decision marks only the selected inbox item", async ({
   let inboxItems = [
     {
       id: decidedItemId,
-      category: "decision_needed",
+      category: "action_needed",
       title: "Approve onboarding exception handling",
-      recommended_action: "Record a decision on escalation path.",
       thread_id: sharedThreadId,
       related_refs: [`thread:${sharedThreadId}`],
       source_event_time: hoursAgo(30),
     },
     {
       id: otherItemId,
-      category: "exception",
+      category: "risk_exception",
       title: "Missing legal signer",
-      recommended_action: "Acknowledge and assign owner.",
       thread_id: sharedThreadId,
       related_refs: ["event:evt-1001"],
       source_event_time: hoursAgo(1),
@@ -310,18 +297,16 @@ test("undo returns a queued inbox decision before it is sent to core", async ({
   const inboxItems = [
     {
       id: decidedItemId,
-      category: "decision_needed",
+      category: "action_needed",
       title: "Approve onboarding exception handling",
-      recommended_action: "Record a decision on escalation path.",
       thread_id: sharedThreadId,
       related_refs: [`thread:${sharedThreadId}`],
       source_event_time: hoursAgo(30),
     },
     {
       id: otherItemId,
-      category: "exception",
+      category: "risk_exception",
       title: "Missing legal signer",
-      recommended_action: "Acknowledge and assign owner.",
       thread_id: sharedThreadId,
       related_refs: ["event:evt-1001"],
       source_event_time: hoursAgo(1),
@@ -488,9 +473,8 @@ test("inbox thread context shows subject link for decisions", async ({
         items: [
           {
             id: "inbox-001",
-            category: "decision_needed",
+            category: "action_needed",
             title: "Approve onboarding exception handling",
-            recommended_action: "Record a decision on escalation path.",
             thread_id: threadId,
             refs: [`thread:${threadId}`],
             source_event_time: hoursAgo(4),

--- a/web-ui/tests/e2e/shell.spec.js
+++ b/web-ui/tests/e2e/shell.spec.js
@@ -61,9 +61,11 @@ test("renders a dashboard on / and routes into inbox", async ({ page }) => {
     page.getByRole("heading", { name: "Recent Docs" }),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Review inbox" }).click();
+  await page.getByRole("link", { name: "Inbox", exact: true }).click();
   await expect(page).toHaveURL(/\/inbox$/);
-  await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Inbox", exact: true }),
+  ).toBeVisible();
 });
 
 test("shows partial-failure messaging when one dashboard source is unavailable", async ({

--- a/web-ui/tests/unit/dashboardSummary.test.js
+++ b/web-ui/tests/unit/dashboardSummary.test.js
@@ -11,27 +11,16 @@ import {
 describe("dashboard summaries", () => {
   it("summarizes inbox categories in expected order", () => {
     const summary = buildInboxCategorySummary([
-      { category: "exception" },
-      { category: "decision_needed" },
-      { category: "decision_needed" },
+      { category: "risk_exception" },
+      { category: "action_needed" },
+      { category: "action_needed" },
       { category: "unknown" },
     ]);
 
     expect(summary).toEqual([
-      { category: "decision_needed", label: "Needs Decision", count: 2 },
-      {
-        category: "intervention_needed",
-        label: "Needs Intervention",
-        count: 0,
-      },
-      { category: "exception", label: "Exception", count: 1 },
-      { category: "work_item_risk", label: "Work item risk", count: 0 },
-      { category: "stale_topic", label: "Stale Topic", count: 0 },
-      {
-        category: "document_attention",
-        label: "Document Attention",
-        count: 0,
-      },
+      { category: "action_needed", label: "Action needed", count: 2 },
+      { category: "risk_exception", label: "Risk / Exception", count: 1 },
+      { category: "attention", label: "Attention", count: 0 },
       { category: "unknown", label: "unknown", count: 1 },
     ]);
   });

--- a/web-ui/tests/unit/inboxUtils.test.js
+++ b/web-ui/tests/unit/inboxUtils.test.js
@@ -18,32 +18,26 @@ describe("inbox grouping", () => {
     const grouped = groupInboxItems(
       [
         {
-          id: "new-decision",
-          category: "decision_needed",
-          title: "Decision just raised",
+          id: "new-action",
+          category: "action_needed",
+          title: "Action just raised",
           source_event_time: "2026-03-07T11:00:00.000Z",
         },
         {
           id: "old-risk",
-          category: "work_item_risk",
+          category: "risk_exception",
           title: "Aging risk",
           source_event_time: "2026-03-03T10:00:00.000Z",
         },
         {
-          id: "new-intervention",
-          category: "intervention_needed",
-          title: "Human needs to publish the approved post",
-          source_event_time: "2026-03-07T11:30:00.000Z",
-        },
-        {
-          id: "old-decision",
-          category: "decision_needed",
+          id: "old-action",
+          category: "action_needed",
           source_event_time: "2026-03-03T10:00:00.000Z",
-          title: "Decision waiting for days",
+          title: "Action waiting for days",
         },
         {
-          id: "fresh-exception",
-          category: "exception",
+          id: "fresh-risk",
+          category: "risk_exception",
           source_event_time: "2026-03-07T10:00:00.000Z",
           title: "Fresh exception",
         },
@@ -52,50 +46,46 @@ describe("inbox grouping", () => {
     );
 
     expect(grouped.map((group) => group.category)).toEqual([
-      "decision_needed",
-      "intervention_needed",
-      "exception",
-      "work_item_risk",
-      "stale_topic",
-      "document_attention",
+      "action_needed",
+      "risk_exception",
+      "attention",
     ]);
 
     expect(grouped[0].items.map((item) => item.id)).toEqual([
-      "old-decision",
-      "new-decision",
+      "old-action",
+      "new-action",
     ]);
     expect(grouped[1].items.map((item) => item.id)).toEqual([
-      "new-intervention",
+      "old-risk",
+      "fresh-risk",
     ]);
-    expect(grouped[2].items.map((item) => item.id)).toEqual([
-      "fresh-exception",
-    ]);
-    expect(grouped[3].items.map((item) => item.id)).toEqual(["old-risk"]);
-    expect(grouped[4].items).toEqual([]);
-    expect(grouped[5].items).toEqual([]);
+    expect(grouped[2].items).toEqual([]);
   });
 });
 
 describe("inbox urgency derivation", () => {
   it("derives urgency level from category + source event age", () => {
     const now = "2026-03-07T12:00:00.000Z";
+    // risk_exception base=84, aged 8h → 84+6=90 → immediate
     const immediate = deriveInboxUrgency(
       {
-        category: "exception",
-        source_event_time: "2026-03-07T10:00:00.000Z",
+        category: "risk_exception",
+        source_event_time: "2026-03-07T04:00:00.000Z",
       },
       { now },
     );
+    // action_needed base=76, fresh → 76 → high (>=74)
     const high = deriveInboxUrgency(
       {
-        category: "decision_needed",
+        category: "action_needed",
         source_event_time: "2026-03-07T11:30:00.000Z",
       },
       { now },
     );
+    // attention base=58, fresh → 58 → normal
     const normal = deriveInboxUrgency(
       {
-        category: "work_item_risk",
+        category: "attention",
         source_event_time: "2026-03-07T11:30:00.000Z",
       },
       { now },
@@ -107,9 +97,10 @@ describe("inbox urgency derivation", () => {
   });
 
   it("parses ISO now values when computing age-based urgency boosts", () => {
+    // action_needed base=76, aged 26h → 76+10=86 → high
     const urgency = deriveInboxUrgency(
       {
-        category: "decision_needed",
+        category: "action_needed",
         source_event_time: "2026-03-06T10:00:00.000Z",
       },
       { now: "2026-03-07T12:00:00.000Z" },
@@ -125,17 +116,17 @@ describe("inbox urgency derivation", () => {
     const items = [
       {
         id: "1",
-        category: "exception",
-        source_event_time: "2026-03-07T10:00:00.000Z",
+        category: "risk_exception",
+        source_event_time: "2026-03-07T04:00:00.000Z", // 8h old → 84+6=90 → immediate
       },
       {
         id: "2",
-        category: "decision_needed",
-        source_event_time: "2026-03-07T11:00:00.000Z",
+        category: "action_needed",
+        source_event_time: "2026-03-07T11:00:00.000Z", // fresh → 76 → high
       },
       {
         id: "3",
-        category: "work_item_risk",
+        category: "attention", // no timestamp → base 58 → normal
       },
     ];
 
@@ -261,7 +252,7 @@ describe("inbox typed-ref rendering targets", () => {
   it("formats board panel resource line from subject_ref, not misleading topic_id", () => {
     const cardAnchored = enrichInboxItem({
       id: "1",
-      category: "work_item_risk",
+      category: "risk_exception",
       subject_ref: "card:card-1",
       title: "Risk",
       topic_id: "topic-extra",
@@ -273,7 +264,7 @@ describe("inbox typed-ref rendering targets", () => {
 
     const topicAnchored = enrichInboxItem({
       id: "2",
-      category: "stale_topic",
+      category: "risk_exception",
       subject_ref: "topic:topic-1",
       title: "Stale",
       thread_id: "thread-1",
@@ -284,7 +275,7 @@ describe("inbox typed-ref rendering targets", () => {
 
     const threadAnchored = enrichInboxItem({
       id: "3",
-      category: "decision_needed",
+      category: "action_needed",
       subject_ref: "thread:thread-1",
       title: "Decide",
       topic_id: "topic-1",
@@ -297,7 +288,7 @@ describe("inbox typed-ref rendering targets", () => {
       formatInboxItemBoardPanelResourceLine(
         enrichInboxItem({
           id: "4",
-          category: "document_attention",
+          category: "attention",
           subject_ref: "document:doc-1",
           title: "Doc",
         }),
@@ -309,7 +300,7 @@ describe("inbox typed-ref rendering targets", () => {
         enrichInboxItem({
           id: "5",
           thread_id: "thread-only",
-          category: "stale_topic",
+          category: "risk_exception",
           title: "Legacy",
         }),
       ),

--- a/web-ui/tests/unit/oarCoreClient.test.js
+++ b/web-ui/tests/unit/oarCoreClient.test.js
@@ -320,13 +320,13 @@ describe("oarCoreClient error messaging", () => {
     });
 
     await client.ackInboxItem({
-      inbox_item_id: "inbox:decision_needed:thread-1:none:evt-1",
+      inbox_item_id: "inbox:action_needed:thread-1:none:evt-1",
       subject_ref: "thread:thread-1",
     });
 
     expect(seenRequests).toEqual([
       {
-        url: "http://core.test/inbox/inbox%3Adecision_needed%3Athread-1%3Anone%3Aevt-1/acknowledge",
+        url: "http://core.test/inbox/inbox%3Aaction_needed%3Athread-1%3Anone%3Aevt-1/acknowledge",
         method: "POST",
         body: expect.any(String),
       },


### PR DESCRIPTION
## Summary

This branch delivers a tighter inbox category model (core + web-ui), small workspace/dev fixes, dashboard copy cleanup, and a consolidated archive/trash control surface across operator lists and thread surfaces.

## Changes

- **Inbox:** Collapse inbox categories to `action_needed`, `risk_exception`, and `attention` (core handlers/tests + web-ui inbox consumption).
- **Dev / fixtures:** Ignore ephemeral `.oar-workspace-seed-verify-*` roots; align web-ui seed data with passkey usernames; simplify board page wiring.
- **Dashboard:** Remove the "Review inbox" header shortcut.
- **Archive / trash UX:** Add `ArchiveButton` and `TrashButton`; migrate docs, threads (topics), boards, artifacts, topic detail, document detail, timeline events, and thread messages. Docs list right column matches artifacts (metadata + actions on one row). Timeline actions are always visible (no hover-only reveal).
- **Copy:** Timeline confirm modal for `message_posted` now states reply cascade (matches `MessagesTab` and core behavior). Messages empty-state copy fix (topics → messages).

## Validation

- `make check` (repo root) — pass before push.

## Review notes

Follow-up ideas (non-blocking): optional `aria-label`s on icon-only archive/trash buttons; narrow breakpoints still hide list-row actions behind `sm:flex` (detail surfaces remain available).

Made with [Cursor](https://cursor.com)