### PR TITLE
[codex] Route hosted client auth fallback to control plane

### DIFF
--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -34,7 +34,10 @@
   import SessionEndedOverlay from "$lib/components/SessionEndedOverlay.svelte";
   import { listAllPrincipals } from "$lib/authPrincipals";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
-  import { sanitizeHostedReturnPath } from "$lib/hosted/launchFlow.js";
+  import {
+    buildHostedSignInPath,
+    sanitizeHostedReturnPath,
+  } from "$lib/hosted/launchFlow.js";
   import { hostedSession, loadHostedSession } from "$lib/hosted/session.js";
   import { coreClient } from "$lib/coreClient";
   import { computeWorkspaceShellIdentity } from "$lib/workspaceShellIdentity.js";
@@ -340,16 +343,25 @@
       return;
     }
 
-    const loginPath = workspacePath(org, ws, "/login");
     const returnTo = sanitizeHostedReturnPath(
       `${currentAppPath || "/"}${$page.url.search || ""}`,
     );
-    const params = new URLSearchParams();
-    if (returnTo !== "/") {
-      params.set("return_to", returnTo);
-    }
-    const destination =
-      params.size > 0 ? `${loginPath}?${params.toString()}` : loginPath;
+    const destination = hostedMode
+      ? buildHostedSignInPath({
+          workspaceSlug: ws,
+          workspaceId: $page.data?.workspace?.workspaceId,
+          returnPath: returnTo,
+        })
+      : (() => {
+          const loginPath = workspacePath(org, ws, "/login");
+          const params = new URLSearchParams();
+          if (returnTo !== "/") {
+            params.set("return_to", returnTo);
+          }
+          return params.size > 0
+            ? `${loginPath}?${params.toString()}`
+            : loginPath;
+        })();
 
     const generation = ++loginRedirectGeneration;
 

--- a/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
+++ b/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
@@ -151,6 +151,9 @@ export async function load(event) {
       label: resolved.workspace.label,
       description: resolved.workspace.description,
       coreBaseUrl: String(resolved.workspace.coreBaseUrl ?? "").trim(),
+      workspaceId: String(
+        resolved.workspace.workspaceId ?? resolved.workspace.id ?? "",
+      ).trim(),
     },
   };
 }

--- a/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
+++ b/web-ui/src/routes/o/[organization]/w/[workspace]/+layout.server.js
@@ -151,9 +151,7 @@ export async function load(event) {
       label: resolved.workspace.label,
       description: resolved.workspace.description,
       coreBaseUrl: String(resolved.workspace.coreBaseUrl ?? "").trim(),
-      workspaceId: String(
-        resolved.workspace.workspaceId ?? resolved.workspace.id ?? "",
-      ).trim(),
+      workspaceId,
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes the remaining hosted redirect path where the client-side workspace shell could navigate to `/o/{org}/w/{workspace}/login` when it had no workspace-core agent session.

## Root cause

The server-side nested login route was already fixed to avoid rendering self-hosted passkey auth in hosted mode, but the root workspace shell still had a browser fallback that always built the workspace-local `/login` URL. If a hosted user had a control-plane session but no valid workspace-core session, client navigation from the workspace home could still land on the self-host login path.

## Changes

- Use `buildHostedSignInPath` for the client-side auth fallback when `shellCapabilities.mode === "hosted"`.
- Include `workspaceId` in workspace layout data so `/hosted/signin` can auto-continue the launch flow instead of only showing provider buttons.

## Validation

- `pnpm -C web-ui exec prettier --check 'src/routes/+layout.svelte' 'src/routes/o/[organization]/w/[workspace]/+layout.server.js'`
- `pnpm -C web-ui exec vitest run tests/unit/workspaceLayoutServer.integration.test.js tests/unit/workspaceLoginRoute.test.js`
- `ADAPTER=node pnpm -C web-ui run build`

Operational follow-up on the host:

- Added `/v1/internal/accounts/status` to the Caddy control-plane route matcher so workspace-core account status refresh reaches the control plane instead of the web UI.
- Restarted the existing workspace core container to clear failed account-status refresh cache.