### PR TITLE
[codex] Improve card resolve CLI workflow

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -1408,7 +1408,7 @@ Agent-facing Card workflow:
   cards revise             Revise card title/body from `--content-file`; discovers `if_base_revision` when omitted.
   cards move               Move workflow column; discovers the parent board concurrency token when omitted.
   cards assign             Replace or clear assignees.
-  cards resolve            Move to done with resolution evidence refs.
+  cards resolve            Move to done with resolution evidence refs or an evidence body.
   cards reopen             Move a resolved card back to active workflow.
   Tip: use `cards message <card-id> --body-file update.md` for ordinary status updates. Use raw `events create` only for contract-level writes or unusual integrations.
 
@@ -4038,6 +4038,8 @@ Local Help: topics message
 
 Flags:
   --topic <topic-id>           Topic id or unique prefix to message.
+  --thread <thread-id>         Backing thread id for thread-scoped message fallback.
+  --thread-id <thread-id>      Backing thread id for thread-scoped message fallback.
   --body <text>                Message body text.
   --body-file <path>           Load message body text from a local file.
   --summary <text>             Optional short event summary.
@@ -4098,6 +4100,8 @@ Local Help: topics reply
 
 Flags:
   --topic <topic-id>           Topic id or unique prefix to reply on.
+  --thread <thread-id>         Backing thread id for thread-scoped reply fallback.
+  --thread-id <thread-id>      Backing thread id for thread-scoped reply fallback.
   --to <message-id>            Message/event id or unique prefix being replied to.
   --body <text>                Reply body text.
   --body-file <path>           Load reply body text from a local file.
@@ -4467,17 +4471,21 @@ Local Help: cards resolve
 
 - Kind: `local helper`
 - Summary: Resolve a card into the done column with evidence refs.
-- Composition: Builds a focused `cards.move` request that both moves and records terminal resolution evidence.
+- Composition: With `--body` or `--body-file`, posts a card message first and passes its `event:<id>` as terminal resolution evidence.
 - JSON body: `{ column_key: "done", resolution, resolution_refs, if_board_updated_at, actor_id? }`; discovers the board concurrency token when omitted.
 - Examples:
-  - `anx cards resolve --card <card-id> --resolution-ref event:<event-id>`
+  - `anx cards resolve --card <card-id> --body-file evidence.md`
   - `anx cards resolve --card <card-id> --resolution-ref event:<event-id>`
 
 Flags:
   --card <card-id>             Card id or unique prefix to resolve.
   --resolution-ref <typed-ref> Evidence event/artifact typed ref, repeatable.
+  --body <text>                Post inline evidence to the card thread before resolving.
+  --body-file <path>           Load evidence text from a file before resolving.
+  --summary <text>             Optional short evidence event summary.
   --resolution <value>         Resolution value, default done.
   --if-board-updated-at <timestamp> Board optimistic concurrency token; discovered when omitted.
+  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
 
 
 Global flags:

--- a/cli/docs/runbook.md
+++ b/cli/docs/runbook.md
@@ -200,7 +200,7 @@ anx --agent agent-a cards create --board board_product_launch --topic topic_123 
 anx --agent agent-a cards revise --card card_789 --content-file card.md
 anx --agent agent-a cards assign --card card_789 --assignee-ref actor:agent-a
 anx --agent agent-a cards move --card card_789 --column review
-anx --agent agent-a cards resolve --card card_789 --resolution-ref event:event_123
+anx --agent agent-a cards resolve --card card_789 --body-file evidence.md
 # Packet APIs are subject-based: `packet.subject_ref` must be `card:<card-id>`.
 anx --agent agent-a receipts create --from-file receipt.json
 anx --agent agent-a reviews create --from-file review.json

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -78,6 +78,8 @@ var localHelperTopics = []localHelperTopic{
 		},
 		Flags: []localHelperFlag{
 			{Name: "--topic <topic-id>", Description: "Topic id or unique prefix to message."},
+			{Name: "--thread <thread-id>", Description: "Backing thread id for thread-scoped message fallback."},
+			{Name: "--thread-id <thread-id>", Description: "Backing thread id for thread-scoped message fallback."},
 			{Name: "--body <text>", Description: "Message body text."},
 			{Name: "--body-file <path>", Description: "Load message body text from a local file."},
 			{Name: "--summary <text>", Description: "Optional short event summary."},
@@ -114,6 +116,8 @@ var localHelperTopics = []localHelperTopic{
 		},
 		Flags: []localHelperFlag{
 			{Name: "--topic <topic-id>", Description: "Topic id or unique prefix to reply on."},
+			{Name: "--thread <thread-id>", Description: "Backing thread id for thread-scoped reply fallback."},
+			{Name: "--thread-id <thread-id>", Description: "Backing thread id for thread-scoped reply fallback."},
 			{Name: "--to <message-id>", Description: "Message/event id or unique prefix being replied to."},
 			{Name: "--body <text>", Description: "Reply body text."},
 			{Name: "--body-file <path>", Description: "Load reply body text from a local file."},
@@ -340,16 +344,20 @@ var localHelperTopics = []localHelperTopic{
 		Path:        "cards resolve",
 		Summary:     "Resolve a card into the done column with evidence refs.",
 		JSONShape:   "`{ column_key: \"done\", resolution, resolution_refs, if_board_updated_at, actor_id? }`; discovers the board concurrency token when omitted.",
-		Composition: "Builds a focused `cards.move` request that both moves and records terminal resolution evidence.",
+		Composition: "With `--body` or `--body-file`, posts a card message first and passes its `event:<id>` as terminal resolution evidence.",
 		Examples: []string{
-			"anx cards resolve --card <card-id> --resolution-ref event:<event-id>",
+			"anx cards resolve --card <card-id> --body-file evidence.md",
 			"anx cards resolve --card <card-id> --resolution-ref event:<event-id>",
 		},
 		Flags: []localHelperFlag{
 			{Name: "--card <card-id>", Description: "Card id or unique prefix to resolve."},
 			{Name: "--resolution-ref <typed-ref>", Description: "Evidence event/artifact typed ref, repeatable."},
+			{Name: "--body <text>", Description: "Post inline evidence to the card thread before resolving."},
+			{Name: "--body-file <path>", Description: "Load evidence text from a file before resolving."},
+			{Name: "--summary <text>", Description: "Optional short evidence event summary."},
 			{Name: "--resolution <value>", Description: "Resolution value, default done."},
 			{Name: "--if-board-updated-at <timestamp>", Description: "Board optimistic concurrency token; discovered when omitted."},
+			{Name: "--actor-id <actor-id>", Description: "Actor id; defaults from the active profile when available."},
 		},
 	},
 	{
@@ -969,7 +977,7 @@ Read paths:
   cards revise             Revise card title/body from ` + "`--content-file`" + `; discovers ` + "`if_base_revision`" + ` when omitted.
   cards move               Move workflow column; discovers the parent board concurrency token when omitted.
   cards assign             Replace or clear assignees.
-  cards resolve            Move to done with resolution evidence refs.
+  cards resolve            Move to done with resolution evidence refs or an evidence body.
   cards reopen             Move a resolved card back to active workflow.
   Tip: use ` + "`cards message <card-id> --body-file update.md`" + ` for ordinary status updates. Use raw ` + "`events create`" + ` only for contract-level writes or unusual integrations.`)
 	case "auth":

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -2541,6 +2541,123 @@ func TestCardsFileFirstWorkflowCommands(t *testing.T) {
 	}
 }
 
+func TestCardsResolveBodyPostsEvidenceBeforeMove(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cardID       = "card_resolve_body_123456"
+		boardID      = "board_resolve_body_123456"
+		threadID     = "thread_resolve_body_123456"
+		eventID      = "event_resolve_body_123456"
+		cardUpdated  = "2026-04-21T00:00:00Z"
+		boardUpdated = "2026-04-21T00:05:00Z"
+		profileActor = "actor_resolve_body"
+	)
+
+	var postedEvidence, moved bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/cards/"+cardID:
+			_, _ = w.Write([]byte(`{"card":{"id":"` + cardID + `","board_id":"` + boardID + `","board_ref":"board:` + boardID + `","title":"Resolve body","thread_id":"` + threadID + `","updated_at":"` + cardUpdated + `"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/boards/"+boardID:
+			_, _ = w.Write([]byte(`{"board":{"id":"` + boardID + `","updated_at":"` + boardUpdated + `"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/events":
+			if moved {
+				t.Fatalf("expected evidence event before card move")
+			}
+			var posted map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+				t.Fatalf("decode evidence body: %v", err)
+			}
+			assertMessagePostedMutation(t, posted, profileActor, threadID, []string{"card:" + cardID, "thread:" + threadID, "board:" + boardID}, "Evidence from disk.")
+			postedEvidence = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"event":{"id":"` + eventID + `","type":"message_posted","thread_id":"` + threadID + `"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/cards/"+cardID+"/move":
+			if !postedEvidence {
+				t.Fatalf("expected card resolve to post evidence before move")
+			}
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode move body: %v", err)
+			}
+			refs := asSlice(payload["resolution_refs"])
+			if len(refs) != 1 || anyStringValue(refs[0]) != "event:"+eventID {
+				t.Fatalf("expected posted evidence ref, got %#v", payload)
+			}
+			if got := anyStringValue(payload["if_board_updated_at"]); got != boardUpdated {
+				t.Fatalf("expected discovered board token %q, got %#v", boardUpdated, payload)
+			}
+			moved = true
+			_, _ = w.Write([]byte(`{"board":{"id":"` + boardID + `","updated_at":"2026-04-21T00:10:00Z"},"card":{"id":"` + cardID + `","board_id":"` + boardID + `","column_key":"done","resolution":"done","resolution_refs":["event:` + eventID + `"]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-resolve-body", `{"agent":"agent-resolve-body","actor_id":"`+profileActor+`","access_token":"token","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+	evidenceFile := filepath.Join(home, "evidence.md")
+	if err := os.WriteFile(evidenceFile, []byte("Evidence from disk.\n"), 0o600); err != nil {
+		t.Fatalf("write evidence file: %v", err)
+	}
+
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{
+		"--json", "--base-url", server.URL, "--agent", "agent-resolve-body",
+		"cards", "resolve", cardID, "--body-file", evidenceFile,
+	}))
+	if got := anyStringValue(payload["command_id"]); got != "cards.move" {
+		t.Fatalf("expected final cards.move command_id, got %#v", payload)
+	}
+	if !postedEvidence || !moved {
+		t.Fatalf("expected evidence post and move")
+	}
+}
+
+func TestTopicsMessageAcceptsBackingThreadAlias(t *testing.T) {
+	t.Parallel()
+
+	const (
+		threadID     = "thread_topic_alias_123456"
+		profileActor = "actor_topic_alias"
+	)
+
+	var posted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/events":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode topics thread message body: %v", err)
+			}
+			assertMessagePostedMutation(t, payload, profileActor, threadID, []string{"thread:" + threadID}, "Thread-scoped reply path.")
+			posted = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"event":{"id":"event_topic_alias_123456","type":"message_posted","thread_id":"` + threadID + `"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-topic-alias", `{"agent":"agent-topic-alias","actor_id":"`+profileActor+`","access_token":"token","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{
+		"--json", "--base-url", server.URL, "--agent", "agent-topic-alias",
+		"topics", "message", "--thread", threadID, "--body", "Thread-scoped reply path.",
+	}))
+	if got := anyStringValue(payload["command_id"]); got != "events.create" {
+		t.Fatalf("expected events.create command_id, got %#v", payload)
+	}
+	if !posted {
+		t.Fatalf("expected event post")
+	}
+}
+
 func TestTopicsBoardsNoJSONAndMessageWorkflow(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/resource_messages.go
+++ b/cli/internal/app/resource_messages.go
@@ -23,11 +23,13 @@ type messageTarget struct {
 func (a *App) parseTopicMessageInput(ctx context.Context, args []string, cfg config.Resolved, commandName string, replyToEventID string) (map[string]any, messageTarget, bool, error) {
 	leadingTopicID, args := popLeadingPositional(args)
 	fs := newSilentFlagSet(commandName)
-	var topicIDFlag, bodyFlag, bodyFileFlag, summaryFlag, actorIDFlag trackedString
+	var topicIDFlag, threadIDFlag, bodyFlag, bodyFileFlag, summaryFlag, actorIDFlag trackedString
 	var refFlags trackedStrings
 	var dryRunFlag trackedBool
 	fs.Var(&topicIDFlag, "topic", "Topic id to message")
 	fs.Var(&topicIDFlag, "topic-id", "Topic id to message")
+	fs.Var(&threadIDFlag, "thread", "Backing thread id to message")
+	fs.Var(&threadIDFlag, "thread-id", "Backing thread id to message")
 	fs.Var(&bodyFlag, "body", "Message body text")
 	fs.Var(&bodyFileFlag, "body-file", "Load message body text from a local file")
 	fs.Var(&summaryFlag, "summary", "Optional short event summary")
@@ -46,20 +48,36 @@ func (a *App) parseTopicMessageInput(ctx context.Context, args []string, cfg con
 	if len(positionals) > 0 {
 		return nil, messageTarget{}, false, errnorm.Usage("invalid_args", fmt.Sprintf("unexpected positional arguments for `anx %s`", commandName))
 	}
-	if err := validateID(topicID, "topic id"); err != nil {
+	threadID := strings.TrimSpace(threadIDFlag.value)
+	if topicID != "" && threadID != "" {
+		return nil, messageTarget{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("provide only one of --topic or --thread for `anx %s`", commandName))
+	}
+	if topicID == "" && threadID == "" {
+		return nil, messageTarget{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("topic id is required for `anx %s`; pass --topic or --thread", commandName))
+	}
+	if topicID != "" {
+		if err := validateID(topicID, "topic id"); err != nil {
+			return nil, messageTarget{}, false, err
+		}
+	} else if err := validateID(threadID, "thread id"); err != nil {
 		return nil, messageTarget{}, false, err
 	}
 	message, err := a.readMessageText(bodyFlag.value, bodyFileFlag.value, commandName)
 	if err != nil {
 		return nil, messageTarget{}, false, err
 	}
-	topic, err := a.fetchTopicBody(ctx, cfg, topicID)
-	if err != nil {
-		return nil, messageTarget{}, false, err
-	}
-	target, err := topicMessageTarget(topic, topicID)
-	if err != nil {
-		return nil, messageTarget{}, false, err
+	var target messageTarget
+	if threadID != "" {
+		target = threadMessageTarget(threadID)
+	} else {
+		topic, err := a.fetchTopicBody(ctx, cfg, topicID)
+		if err != nil {
+			return nil, messageTarget{}, false, err
+		}
+		target, err = topicMessageTarget(topic, topicID)
+		if err != nil {
+			return nil, messageTarget{}, false, err
+		}
 	}
 	body, err := buildMessagePostedBody(cfg, actorIDFlag.value, target, message, summaryFlag.value, refFlags.values, replyToEventID)
 	if err != nil {
@@ -691,6 +709,17 @@ func cardMessageTarget(card map[string]any, fallbackCardID string) (messageTarge
 	}, nil
 }
 
+func threadMessageTarget(threadID string) messageTarget {
+	threadID = strings.TrimSpace(threadID)
+	return messageTarget{
+		SubjectKind: "thread",
+		SubjectID:   threadID,
+		SubjectRef:  "thread:" + threadID,
+		ThreadID:    threadID,
+		MessageKind: "thread_message",
+	}
+}
+
 func applyReplyToMessageBody(body map[string]any, replyToEventID string) {
 	event := asMap(body["event"])
 	if event == nil {
@@ -776,6 +805,29 @@ func (a *App) readMessageText(body string, bodyFile string, commandName string) 
 		return string(stdin), nil
 	}
 	return "", errnorm.Usage("invalid_request", fmt.Sprintf("message body is required for `anx %s`; use --body, --body-file, or pipe text on stdin", commandName))
+}
+
+func (a *App) readExplicitMessageText(body string, bodyFile string, commandName string) (string, error) {
+	body = strings.TrimSpace(body)
+	bodyFile = strings.TrimSpace(bodyFile)
+	if body != "" && bodyFile != "" {
+		return "", errnorm.Usage("invalid_request", fmt.Sprintf("provide only one of --body or --body-file for `anx %s`", commandName))
+	}
+	if body != "" {
+		return body, nil
+	}
+	if bodyFile != "" {
+		content, err := a.readRawFile(bodyFile)
+		if err != nil {
+			return "", err
+		}
+		text := string(content)
+		if strings.TrimSpace(text) == "" {
+			return "", errnorm.Usage("invalid_request", fmt.Sprintf("message body file is empty for `anx %s`", commandName))
+		}
+		return text, nil
+	}
+	return "", errnorm.Usage("invalid_request", fmt.Sprintf("message body is required for `anx %s`; use --body or --body-file", commandName))
 }
 
 func (a *App) decorateMessageWriteResult(result *commandResult, callErr error, cfg config.Resolved, commandID string, card map[string]any) *commandResult {

--- a/cli/internal/app/resource_topics_cards.go
+++ b/cli/internal/app/resource_topics_cards.go
@@ -22,7 +22,7 @@ var topicsSubcommandSpec = subcommandSpec{
 var cardsSubcommandSpec = subcommandSpec{
 	command:  "cards",
 	valid:    []string{"list", "get", "create", "message", "messages", "reply", "revise", "history", "revision", "patch", "move", "assign", "resolve", "reopen", "archive", "trash", "purge", "restore", "timeline"},
-	examples: []string{"anx cards list", "anx cards create --board <board-id> --title \"Implement login\" --content-file card.md", "anx cards message <card-id> --body-file update.md", "anx cards messages <card-id>", "anx cards reply <card-id> --to <message-id> --body-file reply.md", "anx cards revise --card <card-id> --content-file card.md", "anx cards history --card-id <card-id>", "anx cards assign --card <card-id> --assignee-ref actor:<actor-id>", "anx cards resolve --card <card-id> --resolution-ref event:<event-id>", "anx cards move --card-id <card-id> --column review", "anx cards get --card-id <card-id>"},
+	examples: []string{"anx cards list", "anx cards create --board <board-id> --title \"Implement login\" --content-file card.md", "anx cards message <card-id> --body-file update.md", "anx cards messages <card-id>", "anx cards reply <card-id> --to <message-id> --body-file reply.md", "anx cards revise --card <card-id> --content-file card.md", "anx cards history --card-id <card-id>", "anx cards assign --card <card-id> --assignee-ref actor:<actor-id>", "anx cards resolve --card <card-id> --body-file evidence.md", "anx cards move --card-id <card-id> --column review", "anx cards get --card-id <card-id>"},
 }
 
 func (a *App) runTopicsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
@@ -341,11 +341,25 @@ func (a *App) runCardsCommand(ctx context.Context, args []string, cfg config.Res
 		result, callErr := a.invokeTypedJSONWithIDResolution(ctx, cfg, "cards assign", "cards.patch", "card_id", id, cardIDLookupSpec, nil, body)
 		return result, "cards assign", callErr
 	case "resolve":
-		id, body, err := a.parseCardResolveInput(ctx, args[1:], cfg, "cards resolve")
+		plan, err := a.parseCardResolveInput(args[1:], cfg, "cards resolve")
 		if err != nil {
 			return nil, "cards resolve", err
 		}
-		result, callErr := a.invokeTypedJSONWithIDResolution(ctx, cfg, "cards resolve", "cards.move", "card_id", id, cardIDLookupSpec, nil, body)
+		if plan.hasEvidenceMessage {
+			ref, err := a.postCardResolveEvidence(ctx, cfg, plan)
+			if err != nil {
+				return nil, "cards resolve", err
+			}
+			plan.resolutionRefs = normalizeStringFilters(append(plan.resolutionRefs, ref))
+			plan.moveBody["resolution_refs"] = plan.resolutionRefs
+		}
+		if len(plan.resolutionRefs) == 0 {
+			return nil, "cards resolve", errnorm.Usage("invalid_request", "`anx cards resolve` requires at least one --resolution-ref, --body, or --body-file")
+		}
+		if err := a.ensureCardMoveConcurrency(ctx, cfg, plan.cardID, plan.moveBody); err != nil {
+			return nil, "cards resolve", err
+		}
+		result, callErr := a.invokeTypedJSONWithIDResolution(ctx, cfg, "cards resolve", "cards.move", "card_id", plan.cardID, cardIDLookupSpec, nil, plan.moveBody)
 		return result, "cards resolve", callErr
 	case "reopen":
 		id, body, err := a.parseCardReopenInput(ctx, args[1:], cfg, "cards reopen")
@@ -813,28 +827,39 @@ func (a *App) parseCardMoveInput(ctx context.Context, args []string, cfg config.
 	return cardID, body, nil
 }
 
-func (a *App) parseCardResolveInput(ctx context.Context, args []string, cfg config.Resolved, commandName string) (string, map[string]any, error) {
+type cardResolvePlan struct {
+	cardID             string
+	moveBody           map[string]any
+	resolutionRefs     []string
+	evidenceBody       string
+	evidenceSummary    string
+	evidenceActorIDRaw string
+	hasEvidenceMessage bool
+}
+
+func (a *App) parseCardResolveInput(args []string, cfg config.Resolved, commandName string) (cardResolvePlan, error) {
+	leadingCardID, args := popLeadingPositional(args)
 	fs := newSilentFlagSet(commandName)
-	var cardIDFlag, resolutionFlag, ifBoardUpdatedAtFlag, actorIDFlag trackedString
+	var cardIDFlag, resolutionFlag, ifBoardUpdatedAtFlag, actorIDFlag, bodyFlag, bodyFileFlag, summaryFlag trackedString
 	var resolutionRefFlags trackedStrings
 	fs.Var(&cardIDFlag, "card", "Card id")
 	fs.Var(&cardIDFlag, "card-id", "Card id")
 	fs.Var(&resolutionFlag, "resolution", "Resolution value: done (abandon work with trash, not resolution)")
 	fs.Var(&resolutionRefFlags, "resolution-ref", "Evidence event/artifact typed ref (repeatable)")
+	fs.Var(&bodyFlag, "body", "Post this evidence body to the card thread before resolving")
+	fs.Var(&bodyFileFlag, "body-file", "Load evidence body text from a local file before resolving")
+	fs.Var(&summaryFlag, "summary", "Optional short evidence event summary")
 	fs.Var(&ifBoardUpdatedAtFlag, "if-board-updated-at", "Board updated_at concurrency token; discovered when omitted")
 	fs.Var(&actorIDFlag, "actor-id", "Actor id")
 	if err := fs.Parse(args); err != nil {
-		return "", nil, errnorm.Usage("invalid_flags", err.Error())
+		return cardResolvePlan{}, errnorm.Usage("invalid_flags", err.Error())
 	}
-	cardID, err := parseCardIDFromFlagOrPositionals(cardIDFlag.value, fs.Args(), commandName)
+	cardID, err := parseCardIDFromFlagOrPositionals(firstNonEmpty(cardIDFlag.value, leadingCardID), fs.Args(), commandName)
 	if err != nil {
-		return "", nil, err
+		return cardResolvePlan{}, err
 	}
 	resolution := firstNonEmpty(strings.TrimSpace(resolutionFlag.value), "done")
 	refs := normalizeStringFilters(resolutionRefFlags.values)
-	if len(refs) == 0 {
-		return "", nil, errnorm.Usage("invalid_request", "`anx cards resolve` requires at least one --resolution-ref")
-	}
 	body := map[string]any{
 		"column_key":      "done",
 		"resolution":      resolution,
@@ -845,15 +870,56 @@ func (a *App) parseCardResolveInput(ctx context.Context, args []string, cfg conf
 	}
 	actorID, err := resolveActorIDAlias(actorIDFlag.value, cfg)
 	if err != nil {
-		return "", nil, err
+		return cardResolvePlan{}, err
 	}
 	if actorID != "" {
 		body["actor_id"] = actorID
 	}
-	if err := a.ensureCardMoveConcurrency(ctx, cfg, cardID, body); err != nil {
-		return "", nil, err
+	bodyText := ""
+	hasBodyFlag := strings.TrimSpace(bodyFlag.value) != "" || strings.TrimSpace(bodyFileFlag.value) != ""
+	if hasBodyFlag {
+		bodyText, err = a.readExplicitMessageText(bodyFlag.value, bodyFileFlag.value, commandName)
+		if err != nil {
+			return cardResolvePlan{}, err
+		}
 	}
-	return cardID, body, nil
+	return cardResolvePlan{
+		cardID:             cardID,
+		moveBody:           body,
+		resolutionRefs:     refs,
+		evidenceBody:       bodyText,
+		evidenceSummary:    summaryFlag.value,
+		evidenceActorIDRaw: actorIDFlag.value,
+		hasEvidenceMessage: hasBodyFlag,
+	}, nil
+}
+
+func (a *App) postCardResolveEvidence(ctx context.Context, cfg config.Resolved, plan cardResolvePlan) (string, error) {
+	card, err := a.fetchCardBody(ctx, cfg, plan.cardID)
+	if err != nil {
+		return "", err
+	}
+	target, err := cardMessageTarget(card, plan.cardID)
+	if err != nil {
+		return "", err
+	}
+	body, err := buildMessagePostedBody(cfg, plan.evidenceActorIDRaw, target, plan.evidenceBody, plan.evidenceSummary, nil, "")
+	if err != nil {
+		return "", err
+	}
+	if err := validateEventsCreateInput(body, "cards resolve"); err != nil {
+		return "", err
+	}
+	result, err := a.invokeTypedJSON(ctx, cfg, "cards resolve", "events.create", nil, nil, body)
+	if err != nil {
+		return "", err
+	}
+	event := extractNestedMap(extractNestedMap(asMap(result.Data), "body"), "event")
+	eventID := strings.TrimSpace(anyString(event["id"]))
+	if eventID == "" {
+		return "", errnorm.Usage("invalid_response", "cards resolve evidence event response did not include event id")
+	}
+	return "event:" + eventID, nil
 }
 
 func (a *App) parseCardReopenInput(ctx context.Context, args []string, cfg config.Resolved, commandName string) (string, map[string]any, error) {

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -165,7 +165,7 @@ var boardsSubcommandSpec = subcommandSpec{
 var boardsCardsSubcommandSpec = subcommandSpec{
 	command:  "boards cards",
 	valid:    []string{"list", "create", "create-batch", "get", "patch", "move", "archive"},
-	examples: []string{"anx cards create --board <board-id> --title \"Buy groceries\" --content-file card.md", "anx cards message <card-id> --body-file update.md", "anx cards move --card <card-id> --column review", "anx cards resolve --card <card-id> --resolution-ref event:<event-id>", "anx boards cards list <board-id>", "anx boards cards get <board-id> <card-id>", "anx boards cards create-batch --board-id <board-id> --from-file batch.json"},
+	examples: []string{"anx cards create --board <board-id> --title \"Buy groceries\" --content-file card.md", "anx cards message <card-id> --body-file update.md", "anx cards move --card <card-id> --column review", "anx cards resolve --card <card-id> --body-file evidence.md", "anx boards cards list <board-id>", "anx boards cards get <board-id> <card-id>", "anx boards cards create-batch --board-id <board-id> --from-file batch.json"},
 }
 
 var docsSubcommandSpec = subcommandSpec{

--- a/cli/internal/app/text_output.go
+++ b/cli/internal/app/text_output.go
@@ -383,6 +383,7 @@ func formatCardRecord(card map[string]any) string {
 	lines = appendScalar(lines, "thread_id", card, "thread_id")
 	lines = appendScalar(lines, "document_ref", card, "document_ref")
 	lines = appendScalar(lines, "column_key", card, "column_key")
+	lines = appendScalar(lines, "status", card, "status")
 	lines = appendScalar(lines, "rank", card, "rank")
 	lines = appendScalar(lines, "risk", card, "risk")
 	lines = appendScalar(lines, "resolution", card, "resolution")
@@ -395,6 +396,7 @@ func formatCardRecord(card map[string]any) string {
 		lines = appendScalar(lines, "trashed_by", card, "trashed_by")
 		lines = appendScalar(lines, "trash_reason", card, "trash_reason")
 	}
+	lines = appendScalar(lines, "created_at", card, "created_at")
 	lines = appendScalar(lines, "updated_at", card, "updated_at")
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

- Add `cards resolve --body` / `--body-file` so the CLI posts card evidence and resolves with the captured `event:<id>` in one command.
- Let `cards resolve <card-id> --body...` work with flags after the positional card id.
- Let `topics message` / `topics reply` accept `--thread` / `--thread-id` for backing-thread handoffs.
- Expand card detail text output with `status` and `created_at`, and refresh CLI help/runbook docs.

## Validation

- `cd cli && go test ./internal/app`
- `cd cli && go test ./...`
- `make cli-check`
- commit hook: CLI checks
- pre-push hook: CLI integration tests

## ANX Card

Resolved card `28c39c13-10b8-4ad7-9aa7-0ca4f249aecd` with evidence event `event:055735fc-5aa9-4554-932a-0317df09e605`.
