### PR TITLE
[codex] Add bundled Hermes ACP bridge adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.venv/
 .bin/
 .pnpm-store/
 .tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+default_install_hook_types: [pre-commit, pre-push]
+
+repos:
+  - repo: local
+    hooks:
+      - id: cli-check
+        name: CLI checks
+        entry: make cli-check
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+      - id: cli-integration-test
+        name: CLI integration tests
+        entry: make cli-integration-test
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CLI_DIR := cli
 WEB_UI_DIR := web-ui
 BRIDGE_DIR := adapters/agent-bridge
 HTTP_RECORD_DIR := tools/anx-http-record
+PYTHON ?= python3
+PRE_COMMIT_BIN := $(CURDIR)/.venv/bin/pre-commit
 
 CORE_HOST ?= 127.0.0.1
 CORE_PORT ?= 8000
@@ -28,6 +30,9 @@ help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 setup: ## Install repo tooling plus dependencies for web-ui, core, and cli
+	$(PYTHON) -m venv .venv
+	.venv/bin/pip install --upgrade pip pre-commit
+	$(PRE_COMMIT_BIN) install --install-hooks -t pre-commit -t pre-push
 	./scripts/install-actionlint.sh
 	pnpm install
 	cd $(CORE_DIR) && go mod download

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make serve
 make e2e-smoke
 ```
 
-`make setup` also installs the pinned local `actionlint` binary used by repo workflow checks into `.bin/`.
+`make setup` also installs pre-commit/pre-push hooks into a repo-local `.venv/` and installs the pinned local `actionlint` binary used by repo workflow checks into `.bin/`.
 
 Regenerate contract artifacts from the canonical OpenAPI contracts:
 

--- a/adapters/agent-bridge/README.md
+++ b/adapters/agent-bridge/README.md
@@ -8,11 +8,24 @@ This package implements three things:
 
 1. **Wake registration metadata** stored on the authenticated ANX principal
 2. **Bridge readiness check-ins** stored in ANX events and reflected in that registration
-3. **Pluggable local adapters** that consume wake events and invoke code you write (subprocess JSON or optional in-process Python plugin)
-
-ANX does **not** ship or maintain integrations for specific third-party agent products. You implement a small adapter (shell, Python, Node, etc.) against a stable JSON contract.
+3. **Pluggable local adapters** that consume wake events and invoke code you write (subprocess JSON, the bundled Hermes ACP subprocess adapter, or optional in-process Python plugin)
 
 ## Adapter kinds
+
+### `hermes` (recommended for Hermes ACP operators)
+
+`anx bridge init-config --kind hermes` writes a config that uses the bundled adapter:
+
+```toml
+[bridge]
+driver_kind = "hermes"
+adapter_kind = "hermes"
+
+[adapter]
+kind = "hermes"
+```
+
+The bundled adapter starts Hermes over ACP stdio through the same subprocess isolation used by custom adapters, creates or resumes an ACP session, collects streamed text from `session/update` notifications, and returns the response through the stable bridge JSON contract. It discovers the Hermes binary from `HERMES_BIN`, `[adapter].hermes_bin`, or `hermes` on `PATH`. Optional controls: `HERMES_ARGS` / `[adapter].hermes_args`, `HERMES_CWD` / `[adapter].hermes_cwd`, `HERMES_INTERACTIVE` / `[adapter].interactive`, and `[adapter].command` when you need to override the Python module entrypoint.
 
 ### `subprocess` (recommended)
 
@@ -136,6 +149,7 @@ Minimum config contract:
 - `agent.toml` `[auth] state_path` optional; defaults to `profiles/default.json`
 - `wake.toml` with one or more `[[workspaces]]` entries; this is the local wake subscription source
 - bridge `[runtime] state_dir` optional; defaults under the agent home
+- **Hermes ACP:** generated as `[adapter] kind = "hermes"`, optional `command`, `hermes_bin`, `hermes_args`, `hermes_cwd`, `interactive`
 - **Subprocess:** `[adapter] kind = "subprocess"`, `command` (argv array), optional `cwd`, `env`, `timeout_seconds`, `doctor_timeout_seconds`, `doctor_command`
 
 ### JSON contract (subprocess)
@@ -155,8 +169,8 @@ Minimum config contract:
 
 1. `anx bridge install` and `anx-agent-bridge --version`
 2. Note the deployment `workspace_id`
-3. `anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <id> --handle <handle> --adapter-entrypoint ./adapter.py`
-4. Implement `./adapter.py` (or change `[adapter].command` to any executable). Validate with `anx-agent-bridge adapter contract --config ./bridge.toml`
+3. For Hermes, `anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <id> --handle <handle>`
+4. For custom adapters, use `--kind subprocess` or `--kind python-plugin`; validate subprocess adapters with `anx-agent-bridge adapter contract --config ./bridge.toml`
 5. `anx bridge import-auth --config ./bridge.toml --from-profile <agent>` when auth exists
 6. `anx-agent-bridge auth register ... --apply-registration` when auth does not exist
 7. `anx bridge start --config ./bridge.toml`
@@ -167,6 +181,7 @@ Minimum config contract:
 - `anx_agent_bridge/registry.py` - registration apply/status and check-in publication
 - `anx_agent_bridge/bridge.py` - wake claim, adapter dispatch, reply/failure writeback
 - `anx_agent_bridge/adapters/adapter_contract.py` - JSON schemas and sample payloads
+- `anx_agent_bridge/adapters/hermes_acp.py` - bundled Hermes ACP subprocess adapter
 - `anx_agent_bridge/adapters/subprocess_adapter.py` - generic subprocess runner
 - `anx_agent_bridge/adapters/python_plugin.py` - explicit module loader
 - `anx_agent_bridge/adapters/deterministic_ack.py` - test-only canned replies

--- a/adapters/agent-bridge/anx_agent_bridge/adapters/hermes_acp.py
+++ b/adapters/agent-bridge/anx_agent_bridge/adapters/hermes_acp.py
@@ -139,19 +139,19 @@ class _HermesClient:
 
 
 def _resolve_hermes_bin(settings: dict[str, Any]) -> str:
-    configured = _clean_string(settings.get("hermes_bin")) or _clean_string(os.environ.get("HERMES_BIN"))
+    configured = _clean_string(os.environ.get("HERMES_BIN")) or _clean_string(settings.get("hermes_bin"))
     if configured:
         return str(Path(configured).expanduser())
     return shutil.which("hermes") or ""
 
 
 def _resolve_hermes_args(settings: dict[str, Any]) -> list[str]:
-    raw = settings.get("hermes_args")
-    if isinstance(raw, list) and raw:
-        return [str(item) for item in raw if str(item).strip()]
     env_args = _clean_string(os.environ.get("HERMES_ARGS"))
     if env_args:
         return env_args.split()
+    raw = settings.get("hermes_args")
+    if isinstance(raw, list) and raw:
+        return [str(item) for item in raw if str(item).strip()]
     return list(DEFAULT_HERMES_ARGS)
 
 
@@ -328,7 +328,7 @@ def _session_update_text(update: Any) -> str:
     if isinstance(content, dict):
         if _clean_string(content.get("type")) == "text":
             return _clean_string(content.get("text"))
-        return _clean_string(content.get("text"))
+        return ""
     return _clean_string(data.get("text"))
 
 

--- a/adapters/agent-bridge/anx_agent_bridge/adapters/hermes_acp.py
+++ b/adapters/agent-bridge/anx_agent_bridge/adapters/hermes_acp.py
@@ -1,0 +1,417 @@
+"""Bundled Hermes ACP subprocess adapter for ``anx-agent-bridge``.
+
+This module is intentionally a subprocess entrypoint, not an in-process bridge adapter.
+Hermes owns its ACP lifecycle; the Agent Nexus bridge owns wake claiming, auth, and writeback.
+Keeping the boundary JSON-over-stdio makes the bundled adapter easy for operators to copy and
+modify when they need local Hermes-specific behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_HERMES_ARGS = ["acp"]
+DEFAULT_PROTOCOL_VERSION = 1
+MODE_DISPATCH = "dispatch"
+MODE_DOCTOR = "doctor"
+RESPONSE_SCHEMA_VERSION = "anx-bridge-adapter-response/v1"
+
+
+def main() -> int:
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+        if not isinstance(request, dict):
+            raise ValueError("adapter request must be a JSON object")
+        mode = str(request.get("mode") or os.environ.get("ANX_BRIDGE_MODE") or "").strip()
+        settings = request.get("adapter") if isinstance(request.get("adapter"), dict) else {}
+        if mode == MODE_DOCTOR:
+            _print_response(_doctor(settings))
+            return 0
+        if mode == MODE_DISPATCH:
+            _print_response(asyncio.run(_dispatch(request, settings)))
+            return 0
+        raise ValueError(f"unsupported adapter mode: {mode!r}")
+    except Exception as exc:
+        print(f"hermes adapter error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _doctor(settings: dict[str, Any]) -> dict[str, Any]:
+    details: dict[str, Any] = {}
+    ok = True
+    messages: list[str] = []
+
+    hermes_bin = _resolve_hermes_bin(settings)
+    details["hermes_bin"] = hermes_bin or ""
+    if not hermes_bin:
+        ok = False
+        messages.append("Hermes binary not found; set HERMES_BIN or [adapter].hermes_bin")
+    else:
+        version = _probe_version(hermes_bin)
+        details["hermes_version"] = version
+        if not version:
+            messages.append("Hermes binary resolved, but version probing produced no output")
+
+    acp_mod = _import_acp()
+    details["acp_importable"] = acp_mod is not None
+    if acp_mod is None:
+        ok = False
+        messages.append("Python package `acp` is not importable in this adapter runtime")
+
+    details["cwd"] = _resolve_cwd(settings)
+    details["hermes_args"] = _resolve_hermes_args(settings)
+    details["interactive"] = _resolve_bool(settings, "interactive", "HERMES_INTERACTIVE", False)
+    return {
+        "schema_version": RESPONSE_SCHEMA_VERSION,
+        "ok": ok,
+        "message": "; ".join(messages) if messages else "Hermes ACP adapter is ready",
+        "details": details,
+    }
+
+
+async def _dispatch(request: dict[str, Any], settings: dict[str, Any]) -> dict[str, Any]:
+    hermes_bin = _resolve_hermes_bin(settings)
+    if not hermes_bin:
+        raise RuntimeError("Hermes binary not found; set HERMES_BIN or [adapter].hermes_bin")
+    acp_mod = _import_acp()
+    if acp_mod is None:
+        raise RuntimeError("Python package `acp` is not importable in this adapter runtime")
+
+    collector = _HermesClient(allow_first_permission=_resolve_bool(settings, "interactive", "HERMES_INTERACTIVE", False))
+    cmd = [hermes_bin, *_resolve_hermes_args(settings)]
+    cwd = _resolve_cwd(settings)
+    prompt_text = _build_prompt(request)
+    existing_session_id = _clean_string(request.get("existing_native_session_id"))
+
+    async with _spawn_agent_process(acp_mod, collector, cmd) as (conn, _proc):
+        await _call_initialize(conn)
+        if existing_session_id:
+            session_id = await _load_session(conn, cwd, existing_session_id)
+        else:
+            session_id = await _new_session(conn, cwd)
+        prompt_response = await _prompt(conn, session_id, prompt_text, acp_mod)
+
+    response_text = collector.response_text().strip() or _extract_response_text(prompt_response).strip()
+    if not response_text:
+        response_text = "Hermes completed the ACP turn without returning text."
+    return {
+        "schema_version": RESPONSE_SCHEMA_VERSION,
+        "response_text": response_text,
+        "native_session_id": session_id,
+        "metadata": {
+            "adapter_kind": "hermes",
+            "hermes_command": cmd,
+            "cwd": cwd,
+            "stop_reason": _get_value(prompt_response, "stopReason", "stop_reason"),
+        },
+    }
+
+
+class _HermesClient:
+    def __init__(self, *, allow_first_permission: bool) -> None:
+        self.allow_first_permission = allow_first_permission
+        self._chunks: list[str] = []
+
+    async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
+        text = _session_update_text(update)
+        if text:
+            self._chunks.append(text)
+
+    async def request_permission(self, options: Any, session_id: str, tool_call: Any, **kwargs: Any) -> dict[str, Any]:
+        if not self.allow_first_permission:
+            return {"outcome": {"outcome": "cancelled"}}
+        option_id = _first_permission_option_id(options)
+        if option_id:
+            return {"outcome": {"outcome": "selected", "option_id": option_id}}
+        return {"outcome": {"outcome": "cancelled"}}
+
+    def response_text(self) -> str:
+        return "".join(self._chunks)
+
+
+def _resolve_hermes_bin(settings: dict[str, Any]) -> str:
+    configured = _clean_string(settings.get("hermes_bin")) or _clean_string(os.environ.get("HERMES_BIN"))
+    if configured:
+        return str(Path(configured).expanduser())
+    return shutil.which("hermes") or ""
+
+
+def _resolve_hermes_args(settings: dict[str, Any]) -> list[str]:
+    raw = settings.get("hermes_args")
+    if isinstance(raw, list) and raw:
+        return [str(item) for item in raw if str(item).strip()]
+    env_args = _clean_string(os.environ.get("HERMES_ARGS"))
+    if env_args:
+        return env_args.split()
+    return list(DEFAULT_HERMES_ARGS)
+
+
+def _resolve_cwd(settings: dict[str, Any]) -> str:
+    raw = _clean_string(os.environ.get("HERMES_CWD")) or _clean_string(settings.get("hermes_cwd")) or _clean_string(settings.get("cwd"))
+    if not raw:
+        return os.getcwd()
+    return str(Path(raw).expanduser().resolve())
+
+
+def _resolve_bool(settings: dict[str, Any], key: str, env_key: str, default: bool) -> bool:
+    raw = os.environ.get(env_key)
+    if raw is None:
+        raw = settings.get(key)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _probe_version(hermes_bin: str) -> str:
+    for args in ([hermes_bin, "--version"], [hermes_bin, "version"]):
+        try:
+            proc = subprocess.run(args, check=False, text=True, capture_output=True, timeout=10)
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        output = (proc.stdout or proc.stderr or "").strip()
+        if output:
+            return output.splitlines()[0]
+    return ""
+
+
+def _import_acp() -> Any | None:
+    try:
+        return importlib.import_module("acp")
+    except ImportError:
+        return None
+
+
+def _spawn_agent_process(acp_mod: Any, client: _HermesClient, cmd: list[str]) -> Any:
+    spawn = getattr(acp_mod, "spawn_agent_process")
+    try:
+        return spawn(client, *cmd)
+    except TypeError:
+        return spawn(lambda _agent: client, *cmd)
+
+
+async def _call_initialize(conn: Any) -> Any:
+    if hasattr(conn, "initialize"):
+        try:
+            return await conn.initialize(protocol_version=DEFAULT_PROTOCOL_VERSION)
+        except TypeError:
+            pass
+        req = _schema_instance("InitializeRequest", protocolVersion=DEFAULT_PROTOCOL_VERSION)
+        if req is not None:
+            try:
+                return await conn.initialize(req)
+            except TypeError:
+                pass
+    return await _send_request(conn, "initialize", {"protocolVersion": DEFAULT_PROTOCOL_VERSION})
+
+
+async def _new_session(conn: Any, cwd: str) -> str:
+    if hasattr(conn, "new_session"):
+        try:
+            session = await conn.new_session(cwd=cwd, mcp_servers=[])
+            return _session_id(session)
+        except TypeError:
+            pass
+    if hasattr(conn, "newSession"):
+        req = _schema_instance("NewSessionRequest", cwd=cwd, mcpServers=[])
+        if req is not None:
+            try:
+                session = await conn.newSession(req)
+                return _session_id(session)
+            except TypeError:
+                pass
+    session = await _send_request(conn, "session/new", {"cwd": cwd, "mcpServers": []})
+    return _session_id(session)
+
+
+async def _load_session(conn: Any, cwd: str, session_id: str) -> str:
+    if hasattr(conn, "load_session"):
+        try:
+            session = await conn.load_session(cwd=cwd, session_id=session_id, mcp_servers=[])
+            return _optional_session_id(session) or session_id
+        except TypeError:
+            pass
+    if hasattr(conn, "loadSession"):
+        req = _schema_instance("LoadSessionRequest", cwd=cwd, sessionId=session_id, mcpServers=[])
+        if req is not None:
+            try:
+                session = await conn.loadSession(req)
+                return _optional_session_id(session) or session_id
+            except TypeError:
+                pass
+    session = await _send_request(conn, "session/load", {"cwd": cwd, "sessionId": session_id, "mcpServers": []})
+    return _optional_session_id(session) or session_id
+
+
+async def _prompt(conn: Any, session_id: str, prompt_text: str, acp_mod: Any) -> Any:
+    block = _text_block(acp_mod, prompt_text)
+    if hasattr(conn, "prompt"):
+        try:
+            return await conn.prompt(session_id=session_id, prompt=[block])
+        except TypeError:
+            pass
+        req = _schema_instance("PromptRequest", sessionId=session_id, prompt=[block])
+        if req is not None:
+            try:
+                return await conn.prompt(req)
+            except TypeError:
+                pass
+    return await _send_request(conn, "session/prompt", {"sessionId": session_id, "prompt": [block]})
+
+
+async def _send_request(conn: Any, method: str, params: dict[str, Any]) -> Any:
+    raw_conn = getattr(conn, "_conn", conn)
+    send_request = getattr(raw_conn, "send_request", None)
+    if send_request is None:
+        raise RuntimeError(f"ACP connection does not expose {method!r} or _conn.send_request")
+    return await send_request(method, params)
+
+
+def _schema_instance(name: str, **kwargs: Any) -> Any | None:
+    try:
+        schema = importlib.import_module("acp.schema")
+        cls = getattr(schema, name)
+        return cls(**kwargs)
+    except Exception:
+        return None
+
+
+def _text_block(acp_mod: Any, text: str) -> Any:
+    helper = getattr(acp_mod, "text_block", None)
+    if helper is not None:
+        return helper(text)
+    return {"type": "text", "text": text}
+
+
+def _build_prompt(request: dict[str, Any]) -> str:
+    packet = request.get("wake_packet") if isinstance(request.get("wake_packet"), dict) else {}
+    prompt_text = _clean_string(request.get("prompt_text"))
+    lines = [
+        "Agent Nexus wake request",
+        "",
+        f"Handle: {_nested(packet, 'target', 'handle')}",
+        f"Workspace: {_nested(packet, 'workspace', 'name')} ({_nested(packet, 'workspace', 'id')})",
+        f"Thread: {_nested(packet, 'thread', 'title')} ({_nested(packet, 'thread', 'id')})",
+        f"Trigger event: {_nested(packet, 'trigger', 'message_event_id')}",
+        f"Trigger text: {_nested(packet, 'trigger', 'text')}",
+    ]
+    summary = _nested(packet, "context_inline", "current_summary")
+    if summary:
+        lines.extend(["", "Current summary:", summary])
+    preferred = _nested(packet, "context_fetch", "preferred")
+    cli_fetch = packet.get("context_fetch", {}).get("cli", []) if isinstance(packet.get("context_fetch"), dict) else []
+    if preferred or cli_fetch:
+        lines.extend(["", "Context fetch:", f"Preferred: {preferred}"])
+        if isinstance(cli_fetch, list):
+            lines.extend(str(item) for item in cli_fetch if str(item).strip())
+    if prompt_text:
+        lines.extend(["", "Bridge prompt:", prompt_text])
+    return "\n".join(lines).strip()
+
+
+def _session_update_text(update: Any) -> str:
+    data = _to_plain(update)
+    if not isinstance(data, dict):
+        return ""
+    kind = _clean_string(data.get("sessionUpdate") or data.get("session_update"))
+    if kind and kind not in {"agent_message_chunk", "agentMessageChunk"}:
+        return ""
+    content = data.get("content")
+    if isinstance(content, dict):
+        if _clean_string(content.get("type")) == "text":
+            return _clean_string(content.get("text"))
+        return _clean_string(content.get("text"))
+    return _clean_string(data.get("text"))
+
+
+def _extract_response_text(response: Any) -> str:
+    data = _to_plain(response)
+    if isinstance(data, dict):
+        for key in ("response_text", "responseText", "text"):
+            value = _clean_string(data.get(key))
+            if value:
+                return value
+        content = data.get("content")
+        if isinstance(content, list):
+            return "".join(_clean_string(item.get("text")) for item in content if isinstance(item, dict))
+    return ""
+
+
+def _session_id(session: Any) -> str:
+    sid = _optional_session_id(session)
+    if not sid:
+        raise RuntimeError(f"ACP session response did not include a session id: {session!r}")
+    return sid
+
+
+def _optional_session_id(session: Any) -> str:
+    return _get_value(session, "sessionId", "session_id", "id")
+
+
+def _first_permission_option_id(options: Any) -> str:
+    data = _to_plain(options)
+    if isinstance(data, dict):
+        raw_options = data.get("options")
+    else:
+        raw_options = data
+    if isinstance(raw_options, list) and raw_options:
+        first = raw_options[0]
+        if isinstance(first, dict):
+            return _clean_string(first.get("optionId") or first.get("option_id") or first.get("id"))
+        return _clean_string(getattr(first, "optionId", "") or getattr(first, "option_id", "") or getattr(first, "id", ""))
+    return ""
+
+
+def _get_value(obj: Any, *keys: str) -> str:
+    data = _to_plain(obj)
+    if isinstance(data, dict):
+        for key in keys:
+            value = _clean_string(data.get(key))
+            if value:
+                return value
+    for key in keys:
+        value = _clean_string(getattr(obj, key, ""))
+        if value:
+            return value
+    return ""
+
+
+def _nested(data: dict[str, Any], *keys: str) -> str:
+    cur: Any = data
+    for key in keys:
+        if not isinstance(cur, dict):
+            return ""
+        cur = cur.get(key)
+    return _clean_string(cur)
+
+
+def _to_plain(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return value
+
+
+def _clean_string(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _print_response(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, separators=(",", ":"), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adapters/agent-bridge/anx_agent_bridge/cli.py
+++ b/adapters/agent-bridge/anx_agent_bridge/cli.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import hashlib
 import json
+import sys
 from dataclasses import asdict
 from pathlib import Path
 
@@ -139,8 +140,35 @@ def build_adapter(config: LoadedConfig):
         return load_plugin_adapter(mod, fac, dict(config.adapter.raw))
     if kind == "deterministic_ack":
         return DeterministicAckAdapter()
+    if kind == "hermes":
+        command = config.adapter.get_list("command")
+        if not command:
+            command = [sys.executable, "-m", "anx_agent_bridge.adapters.hermes_acp"]
+        cwd = config.adapter.get_str("cwd", "")
+        if cwd:
+            cwd_path = Path(cwd).expanduser()
+            if not cwd_path.is_absolute():
+                cwd_path = (config.config_dir / cwd_path).resolve()
+            cwd = str(cwd_path)
+        else:
+            cwd = str(config.config_dir)
+        env_raw = config.adapter.raw.get("env")
+        env_str: dict[str, str] | None = None
+        if isinstance(env_raw, dict):
+            env_str = {str(k): str(v) for k, v in env_raw.items()}
+        return SubprocessAdapter(
+            command=command,
+            handle=config.agent.handle,
+            workspace_id=config.anx.workspace_id,
+            cwd=cwd,
+            env=env_str,
+            dispatch_timeout_seconds=config.adapter.get_int("timeout_seconds", 900),
+            doctor_timeout_seconds=config.adapter.get_int("doctor_timeout_seconds", 60),
+            doctor_command=None,
+            adapter_raw=dict(config.adapter.raw),
+        )
     raise ValueError(
-        f"Unsupported adapter kind: {kind!r}; use subprocess, python_plugin, or deterministic_ack (tests only)"
+        f"Unsupported adapter kind: {kind!r}; use hermes, subprocess, python_plugin, or deterministic_ack (tests only)"
     )
 
 

--- a/adapters/agent-bridge/pyproject.toml
+++ b/adapters/agent-bridge/pyproject.toml
@@ -12,6 +12,7 @@ authors = [{name = "OpenAI", email = "support@openai.com"}]
 dependencies = [
   "httpx>=0.27,<1.0",
   "cryptography>=42,<47",
+  "agent-client-protocol>=0.6,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/adapters/agent-bridge/tests/test_cli.py
+++ b/adapters/agent-bridge/tests/test_cli.py
@@ -91,6 +91,28 @@ def test_build_adapter_defaults_cwd_to_config_dir(tmp_path: Path):
     assert adapter.cwd == str(tmp_path)
 
 
+def test_build_adapter_hermes_uses_bundled_module(tmp_path: Path):
+    config = LoadedConfig(
+        anx=ANXConfig(base_url="https://anx.example", workspace_id="ws_main", workspace_name="Main"),
+        agent=AgentConfig(
+            handle="hermes",
+            driver_kind="hermes",
+            adapter_kind="hermes",
+            state_dir=tmp_path / "state",
+        ),
+        adapter=AdapterConfig(raw={"kind": "hermes"}),
+        auth_state_path=tmp_path / "auth.json",
+        config_path=tmp_path / "bridge.toml",
+        config_dir=tmp_path,
+    )
+
+    adapter = build_adapter(config)
+
+    assert adapter.command[-2:] == ["-m", "anx_agent_bridge.adapters.hermes_acp"]
+    assert adapter.dispatch_timeout_seconds == 900
+    assert adapter.adapter_raw["kind"] == "hermes"
+
+
 def test_adapter_contract_subcommand_is_available():
     parser = build_parser()
 

--- a/adapters/agent-bridge/tests/test_hermes_acp.py
+++ b/adapters/agent-bridge/tests/test_hermes_acp.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+import importlib.util
+from pathlib import Path
+
+
+_HERMES_PATH = Path(__file__).resolve().parents[1] / "anx_agent_bridge" / "adapters" / "hermes_acp.py"
+_SPEC = importlib.util.spec_from_file_location("hermes_acp", _HERMES_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+hermes_acp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(hermes_acp)
+
+
+def test_hermes_prompt_includes_wake_context() -> None:
+    prompt = hermes_acp._build_prompt(
+        {
+            "prompt_text": "Original bridge prompt",
+            "wake_packet": {
+                "target": {"handle": "zara"},
+                "workspace": {"id": "ws_main", "name": "Main"},
+                "thread": {"id": "thread_1", "title": "Launch plan"},
+                "trigger": {"message_event_id": "", "text": "@zara please review"},
+                "context_inline": {"current_summary": "The plan is waiting on review."},
+                "context_fetch": {
+                    "preferred": "threads.workspace",
+                    "cli": ["anx threads workspace --thread-id thread_1 --json"],
+                },
+            },
+        }
+    )
+
+    assert "Agent Nexus wake request" in prompt
+    assert "Launch plan (thread_1)" in prompt
+    assert "Trigger event:" in prompt
+    assert "@zara please review" in prompt
+    assert "Original bridge prompt" in prompt
+
+
+def test_hermes_session_update_text_collects_agent_chunks() -> None:
+    update = {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "hello"},
+    }
+
+    assert hermes_acp._session_update_text(update) == "hello"
+    assert hermes_acp._session_update_text({"sessionUpdate": "tool_call"}) == ""
+
+
+def test_hermes_doctor_reports_missing_runtime(monkeypatch) -> None:
+    monkeypatch.setenv("PATH", os.devnull)
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+
+    result = hermes_acp._doctor({})
+
+    assert result["schema_version"] == hermes_acp.RESPONSE_SCHEMA_VERSION
+    assert result["ok"] is False
+    assert result["details"]["hermes_bin"] == ""
+    assert "Hermes binary not found" in result["message"]

--- a/adapters/agent-bridge/tests/test_hermes_acp.py
+++ b/adapters/agent-bridge/tests/test_hermes_acp.py
@@ -45,6 +45,15 @@ def test_hermes_session_update_text_collects_agent_chunks() -> None:
 
     assert hermes_acp._session_update_text(update) == "hello"
     assert hermes_acp._session_update_text({"sessionUpdate": "tool_call"}) == ""
+    assert (
+        hermes_acp._session_update_text(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "tool_result", "text": "internal"},
+            }
+        )
+        == ""
+    )
 
 
 def test_hermes_doctor_reports_missing_runtime(monkeypatch) -> None:

--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -452,10 +452,11 @@ Config generation
 
 Generate minimal configs from the CLI:
 
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
   anx bridge init-config --kind python-plugin --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --workspace-id <workspace-id-2> --handle <handle> --plugin-module my_bridge --plugin-factory build_adapter
 
-You own the adapter implementation. ANX does not ship or maintain integrations for specific third-party agents.
+Use `--kind hermes` for the bundled Hermes ACP subprocess adapter. Use `subprocess` or `python-plugin` when you own a custom adapter implementation.
 
 This scaffolds an explicit agent home:
 
@@ -486,7 +487,11 @@ First-time agent-host path
 
   anx bridge install
 
-2. Render the bridge runtime config and agent home, then implement the adapter (see `anx-agent-bridge adapter contract --config ./bridge.toml`):
+2. Render the bridge runtime config and agent home. For Hermes ACP:
+
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
+
+  For a custom subprocess adapter, render the config and then inspect the JSON contract with `anx-agent-bridge adapter contract --config ./bridge.toml`:
 
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
 
@@ -619,7 +624,11 @@ Preferred path when you are using `anx-agent-bridge`
 
 2. Confirm the workspace deployment's `anx-core` config and note the durable workspace id it uses.
 
-3. Generate the agent config and implement your adapter (subprocess JSON or python_plugin):
+3. Generate the agent config. For Hermes ACP, use the bundled adapter:
+
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
+
+  For custom adapters, use subprocess JSON or python_plugin:
 
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
 
@@ -4706,11 +4715,12 @@ Local Help: bridge init-config
 - Composition: Pure local helper. Renders a bridge runtime config that references an explicit agent home, plus agent.toml and wake.toml when --output is used.
 - JSON body: `kind`, `output`, `agent_home`, `workspace_ids`, `handle`, `content`
 - Examples:
+  - `anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent`
   - `anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent --adapter-entrypoint ./adapter.py`
   - `anx bridge init-config --kind python-plugin --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --workspace-id ws_ops --handle myagent --plugin-module my_bridge --plugin-factory build_adapter`
 
 Flags:
-  --kind <subprocess|python-plugin> Template kind to render.
+  --kind <hermes|subprocess|python-plugin> Template kind to render.
   --output <path>              Write the rendered TOML to a file. Omit to print it.
   --agent-home <dir>           Agent home directory for identity, auth, wake config, state, and logs. Default: ./.anx.
   --base-url <url>             ANX base URL for agent.toml identity and wake.toml workspace entries.

--- a/cli/integration/scenarios_integration_test.go
+++ b/cli/integration/scenarios_integration_test.go
@@ -69,7 +69,6 @@ func TestThreadEventHandoffScenario(t *testing.T) {
 		"topic": map[string]any{
 			"title":         "Harness Incident " + runID,
 			"type":          "incident",
-			"status":        "active",
 			"summary":       "Topic created by CLI integration coverage.",
 			"owner_refs":    []any{},
 			"document_refs": []any{},
@@ -80,6 +79,7 @@ func TestThreadEventHandoffScenario(t *testing.T) {
 	}, "topics", "create")
 
 	threadID := mustStringPath(t, topic.Payload, "data.body.topic.thread_id")
+	topicID := mustStringPath(t, topic.Payload, "data.body.topic.id")
 
 	h.runCLIExpectOK(t, "coordinator", map[string]any{
 		"event": map[string]any{
@@ -88,8 +88,13 @@ func TestThreadEventHandoffScenario(t *testing.T) {
 			"refs":      []string{"thread:" + threadID},
 			"summary":   "Need worker acknowledgement for integration run " + runID,
 			"payload": map[string]any{
-				"run_id": runID,
-				"source": "integration_test",
+				"kind":               "ask",
+				"title":              "Need worker acknowledgement for integration run " + runID,
+				"subject_ref":        "thread:" + threadID,
+				"requester_actor_id": "actor-1",
+				"response_proposals": []any{"Acknowledge the request."},
+				"run_id":             runID,
+				"source":             "integration_test",
 			},
 			"provenance": map[string]any{
 				"sources": []string{"inferred"},
@@ -97,10 +102,11 @@ func TestThreadEventHandoffScenario(t *testing.T) {
 		},
 	}, "events", "create")
 
-	workerThread := h.runCLIExpectOK(t, "worker", nil, "threads", "get", "--thread-id", threadID)
-	if !strings.Contains(workerThread.Stdout, "Harness Incident") || !strings.Contains(workerThread.Stdout, runID) {
-		t.Fatalf("expected worker thread read to include run title, got: %s", workerThread.Stdout)
+	workerTopic := h.runCLIExpectOK(t, "worker", nil, "topics", "get", "--topic-id", topicID)
+	if !strings.Contains(workerTopic.Stdout, "Harness Incident") || !strings.Contains(workerTopic.Stdout, runID) {
+		t.Fatalf("expected worker topic read to include run title, got: %s", workerTopic.Stdout)
 	}
+	workerThread := h.runCLIExpectOK(t, "worker", nil, "threads", "get", "--thread-id", threadID)
 
 	ack := h.runCLIExpectOK(t, "worker", map[string]any{
 		"event": map[string]any{
@@ -145,7 +151,6 @@ func TestDocumentLifecycleConflictScenario(t *testing.T) {
 		"topic": map[string]any{
 			"title":         "Harness Docs Lifecycle " + runID,
 			"type":          "incident",
-			"status":        "active",
 			"summary":       "Coordinator started docs lifecycle integration run " + runID + ".",
 			"owner_refs":    []any{},
 			"document_refs": []any{},
@@ -178,6 +183,11 @@ func TestDocumentLifecycleConflictScenario(t *testing.T) {
 			"refs":      []string{"thread:" + threadID, "document:" + documentID},
 			"summary":   "Coordinator requested draft + review for run " + runID,
 			"payload": map[string]any{
+				"kind":                "review",
+				"title":               "Coordinator requested draft + review for run " + runID,
+				"subject_ref":         "document:" + documentID,
+				"requester_actor_id":  "actor-1",
+				"response_proposals":  []any{"Accept the draft and review task."},
 				"run_id":              runID,
 				"document_id":         documentID,
 				"initial_revision_id": initialRevisionID,
@@ -220,7 +230,7 @@ func TestDocumentLifecycleConflictScenario(t *testing.T) {
 		"content":          "Worker-produced revision for run " + runID + " (v2).",
 		"content_type":     "text",
 		"refs":             []string{"thread:" + threadID, "event:" + decisionEventID},
-	}, "docs", "update", "--document-id", documentID)
+	}, "docs", "revise", "--apply", "--document-id", documentID)
 	workerRevisionID := mustStringPath(t, workerUpdate.Payload, "data.body.revision.revision_id")
 
 	completion := h.runCLIExpectOK(t, "worker", map[string]any{
@@ -252,7 +262,7 @@ func TestDocumentLifecycleConflictScenario(t *testing.T) {
 		"content":          "Reviewer stale overwrite attempt for run " + runID + ".",
 		"content_type":     "text",
 		"refs":             []string{"thread:" + threadID, "event:" + completionEventID},
-	}, "docs", "update", "--document-id", documentID)
+	}, "docs", "revise", "--apply", "--document-id", documentID)
 	if stale.ExitCode == 0 {
 		t.Fatalf("expected stale update to fail, got success payload=%s", stale.Stdout)
 	}
@@ -295,9 +305,9 @@ func TestDocumentLifecycleConflictScenario(t *testing.T) {
 		},
 	}, "topics", "patch", "--topic-id", topicID)
 
-	coordThread := h.runCLIExpectOK(t, "coordinator", nil, "threads", "get", "--thread-id", threadID)
-	if !strings.Contains(coordThread.Stdout, "Harness Docs Lifecycle") || !strings.Contains(coordThread.Stdout, runID) {
-		t.Fatalf("expected thread read to include run title, got: %s", coordThread.Stdout)
+	coordTopic := h.runCLIExpectOK(t, "coordinator", nil, "topics", "get", "--topic-id", topicID)
+	if !strings.Contains(coordTopic.Stdout, "Harness Docs Lifecycle") || !strings.Contains(coordTopic.Stdout, runID) {
+		t.Fatalf("expected topic read to include run title, got: %s", coordTopic.Stdout)
 	}
 
 	coordCompletion := h.runCLIExpectOK(t, "coordinator", nil, "events", "get", "--event-id", completionEventID)
@@ -347,7 +357,6 @@ func TestProvenanceWalkScenario(t *testing.T) {
 		"topic": map[string]any{
 			"title":         "Provenance Walk Harness " + runID,
 			"type":          "incident",
-			"status":        "active",
 			"summary":       "Validate event -> thread + event -> artifact traversal via refs.",
 			"owner_refs":    []any{},
 			"document_refs": []any{},
@@ -365,7 +374,12 @@ func TestProvenanceWalkScenario(t *testing.T) {
 			"refs":      []string{"thread:" + threadID, "artifact:" + artifactID},
 			"summary":   "Trace thread provenance for run " + runID,
 			"payload": map[string]any{
-				"run_id": runID,
+				"kind":               "ask",
+				"title":              "Trace thread provenance for run " + runID,
+				"subject_ref":        "artifact:" + artifactID,
+				"requester_actor_id": "actor-1",
+				"response_proposals": []any{"Trace the provenance graph."},
+				"run_id":             runID,
 			},
 			"provenance": map[string]any{
 				"sources": []string{"inferred"},

--- a/cli/internal/app/agent_bridge_guide.go
+++ b/cli/internal/app/agent_bridge_guide.go
@@ -52,10 +52,11 @@ Config generation
 
 Generate minimal configs from the CLI:
 
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
   anx bridge init-config --kind python-plugin --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --workspace-id <workspace-id-2> --handle <handle> --plugin-module my_bridge --plugin-factory build_adapter
 
-You own the adapter implementation. ANX does not ship or maintain integrations for specific third-party agents.
+Use <<tick>>--kind hermes<<tick>> for the bundled Hermes ACP subprocess adapter. Use <<tick>>subprocess<<tick>> or <<tick>>python-plugin<<tick>> when you own a custom adapter implementation.
 
 This scaffolds an explicit agent home:
 
@@ -86,7 +87,11 @@ First-time agent-host path
 
   anx bridge install
 
-2. Render the bridge runtime config and agent home, then implement the adapter (see <<tick>>anx-agent-bridge adapter contract --config ./bridge.toml<<tick>>):
+2. Render the bridge runtime config and agent home. For Hermes ACP:
+
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
+
+  For a custom subprocess adapter, render the config and then inspect the JSON contract with <<tick>>anx-agent-bridge adapter contract --config ./bridge.toml<<tick>>:
 
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
 

--- a/cli/internal/app/bridge_commands.go
+++ b/cli/internal/app/bridge_commands.go
@@ -97,11 +97,12 @@ func init() {
 			JSONShape:   "`kind`, `output`, `agent_home`, `workspace_ids`, `handle`, `content`",
 			Composition: "Pure local helper. Renders a bridge runtime config that references an explicit agent home, plus agent.toml and wake.toml when --output is used.",
 			Examples: []string{
+				"anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent",
 				"anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent --adapter-entrypoint ./adapter.py",
 				"anx bridge init-config --kind python-plugin --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --workspace-id ws_ops --handle myagent --plugin-module my_bridge --plugin-factory build_adapter",
 			},
 			Flags: []localHelperFlag{
-				{Name: "--kind <subprocess|python-plugin>", Description: "Template kind to render."},
+				{Name: "--kind <hermes|subprocess|python-plugin>", Description: "Template kind to render."},
 				{Name: "--output <path>", Description: "Write the rendered TOML to a file. Omit to print it."},
 				{Name: "--agent-home <dir>", Description: "Agent home directory for identity, auth, wake config, state, and logs. Default: ./.anx."},
 				{Name: "--base-url <url>", Description: "ANX base URL for agent.toml identity and wake.toml workspace entries."},
@@ -483,7 +484,7 @@ func (a *App) runBridgeInitConfig(args []string, cfg config.Resolved) (*commandR
 	var adapterEntryFlag trackedString
 	var pluginModuleFlag trackedString
 	var pluginFactoryFlag trackedString
-	fs.Var(&kindFlag, "kind", "Template kind: subprocess or python-plugin")
+	fs.Var(&kindFlag, "kind", "Template kind: hermes, subprocess, or python-plugin")
 	fs.Var(&outputFlag, "output", "Write the rendered TOML to a file")
 	fs.Var(&agentHomeFlag, "agent-home", "Directory for this local agent identity")
 	fs.Var(&baseURLFlag, "base-url", "ANX base URL")
@@ -593,7 +594,7 @@ func (a *App) runBridgeInitConfig(args []string, cfg config.Resolved) (*commandR
 			"Agent home: " + agentHomePath,
 			"Wake config: " + filepath.Join(agentHomePath, "wake.toml"),
 			"Lifecycle: registrations stay pending until the bridge checks in.",
-			"Next: implement your adapter (subprocess JSON or python_plugin), then `anx-agent-bridge adapter contract --config " + outputPath + "`.",
+			bridgeInitConfigNextStep(kind, outputPath),
 		}
 		text = strings.Join(textLines, "\n")
 	}
@@ -705,8 +706,8 @@ func (a *App) runBridgeWorkspaceID(ctx context.Context, args []string, cfg confi
 		for _, workspaceID := range workspaceIDs {
 			repeated = append(repeated, "--workspace-id "+workspaceID)
 		}
-		lines = append(lines, "Next step: anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx "+strings.Join(repeated, " ")+" --handle "+handle+" --adapter-entrypoint ./adapter.py")
-		lines = append(lines, "Or: --kind python-plugin --plugin-module <mod> --plugin-factory <callable> for an in-process Python adapter.")
+		lines = append(lines, "Next step: anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx "+strings.Join(repeated, " ")+" --handle "+handle)
+		lines = append(lines, "Or: --kind subprocess with --adapter-entrypoint for a custom JSON adapter, or --kind python-plugin with --plugin-module and --plugin-factory.")
 	}
 	return &commandResult{
 		Text: strings.Join(lines, "\n"),
@@ -935,6 +936,8 @@ func normalizeBridgeInitConfigKind(kind string) string {
 	switch k {
 	case "python-plugin", "python_plugin":
 		return "python_plugin"
+	case "hermes":
+		return "hermes"
 	case "subprocess":
 		return "subprocess"
 	default:
@@ -946,6 +949,35 @@ func renderBridgeConfigTemplate(params bridgeTemplateParams) (string, string, er
 	agentHome := firstNonEmptyString(params.AgentHome, ".anx")
 	kind := normalizeBridgeInitConfigKind(params.Kind)
 	switch kind {
+	case "hermes":
+		handle := firstNonEmptyString(params.Handle, "<handle>")
+		stateDir := firstNonEmptyString(params.StateDir, "run/"+handle)
+		return strings.TrimSpace(fmt.Sprintf(`
+agent_home = %q
+wake_config = "wake.toml"
+
+[bridge]
+driver_kind = "hermes"
+adapter_kind = "hermes"
+resume_policy = "resume_or_create"
+status = "pending"
+checkin_interval_seconds = 60
+checkin_ttl_seconds = 300
+
+[runtime]
+state_dir = %q
+
+[adapter]
+kind = "hermes"
+timeout_seconds = 900
+doctor_timeout_seconds = 60
+# Optional overrides:
+# command = ["python3", "-m", "anx_agent_bridge.adapters.hermes_acp"]
+# hermes_bin = "/path/to/hermes"
+# hermes_args = ["acp"]
+# cwd = "."
+# interactive = false
+`, agentHome, stateDir)) + "\n", handle, nil
 	case "subprocess":
 		handle := firstNonEmptyString(params.Handle, "<handle>")
 		stateDir := firstNonEmptyString(params.StateDir, "run/"+handle)
@@ -997,8 +1029,15 @@ plugin_module = %q
 plugin_factory = %q
 `, agentHome, stateDir, mod, fac)) + "\n", handle, nil
 	default:
-		return "", "", errnorm.Usage("invalid_request", "unknown bridge config kind; use subprocess or python-plugin")
+		return "", "", errnorm.Usage("invalid_request", "unknown bridge config kind; use hermes, subprocess, or python-plugin")
 	}
+}
+
+func bridgeInitConfigNextStep(kind string, outputPath string) string {
+	if normalizeBridgeInitConfigKind(kind) == "hermes" {
+		return "Next: run `anx bridge doctor --config " + outputPath + "` to verify Hermes and ACP readiness."
+	}
+	return "Next: implement your adapter (subprocess JSON or python_plugin), then `anx-agent-bridge adapter contract --config " + outputPath + "`."
 }
 
 func renderAgentHomeFiles(params bridgeTemplateParams) (agentManifest string, wakeConfig string) {

--- a/cli/internal/app/bridge_commands_test.go
+++ b/cli/internal/app/bridge_commands_test.go
@@ -81,6 +81,31 @@ func TestRenderBridgePythonPluginTemplate(t *testing.T) {
 	}
 }
 
+func TestRenderBridgeHermesTemplate(t *testing.T) {
+	rendered, handle, err := renderBridgeConfigTemplate(bridgeTemplateParams{
+		Kind:          "hermes",
+		BaseURL:       "https://anx.example",
+		WorkspaceIDs:  []string{"ws_main"},
+		WorkspaceName: "Main",
+		Handle:        "myagent",
+	})
+	if err != nil {
+		t.Fatalf("renderBridgeConfigTemplate: %v", err)
+	}
+	if handle != "myagent" {
+		t.Fatalf("expected handle myagent, got %q", handle)
+	}
+	if !strings.Contains(rendered, `driver_kind = "hermes"`) || !strings.Contains(rendered, `adapter_kind = "hermes"`) {
+		t.Fatalf("expected hermes bridge metadata output=%s", rendered)
+	}
+	if !strings.Contains(rendered, `kind = "hermes"`) {
+		t.Fatalf("expected hermes adapter kind output=%s", rendered)
+	}
+	if !strings.Contains(rendered, `command = ["python3", "-m", "anx_agent_bridge.adapters.hermes_acp"]`) {
+		t.Fatalf("expected optional hermes module command hint output=%s", rendered)
+	}
+}
+
 func TestBridgeInstallPackageSpecDefaultsToRepoSubdirectory(t *testing.T) {
 	spec := bridgeInstallPackageSpec("v0.0.6")
 	if !strings.Contains(spec, "agent-nexus.git@v0.0.6#subdirectory=adapters/agent-bridge") {
@@ -465,6 +490,32 @@ func TestBridgeInitConfigSubprocessUsesAdapterEntrypoint(t *testing.T) {
 	}
 	if !strings.Contains(string(content), `command = ["python3", "/custom/adapter.py"]`) {
 		t.Fatalf("expected adapter entrypoint in command, content=%s", content)
+	}
+}
+
+func TestBridgeInitConfigHermesWritesBundledAdapter(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "agent.toml")
+	app := New()
+	result, err := app.runBridgeInitConfig([]string{
+		"--kind", "hermes",
+		"--output", outputPath,
+		"--workspace-id", "ws_main",
+		"--handle", "myagent",
+	}, config.Resolved{})
+	if err != nil {
+		t.Fatalf("runBridgeInitConfig: %v", err)
+	}
+	if !strings.Contains(result.Text, "bridge doctor") {
+		t.Fatalf("expected hermes doctor next step in output=%s", result.Text)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output config: %v", err)
+	}
+	body := string(content)
+	if !strings.Contains(body, `adapter_kind = "hermes"`) || !strings.Contains(body, `kind = "hermes"`) {
+		t.Fatalf("expected hermes adapter config, content=%s", body)
 	}
 }
 

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -24,7 +24,7 @@ var apiSubcommandSpec = subcommandSpec{
 var bridgeSubcommandSpec = subcommandSpec{
 	command:  "bridge",
 	valid:    []string{"install", "import-auth", "init-config", "start", "stop", "restart", "status", "logs", "workspace-id", "doctor"},
-	examples: []string{"anx bridge install", "anx bridge import-auth --config ./bridge.toml --from-profile agent-a", "anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent --adapter-entrypoint ./adapter.py", "anx bridge workspace-id --handle myagent", "anx bridge start --config ./bridge.toml", "anx bridge status --config ./bridge.toml"},
+	examples: []string{"anx bridge install", "anx bridge import-auth --config ./bridge.toml --from-profile agent-a", "anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id ws_main --handle myagent", "anx bridge workspace-id --handle myagent", "anx bridge start --config ./bridge.toml", "anx bridge status --config ./bridge.toml"},
 }
 
 var notificationsSubcommandSpec = subcommandSpec{

--- a/cli/internal/app/wake_routing_guide.go
+++ b/cli/internal/app/wake_routing_guide.go
@@ -64,7 +64,11 @@ Preferred path when you are using <<tick>>anx-agent-bridge<<tick>>
 
 2. Confirm the workspace deployment's <<tick>>anx-core<<tick>> config and note the durable workspace id it uses.
 
-3. Generate the agent config and implement your adapter (subprocess JSON or python_plugin):
+3. Generate the agent config. For Hermes ACP, use the bundled adapter:
+
+  anx bridge init-config --kind hermes --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle>
+
+  For custom adapters, use subprocess JSON or python_plugin:
 
   anx bridge init-config --kind subprocess --output ./bridge.toml --agent-home ./.anx --workspace-id <workspace-id> --handle <handle> --adapter-entrypoint ./adapter.py
 


### PR DESCRIPTION
## Summary

- Add a first-party `hermes` adapter kind to `anx-agent-bridge`, backed by a bundled Hermes ACP subprocess module.
- Add `anx bridge init-config --kind hermes` config generation plus CLI guidance/docs updates.
- Add tests for Hermes config rendering, adapter loading, prompt construction, session update text collection, and doctor failure reporting.

## Details

The Hermes adapter discovers `HERMES_BIN` / `[adapter].hermes_bin` or `hermes` on `PATH`, starts Hermes over ACP stdio, creates or loads an ACP session, sends the Agent Nexus wake prompt, collects streamed text from `session/update`, and returns the standard bridge adapter response.

Closes #189.

## Validation

- `make -C adapters/agent-bridge test`
- `env GOCACHE=/tmp/anx-go-build make cli-check`