### PR TITLE
[codex] Keep hosted workspace login on control-plane auth

### DIFF
--- a/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
+++ b/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
@@ -40,6 +40,14 @@ function workspaceRelativeReturnPath(event, organizationSlug, workspaceSlug) {
     organizationSlug,
     workspaceSlug,
   );
+  if (appPath === "/login") {
+    return sanitizeHostedReturnPath(
+      event.url.searchParams.get("return_to") ??
+        event.url.searchParams.get("return_path") ??
+        "/",
+      "/",
+    );
+  }
   return sanitizeHostedReturnPath(`${appPath}${event.url.search}`, "/");
 }
 

--- a/web-ui/src/routes/o/[organization]/w/[workspace]/login/+page.server.js
+++ b/web-ui/src/routes/o/[organization]/w/[workspace]/login/+page.server.js
@@ -8,37 +8,6 @@ import { handleLaunchInstruction } from "$lib/server/outOfWorkspace/launchSessio
 import { resolveWorkspaceInRoute } from "$lib/server/workspaceResolver";
 import { workspacePath } from "$lib/workspacePaths";
 
-async function loadWorkspaceHumanAuthMode(event, coreBaseUrl) {
-  if (!coreBaseUrl) {
-    return { available: false, mode: "" };
-  }
-  const handshakeURL = new URL("/meta/handshake", `${coreBaseUrl}/`).toString();
-  try {
-    const response = await event.fetch(handshakeURL, {
-      headers: {
-        accept: "application/json",
-      },
-    });
-    if (!response.ok) {
-      return { available: false, mode: "" };
-    }
-    const payload = await response.json();
-    return {
-      available: true,
-      mode: String(payload?.human_auth_mode ?? "").trim(),
-    };
-  } catch {
-    return { available: false, mode: "" };
-  }
-}
-
-function isHostedWorkspaceContext(workspace) {
-  const workspaceID = String(
-    workspace?.workspaceId ?? workspace?.id ?? "",
-  ).trim();
-  return workspaceID !== "";
-}
-
 export async function load(event) {
   const provider =
     event.locals?.outOfWorkspace ?? getOutOfWorkspaceProvider(privateEnv);
@@ -83,17 +52,7 @@ export async function load(event) {
     );
   }
 
-  const authModeLookup = await loadWorkspaceHumanAuthMode(
-    event,
-    workspace.coreBaseUrl,
-  );
-  const hostedWorkspace = isHostedWorkspaceContext(workspace);
-  const failClosedToHostedSSO =
-    hostedWorkspace &&
-    (!authModeLookup.available ||
-      authModeLookup.mode === "external_grant" ||
-      authModeLookup.mode === "");
-  if (!failClosedToHostedSSO) {
+  if (provider.mode !== "hosted") {
     return;
   }
 

--- a/web-ui/tests/unit/workspaceLayoutServer.integration.test.js
+++ b/web-ui/tests/unit/workspaceLayoutServer.integration.test.js
@@ -174,6 +174,32 @@ describe("workspace +layout.server.js (integration with real resolver)", () => {
     expect(thrown.location).toContain("/hosted/signin");
   });
 
+  it("uses the nested login return_to as hosted return_path", async () => {
+    resetEnv({
+      ANX_CONTROL_BASE_URL: "http://127.0.0.1:8100",
+    });
+    const fetchFn = makeCpFetchMock({ workspaces: [] });
+
+    const event = createEvent({
+      pathname: "/o/my-org/w/my-ws/login?return_to=%2Faccess",
+      fetchFn,
+      cookies: {},
+    });
+
+    let thrown;
+    try {
+      await load(event);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown.status).toBe(307);
+    expect(thrown.location).toContain("/hosted/signin");
+    expect(thrown.location).toContain("return_path=%2Faccess");
+    expect(thrown.location).not.toContain("%2Flogin");
+  });
+
   it("returns workspace data when the CP returns a fully ready workspace with a core origin", async () => {
     const fetchFn = makeCpFetchMock({
       workspaces: [

--- a/web-ui/tests/unit/workspaceLoginRoute.test.js
+++ b/web-ui/tests/unit/workspaceLoginRoute.test.js
@@ -124,6 +124,49 @@ describe("workspace login route", () => {
     await expect(load(event)).resolves.toBeUndefined();
   });
 
+  it("does not render workspace-local login when hosted provider is active", async () => {
+    workspaceResolverMocks.resolveWorkspaceInRoute.mockResolvedValue({
+      organizationSlug: "local",
+      workspaceSlug: "acme",
+      workspace: {
+        coreBaseUrl: "https://core.example.test",
+        workspaceId: "ws_123",
+      },
+      error: null,
+    });
+    authSessionMocks.loadWorkspaceAuthenticatedAgent.mockResolvedValue(null);
+
+    const event = createEvent({
+      fetch: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              human_auth_mode: "workspace_local",
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          ),
+      ),
+      locals: {
+        outOfWorkspace: mockHostedProvider({
+          beginLaunchSession: vi.fn(async () => ({
+            kind: "needs_signin",
+            signInUrl: "/hosted/signin?workspace=acme&workspace_id=ws_123",
+          })),
+        }),
+      },
+    });
+
+    await expect(load(event)).rejects.toMatchObject({
+      status: 307,
+      location: "/hosted/signin?workspace=acme&workspace_id=ws_123",
+    });
+  });
+
   it("fails closed to hosted sign-in when hosted handshake lookup fails", async () => {
     workspaceResolverMocks.resolveWorkspaceInRoute.mockResolvedValue({
       organizationSlug: "local",


### PR DESCRIPTION
## Summary

Fixes hosted workspace login routing so hosted deployments do not render the self-hosted workspace passkey login page at `/o/{org}/w/{workspace}/login`.

## Root cause

The nested workspace login route inferred whether to launch hosted auth from workspace metadata and core handshake state. In hosted mode, that still left a path where a stale or missing workspace-core session could land on the self-hosted login surface.

## Changes

- Make the nested workspace login route use the out-of-workspace provider mode as the source of truth: hosted mode always launches through the control plane.
- Preserve `return_to` / `return_path` from nested `/login` URLs as the hosted `return_path`, so `/login?return_to=/access` recovers to `/access` instead of nesting the login route.
- Add regression tests for hosted login routing and return-path normalization.

## Validation

- `pnpm -C web-ui exec vitest run tests/unit/workspaceLoginRoute.test.js tests/unit/workspaceLayoutServer.integration.test.js`
- `pnpm -C web-ui exec prettier --check 'src/routes/o/[organization]/w/[workspace]/+layout.server.js' 'src/routes/o/[organization]/w/[workspace]/login/+page.server.js' tests/unit/workspaceLayoutServer.integration.test.js tests/unit/workspaceLoginRoute.test.js`
- `ADAPTER=node pnpm -C web-ui run build`

Note: full `pnpm -C web-ui test` is currently blocked by pre-existing Prettier drift in unrelated files.