### PR TITLE
[codex] Add CLI URL resource helpers

### DIFF
--- a/cli/internal/app/command_usage_preflight.go
+++ b/cli/internal/app/command_usage_preflight.go
@@ -88,6 +88,10 @@ func preflightKnownCommandShape(args []string) error {
 		return preflightSubcommand(args[1:], secretSubcommandSpec)
 	case "workspace":
 		return preflightWorkspaceSubcommand(args[1:])
+	case "read":
+		return nil
+	case "url":
+		return nil
 	case "actors":
 		return preflightSubcommand(args[1:], actorsSubcommandSpec)
 	case "threads":
@@ -270,7 +274,7 @@ func preflightFlagUsage(args []string, spec map[string]preflightFlagSpec) error 
 func preflightRootCommands() map[string]struct{} {
 	return map[string]struct{}{
 		"version": {}, "doctor": {}, "update": {}, "bridge": {}, "auth": {}, "config": {}, "meta": {}, "notifications": {},
-		"import": {}, "draft": {}, "provenance": {}, "human": {}, "secret": {}, "workspace": {}, "concepts": {}, "primitives": {},
+		"import": {}, "draft": {}, "provenance": {}, "human": {}, "secret": {}, "workspace": {}, "read": {}, "url": {}, "concepts": {}, "primitives": {},
 		"actors": {}, "threads": {}, "topics": {}, "ref-edges": {}, "cards": {}, "artifacts": {}, "boards": {}, "docs": {}, "events": {},
 		"inbox": {}, "derived": {}, "api": {}, "help": {}, "--help": {}, "-h": {},
 	}

--- a/cli/internal/app/commands.go
+++ b/cli/internal/app/commands.go
@@ -75,6 +75,12 @@ func (a *App) runCommand(ctx context.Context, args []string, cfg config.Resolved
 	case "workspace":
 		result, name, err := a.runWorkspaceCommand(ctx, args[1:], cfg)
 		return name, result, err
+	case "read":
+		result, err := a.runReadCommand(ctx, args[1:], cfg)
+		return "read", result, err
+	case "url":
+		result, err := a.runURLCommand(ctx, args[1:], cfg)
+		return "url", result, err
 	case "concepts":
 		if len(args) > 1 {
 			return "concepts", nil, errnorm.Usage("invalid_args", "unexpected positional arguments for `anx concepts`")

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -636,6 +636,8 @@ Core Commands:
   provenance    Walk refs/provenance links as a deterministic graph
   secret        Manage workspace secrets for agent credential injection
   workspace     Summarize workspace boards and counts for first-run orientation
+  read          Read an ANX resource from a URL or typed ref
+  url           Print a shareable ANX URL for a resource
   api call      Perform an arbitrary HTTP API request
   help [topic]  Show onboarding help or generated command help
 `) + "\n")

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -641,7 +641,7 @@ func (a *App) runThreadsCommand(ctx context.Context, args []string, cfg config.R
 		result, err := a.invokeTypedJSON(ctx, cfg, "threads list", "threads.list", nil, query, nil)
 		return result, "threads list", err
 	case "get":
-		id, err := parseIDArg(args[1:], "thread-id", "thread id")
+		id, err := parseResourceIDArg(args[1:], "thread-id", "thread id", "thread")
 		if err != nil {
 			return nil, "threads get", err
 		}
@@ -1092,7 +1092,7 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 		result, err := a.invokeTypedJSON(ctx, cfg, "artifacts list", "artifacts.list", nil, query, nil)
 		return result, "artifacts list", err
 	case "get":
-		id, err := parseIDArg(args[1:], "artifact-id", "artifact id")
+		id, err := parseResourceIDArg(args[1:], "artifact-id", "artifact id", "artifact")
 		if err != nil {
 			return nil, "artifacts get", err
 		}
@@ -1114,7 +1114,7 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 			return nil, "artifacts create", err
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "artifacts create", "artifacts.create", nil, nil, body)
-		return result, "artifacts create", callErr
+		return addResourceURLToResult(cfg, "artifacts.create", result), "artifacts create", callErr
 	case "content":
 		fs := newSilentFlagSet("artifacts content")
 		var artifactIDFlag trackedString
@@ -1391,9 +1391,9 @@ func (a *App) runBoardsCommand(ctx context.Context, args []string, cfg config.Re
 			return dryRunResult("boards create", "boards.create", nil, nil, body), "boards create", nil
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "boards create", "boards.create", nil, nil, body)
-		return result, "boards create", callErr
+		return addResourceURLToResult(cfg, "boards.create", result), "boards create", callErr
 	case "get":
-		id, err := parseIDArg(args[1:], "board-id", "board id")
+		id, err := parseResourceIDArg(args[1:], "board-id", "board id", "board")
 		if err != nil {
 			return nil, "boards get", err
 		}
@@ -1430,7 +1430,7 @@ func (a *App) runBoardsCommand(ctx context.Context, args []string, cfg config.Re
 		)
 		return result, "boards patch", callErr
 	case "workspace":
-		id, err := parseIDArg(args[1:], "board-id", "board id")
+		id, err := parseResourceIDArg(args[1:], "board-id", "board id", "board")
 		if err != nil {
 			return nil, "boards workspace", err
 		}
@@ -1731,7 +1731,7 @@ func (a *App) runBoardCardsCommand(ctx context.Context, args []string, cfg confi
 			ensureEmptyListDefaults(bodyMap, "card", []string{"assignee_refs", "resolution_refs", "related_refs"})
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "boards cards create", "boards.cards.create", map[string]string{"board_id": boardID}, nil, body)
-		return result, "boards cards create", callErr
+		return addResourceURLToResult(cfg, "boards.cards.create", result), "boards cards create", callErr
 	case "create-batch":
 		boardID, body, err := a.parseBoardBatchCardCreateInput(ctx, args[1:], cfg, "boards cards create-batch")
 		if err != nil {
@@ -1851,9 +1851,9 @@ func (a *App) runDocsCommand(ctx context.Context, args []string, cfg config.Reso
 			return dryRunResult("docs create", "docs.create", nil, nil, body), "docs create", nil
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "docs create", "docs.create", nil, nil, body)
-		return result, "docs create", callErr
+		return addResourceURLToResult(cfg, "docs.create", result), "docs create", callErr
 	case "get":
-		id, err := parseIDArg(args[1:], "document-id", "document id")
+		id, err := parseResourceIDArg(args[1:], "document-id", "document id", "document")
 		if err != nil {
 			return nil, "docs get", err
 		}
@@ -1905,7 +1905,7 @@ func (a *App) runDocsCommand(ctx context.Context, args []string, cfg config.Reso
 		result, callErr := a.runDocsReviseCommand(ctx, args[1:], cfg)
 		return result, "docs revise", callErr
 	case "history":
-		id, err := parseIDArg(args[1:], "document-id", "document id")
+		id, err := parseResourceIDArg(args[1:], "document-id", "document id", "document")
 		if err != nil {
 			return nil, "docs history", err
 		}
@@ -2361,7 +2361,7 @@ func (a *App) runEventsCommand(ctx context.Context, args []string, cfg config.Re
 }
 
 func (a *App) runArtifactsInspectCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
-	id, err := parseIDArg(args, "artifact-id", "artifact id")
+	id, err := parseResourceIDArg(args, "artifact-id", "artifact id", "artifact")
 	if err != nil {
 		return nil, err
 	}
@@ -2433,7 +2433,7 @@ func (a *App) runArtifactsInspectCommand(ctx context.Context, args []string, cfg
 }
 
 func (a *App) runDocsContentCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
-	id, err := parseIDArg(args, "document-id", "document id")
+	id, err := parseResourceIDArg(args, "document-id", "document id", "document")
 	if err != nil {
 		return nil, err
 	}
@@ -4160,20 +4160,9 @@ func (a *App) resolveMaybeThreadID(ctx context.Context, cfg config.Resolved, raw
 }
 
 func parseIDArg(args []string, idFlag string, idLabel string) (string, error) {
-	fs := newSilentFlagSet(idLabel)
-	var idArgFlag trackedString
-	fs.Var(&idArgFlag, idFlag, idLabel)
-	if err := fs.Parse(args); err != nil {
-		return "", errnorm.Usage("invalid_flags", err.Error())
-	}
-	positionals := fs.Args()
-	id := strings.TrimSpace(idArgFlag.value)
-	if id == "" && len(positionals) > 0 {
-		id = strings.TrimSpace(positionals[0])
-		positionals = positionals[1:]
-	}
-	if len(positionals) > 0 {
-		return "", errnorm.Usage("invalid_args", "too many positional arguments")
+	id, err := parseRawIDArg(args, idFlag, idLabel)
+	if err != nil {
+		return "", err
 	}
 	if err := validateID(id, idLabel); err != nil {
 		return "", err

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -184,6 +184,152 @@ func TestRefEdgesListRequiresExactlyOneSelector(t *testing.T) {
 	}
 }
 
+func TestReadCommandsAcceptANXURLs(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/cards/card_123":
+			_, _ = w.Write([]byte(`{"card":{"id":"card_123","title":"Card URL","summary":"body"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/docs/doc_123":
+			_, _ = w.Write([]byte(`{"document":{"id":"doc_123","title":"Doc URL"},"revision":{"id":"rev_123","content":"doc body"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/artifacts/art_123":
+			_, _ = w.Write([]byte(`{"artifact":{"id":"art_123","kind":"text/plain","summary":"Artifact URL"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/artifacts/art_123/content":
+			_, _ = w.Write([]byte(`artifact body`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	base := server.URL
+	cardURL := "https://anx.example/o/org/w/workspace/boards/board_123?card=card_123"
+	docURL := "https://anx.example/o/org/w/workspace/docs/doc_123"
+	artifactURL := "https://anx.example/o/org/w/workspace/artifacts/art_123"
+
+	assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", base, "cards", "get", cardURL}))
+	assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", base, "docs", "content", docURL}))
+	assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", base, "artifacts", "inspect", artifactURL}))
+
+	joined := strings.Join(paths, "\n")
+	for _, expected := range []string{"/cards/card_123", "/docs/doc_123", "/artifacts/art_123", "/artifacts/art_123/content"} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected request path %s, got:\n%s", expected, joined)
+		}
+	}
+}
+
+func TestReadDispatchesURLsAndTypedRefs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/cards/card_123":
+			_, _ = w.Write([]byte(`{"card":{"id":"card_123","title":"Card URL","summary":"body"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/docs/doc_123":
+			_, _ = w.Write([]byte(`{"document":{"id":"doc_123","title":"Doc URL"},"revision":{"id":"rev_123","content":"doc body"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	cardURL := "https://anx.example/o/org/w/workspace/boards/board_123?card=card_123"
+
+	cardPayload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", server.URL, "read", cardURL}))
+	if got := anyStringValue(cardPayload["command"]); got != "read" {
+		t.Fatalf("expected read command envelope, got %#v", cardPayload)
+	}
+
+	docPayload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", server.URL, "read", "document:doc_123"}))
+	data := asMap(docPayload["data"])
+	if got := anyStringValue(data["content"]); got != "doc body" {
+		t.Fatalf("expected docs content body, got %#v", docPayload)
+	}
+}
+
+func TestReadRejectsAmbiguousPlainID(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	payload := assertEnvelopeError(t, runCLIForTest(t, home, nil, nil, []string{"--json", "read", "abc123"}))
+	errObj := asMap(payload["error"])
+	if got := anyStringValue(errObj["code"]); got != "invalid_request" {
+		t.Fatalf("expected invalid_request, got %#v", payload)
+	}
+	if got := anyStringValue(errObj["message"]); !strings.Contains(got, "requires an ANX URL or typed ref") {
+		t.Fatalf("expected URL or typed ref guidance, got %#v", payload)
+	}
+}
+
+func TestCreateCommandsAppendShareableURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/boards"):
+			_, _ = w.Write([]byte(`{"board":{"id":"board_123","title":"Board URL"}}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cards"):
+			_, _ = w.Write([]byte(`{"card":{"id":"card_123","board_ref":"board:board_123","title":"Card URL"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	hostedBase := server.URL + "/ws/david-zhang/personal"
+	boardOut := runCLIForTest(t, home, nil, nil, []string{"--base-url", hostedBase, "boards", "create", "--title", "Board URL"})
+	if !strings.Contains(boardOut, "URL: "+server.URL+"/o/david-zhang/w/personal/boards/board_123") {
+		t.Fatalf("expected board create URL, got:\n%s", boardOut)
+	}
+
+	contentFile := filepath.Join(home, "card.md")
+	if err := os.WriteFile(contentFile, []byte("body\n"), 0o600); err != nil {
+		t.Fatalf("write content file: %v", err)
+	}
+	cardOut := runCLIForTest(t, home, nil, nil, []string{"--base-url", hostedBase, "cards", "create", "--board", "board_123", "--title", "Card URL", "--content-file", contentFile})
+	if !strings.Contains(cardOut, "URL: "+server.URL+"/o/david-zhang/w/personal/boards/board_123?card=card_123") {
+		t.Fatalf("expected card create URL, got:\n%s", cardOut)
+	}
+
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", hostedBase, "boards", "create", "--title", "Board URL"}))
+	if got := anyStringValue(asMap(payload["data"])["url"]); got != server.URL+"/o/david-zhang/w/personal/boards/board_123" {
+		t.Fatalf("expected structured URL, got %#v", payload)
+	}
+}
+
+func TestURLCommandPrintsShareableURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cards/card_123"):
+			_, _ = w.Write([]byte(`{"card":{"id":"card_123","board_ref":"board:board_123","title":"Card URL"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	hostedBase := server.URL + "/ws/david-zhang/personal"
+	out := strings.TrimSpace(runCLIForTest(t, home, nil, nil, []string{"--base-url", hostedBase, "url", "card", "card:card_123"}))
+	expected := server.URL + "/o/david-zhang/w/personal/boards/board_123?card=card_123"
+	if out != expected {
+		t.Fatalf("expected %q, got %q", expected, out)
+	}
+}
+
 func TestHumanAskCommandCreatesHumanAttentionRequestedEvent(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/resource_locator.go
+++ b/cli/internal/app/resource_locator.go
@@ -1,0 +1,488 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"agent-nexus-cli/internal/config"
+	"agent-nexus-cli/internal/errnorm"
+)
+
+type resourceLocator struct {
+	Kind    string
+	ID      string
+	BoardID string
+	EventID string
+}
+
+func parseRawIDArg(args []string, idFlag string, idLabel string) (string, error) {
+	fs := newSilentFlagSet(idLabel)
+	var idArgFlag trackedString
+	fs.Var(&idArgFlag, idFlag, idLabel)
+	if err := fs.Parse(args); err != nil {
+		return "", errnorm.Usage("invalid_flags", err.Error())
+	}
+	positionals := fs.Args()
+	id := strings.TrimSpace(idArgFlag.value)
+	if id == "" && len(positionals) > 0 {
+		id = strings.TrimSpace(positionals[0])
+		positionals = positionals[1:]
+	}
+	if len(positionals) > 0 {
+		return "", errnorm.Usage("invalid_args", "too many positional arguments")
+	}
+	return id, nil
+}
+
+func parseResourceIDArg(args []string, idFlag string, idLabel string, expectedKind string) (string, error) {
+	raw, err := parseRawIDArg(args, idFlag, idLabel)
+	if err != nil {
+		return "", err
+	}
+	id, err := normalizeResourceIDInput(raw, expectedKind, idLabel)
+	if err != nil {
+		return "", err
+	}
+	if err := validateID(id, idLabel); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func normalizeResourceIDInput(raw string, expectedKind string, idLabel string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw, nil
+	}
+	if loc, ok, err := parseResourceLocator(raw); err != nil {
+		return "", err
+	} else if ok {
+		if !resourceKindMatches(loc.Kind, expectedKind) {
+			return "", errnorm.Usage("invalid_request", fmt.Sprintf("%s URL points to %s, not %s", idLabel, displayResourceKind(loc.Kind), displayResourceKind(expectedKind)))
+		}
+		return loc.ID, nil
+	}
+	if kind, value, _, err := parseTypedRef(raw); err == nil {
+		if !resourceKindMatches(kind, expectedKind) {
+			return "", errnorm.Usage("invalid_request", fmt.Sprintf("%s typed ref points to %s, not %s", idLabel, displayResourceKind(kind), displayResourceKind(expectedKind)))
+		}
+		return value, nil
+	}
+	return raw, nil
+}
+
+func parseResourceLocator(raw string) (resourceLocator, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.Contains(raw, "://") {
+		return resourceLocator{}, false, nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("invalid ANX URL %q", raw))
+	}
+	segments := normalizedPathSegments(parsed.Path)
+	for idx, segment := range segments {
+		switch segment {
+		case "boards":
+			if idx+1 >= len(segments) {
+				return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("ANX board URL %q is missing a board id", raw))
+			}
+			boardID := strings.TrimSpace(segments[idx+1])
+			if cardID := strings.TrimSpace(parsed.Query().Get("card")); cardID != "" {
+				return resourceLocator{Kind: "card", ID: cardID, BoardID: boardID}, true, nil
+			}
+			return resourceLocator{Kind: "board", ID: boardID}, true, nil
+		case "topics":
+			if idx+1 >= len(segments) {
+				return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("ANX topic URL %q is missing a topic id", raw))
+			}
+			return resourceLocator{Kind: "topic", ID: strings.TrimSpace(segments[idx+1]), EventID: eventIDFromFragment(parsed.Fragment)}, true, nil
+		case "docs":
+			if idx+1 >= len(segments) {
+				return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("ANX doc URL %q is missing a document id", raw))
+			}
+			return resourceLocator{Kind: "document", ID: strings.TrimSpace(segments[idx+1]), EventID: eventIDFromFragment(parsed.Fragment)}, true, nil
+		case "artifacts":
+			if idx+1 >= len(segments) {
+				return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("ANX artifact URL %q is missing an artifact id", raw))
+			}
+			return resourceLocator{Kind: "artifact", ID: strings.TrimSpace(segments[idx+1])}, true, nil
+		case "threads":
+			if idx+1 >= len(segments) {
+				return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("ANX thread URL %q is missing a thread id", raw))
+			}
+			return resourceLocator{Kind: "thread", ID: strings.TrimSpace(segments[idx+1])}, true, nil
+		}
+	}
+	return resourceLocator{}, false, nil
+}
+
+func typedRefLocator(raw string) (resourceLocator, bool, error) {
+	kind, value, _, err := parseTypedRef(raw)
+	if err != nil {
+		return resourceLocator{}, false, nil
+	}
+	switch canonicalResourceKind(kind) {
+	case "board", "card", "topic", "document", "artifact", "thread":
+		return resourceLocator{Kind: canonicalResourceKind(kind), ID: value}, true, nil
+	default:
+		return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("unsupported resource ref kind %q for `anx read`", kind))
+	}
+}
+
+func normalizedPathSegments(rawPath string) []string {
+	parts := strings.Split(strings.Trim(rawPath, "/"), "/")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func eventIDFromFragment(fragment string) string {
+	fragment = strings.TrimSpace(fragment)
+	return strings.TrimPrefix(fragment, "event-")
+}
+
+func resourceKindMatches(actual string, expected string) bool {
+	return canonicalResourceKind(actual) == canonicalResourceKind(expected)
+}
+
+func canonicalResourceKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "doc", "docs", "document", "documents":
+		return "document"
+	case "board", "boards":
+		return "board"
+	case "card", "cards":
+		return "card"
+	case "topic", "topics":
+		return "topic"
+	case "artifact", "artifacts":
+		return "artifact"
+	case "thread", "threads":
+		return "thread"
+	default:
+		return strings.ToLower(strings.TrimSpace(kind))
+	}
+}
+
+func displayResourceKind(kind string) string {
+	switch canonicalResourceKind(kind) {
+	case "document":
+		return "document"
+	default:
+		return canonicalResourceKind(kind)
+	}
+}
+
+func (a *App) runReadCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		return &commandResult{Text: readCommandHelpText(), Data: map[string]any{"help_text": readCommandHelpText()}}, nil
+	}
+	if len(args) > 1 {
+		return nil, errnorm.Usage("invalid_args", "unexpected positional arguments for `anx read`; pass one ANX URL or typed ref")
+	}
+	raw := strings.TrimSpace(args[0])
+	loc, ok, err := parseResourceLocator(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		loc, ok, err = typedRefLocator(raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !ok {
+		return nil, errnorm.Usage("invalid_request", "`anx read` requires an ANX URL or typed ref such as card:<id>, document:<id>, topic:<id>, board:<id>, artifact:<id>, or thread:<id>")
+	}
+	switch canonicalResourceKind(loc.Kind) {
+	case "card":
+		result, _, err := a.runCardsCommand(ctx, []string{"get", loc.ID}, cfg)
+		return result, err
+	case "document":
+		return a.runDocsContentCommand(ctx, []string{loc.ID}, cfg)
+	case "topic":
+		result, _, err := a.runTopicsCommand(ctx, []string{"get", loc.ID}, cfg)
+		return result, err
+	case "board":
+		result, _, err := a.runBoardsCommand(ctx, []string{"get", loc.ID}, cfg)
+		return result, err
+	case "artifact":
+		return a.runArtifactsInspectCommand(ctx, []string{loc.ID}, cfg)
+	case "thread":
+		result, _, err := a.runThreadsCommand(ctx, []string{"inspect", loc.ID}, cfg)
+		return result, err
+	default:
+		return nil, errnorm.Usage("invalid_request", fmt.Sprintf("unsupported resource kind %q for `anx read`", loc.Kind))
+	}
+}
+
+func (a *App) runURLCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, error) {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		return &commandResult{Text: urlCommandHelpText(), Data: map[string]any{"help_text": urlCommandHelpText()}}, nil
+	}
+	if len(args) != 2 {
+		return nil, errnorm.Usage("invalid_args", "`anx url` expects `<type> <id-or-url-or-ref>`")
+	}
+	kind := canonicalResourceKind(args[0])
+	if kind == "" {
+		return nil, errnorm.Usage("invalid_request", "resource type is required")
+	}
+	id, err := normalizeResourceIDInput(args[1], kind, kind+" id")
+	if err != nil {
+		return nil, err
+	}
+	if err := validateID(id, kind+" id"); err != nil {
+		return nil, err
+	}
+	loc := resourceLocator{Kind: kind, ID: id}
+	loc, err = a.resolveLocatorForURL(ctx, cfg, loc)
+	if err != nil {
+		return nil, err
+	}
+	resourceURL, err := resourceURL(cfg, loc)
+	if err != nil {
+		return nil, err
+	}
+	return &commandResult{
+		Text: resourceURL,
+		Data: map[string]any{
+			"url":  resourceURL,
+			"kind": canonicalResourceKind(loc.Kind),
+			"id":   loc.ID,
+		},
+	}, nil
+}
+
+func (a *App) resolveLocatorForURL(ctx context.Context, cfg config.Resolved, loc resourceLocator) (resourceLocator, error) {
+	switch canonicalResourceKind(loc.Kind) {
+	case "board":
+		id, err := a.resolveResourceIDFromList(ctx, cfg, loc.ID, boardIDLookupSpec)
+		if err == nil {
+			loc.ID = id
+		} else if shouldResolveDisplayedShortID(loc.ID) {
+			return loc, err
+		}
+	case "topic":
+		id, err := a.resolveResourceIDFromList(ctx, cfg, loc.ID, topicIDLookupSpec)
+		if err == nil {
+			loc.ID = id
+		} else if shouldResolveDisplayedShortID(loc.ID) {
+			return loc, err
+		}
+	case "document":
+		id, err := a.resolveResourceIDFromList(ctx, cfg, loc.ID, documentIDLookupSpec)
+		if err == nil {
+			loc.ID = id
+		} else if shouldResolveDisplayedShortID(loc.ID) {
+			return loc, err
+		}
+	case "artifact":
+		id, err := a.resolveResourceIDFromList(ctx, cfg, loc.ID, artifactIDLookupSpec)
+		if err == nil {
+			loc.ID = id
+		} else if shouldResolveDisplayedShortID(loc.ID) {
+			return loc, err
+		}
+	case "card":
+		cardID := loc.ID
+		if shouldResolveDisplayedShortID(cardID) {
+			resolved, err := a.resolveResourceIDFromList(ctx, cfg, cardID, cardIDLookupSpec)
+			if err != nil {
+				return loc, err
+			}
+			cardID = resolved
+			loc.ID = resolved
+		}
+		if strings.TrimSpace(loc.BoardID) == "" {
+			result, err := a.invokeTypedJSON(ctx, cfg, "cards get", "cards.get", map[string]string{"card_id": cardID}, nil, nil)
+			if err != nil {
+				return loc, err
+			}
+			card := extractNestedMap(commandResultBody(result), "card")
+			loc.BoardID = refID(anyString(card["board_ref"]))
+		}
+	}
+	return loc, nil
+}
+
+func addResourceURLToResult(cfg config.Resolved, commandID string, result *commandResult) *commandResult {
+	if result == nil {
+		return result
+	}
+	body := commandResultBody(result)
+	loc, ok := locatorFromCommandBody(commandID, body)
+	if !ok {
+		return result
+	}
+	resourceURL, err := resourceURL(cfg, loc)
+	if err != nil || strings.TrimSpace(resourceURL) == "" {
+		return result
+	}
+	data := asMap(result.Data)
+	if data != nil {
+		data["url"] = resourceURL
+		if body != nil {
+			body["url"] = resourceURL
+			data["body"] = body
+		}
+		result.Data = data
+	}
+	if strings.TrimSpace(result.Text) != "" && !cfg.Verbose && !cfg.Headers {
+		result.Text = strings.TrimRight(result.Text, "\n") + "\nURL: " + resourceURL
+	}
+	return result
+}
+
+func locatorFromCommandBody(commandID string, body map[string]any) (resourceLocator, bool) {
+	switch strings.TrimSpace(commandID) {
+	case "boards.create":
+		board := extractNestedMap(body, "board")
+		id := strings.TrimSpace(anyString(board["id"]))
+		return resourceLocator{Kind: "board", ID: id}, id != ""
+	case "topics.create":
+		topic := extractNestedMap(body, "topic")
+		id := strings.TrimSpace(anyString(topic["id"]))
+		return resourceLocator{Kind: "topic", ID: id}, id != ""
+	case "docs.create":
+		document := extractNestedMap(body, "document")
+		id := strings.TrimSpace(anyString(document["id"]))
+		return resourceLocator{Kind: "document", ID: id}, id != ""
+	case "artifacts.create":
+		artifact := extractNestedMap(body, "artifact")
+		id := strings.TrimSpace(anyString(artifact["id"]))
+		return resourceLocator{Kind: "artifact", ID: id}, id != ""
+	case "cards.create", "boards.cards.create":
+		card := extractNestedMap(body, "card")
+		id := strings.TrimSpace(anyString(card["id"]))
+		boardID := refID(anyString(card["board_ref"]))
+		if boardID == "" {
+			board := extractNestedMap(body, "board")
+			boardID = strings.TrimSpace(anyString(board["id"]))
+		}
+		return resourceLocator{Kind: "card", ID: id, BoardID: boardID}, id != "" && boardID != ""
+	default:
+		return resourceLocator{}, false
+	}
+}
+
+func resourceURL(cfg config.Resolved, loc resourceLocator) (string, error) {
+	base, err := webWorkspaceBaseURL(cfg.BaseURL)
+	if err != nil {
+		return "", err
+	}
+	switch canonicalResourceKind(loc.Kind) {
+	case "board":
+		return joinURLPath(base, "boards", loc.ID), nil
+	case "card":
+		if strings.TrimSpace(loc.BoardID) == "" {
+			return "", errnorm.Usage("invalid_request", "card URL requires board context")
+		}
+		boardURL := joinURLPath(base, "boards", loc.BoardID)
+		sep := "?"
+		if strings.Contains(boardURL, "?") {
+			sep = "&"
+		}
+		return boardURL + sep + "card=" + url.QueryEscape(loc.ID), nil
+	case "topic":
+		out := joinURLPath(base, "topics", loc.ID)
+		if strings.TrimSpace(loc.EventID) != "" {
+			out += "#event-" + url.PathEscape(loc.EventID)
+		}
+		return out, nil
+	case "document":
+		return joinURLPath(base, "docs", loc.ID), nil
+	case "artifact":
+		return joinURLPath(base, "artifacts", loc.ID), nil
+	case "thread":
+		return joinURLPath(base, "threads", loc.ID), nil
+	default:
+		return "", errnorm.Usage("invalid_request", fmt.Sprintf("unsupported resource kind %q", loc.Kind))
+	}
+}
+
+func webWorkspaceBaseURL(rawBase string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawBase))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errnorm.Usage("invalid_request", fmt.Sprintf("base URL %q is not a valid absolute URL", rawBase))
+	}
+	segments := normalizedPathSegments(parsed.Path)
+	if len(segments) >= 3 && segments[0] == "ws" {
+		parsed.Path = path.Join("/", "o", segments[1], "w", segments[2])
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return strings.TrimRight(parsed.String(), "/"), nil
+	}
+	for idx := 0; idx+3 < len(segments); idx++ {
+		if segments[idx] == "o" && segments[idx+2] == "w" {
+			parsed.Path = path.Join(append([]string{"/"}, segments[:idx+4]...)...)
+			parsed.RawQuery = ""
+			parsed.Fragment = ""
+			return strings.TrimRight(parsed.String(), "/"), nil
+		}
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func joinURLPath(base string, segments ...string) string {
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return strings.TrimRight(base, "/")
+	}
+	all := normalizedPathSegments(parsed.Path)
+	for _, segment := range segments {
+		if segment = strings.TrimSpace(segment); segment != "" {
+			all = append(all, segment)
+		}
+	}
+	escaped := make([]string, 0, len(all))
+	for _, segment := range all {
+		escaped = append(escaped, url.PathEscape(segment))
+	}
+	parsed.Path = "/" + strings.Join(escaped, "/")
+	return parsed.String()
+}
+
+func refID(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if _, value, _, err := parseTypedRef(ref); err == nil {
+		return value
+	}
+	return ref
+}
+
+func readCommandHelpText() string {
+	return strings.TrimSpace(`Local Help: read
+
+- Kind: local helper
+- Summary: Read an ANX resource from a URL or typed ref.
+- Examples:
+  - anx read https://anx.example/o/org/w/workspace/boards/<board-id>?card=<card-id>
+  - anx read document:<document-id>
+  - anx read artifact:<artifact-id>`)
+}
+
+func urlCommandHelpText() string {
+	return strings.TrimSpace(`Local Help: url
+
+- Kind: local helper
+- Summary: Print a shareable ANX URL for a resource.
+- Examples:
+  - anx url card <card-id>
+  - anx url board <board-id>
+  - anx url document <document-id>`)
+}

--- a/cli/internal/app/resource_locator.go
+++ b/cli/internal/app/resource_locator.go
@@ -74,6 +74,21 @@ func normalizeResourceIDInput(raw string, expectedKind string, idLabel string) (
 	return raw, nil
 }
 
+// resourceLocatorScanStart returns the index of the first path segment after the
+// workspace prefix (/o/<org>/w/<workspace> or /ws/<org>/<workspace>), matching
+// webWorkspaceBaseURL. When no prefix is found, 0 preserves legacy URL parsing.
+func resourceLocatorScanStart(segments []string) int {
+	if len(segments) >= 3 && segments[0] == "ws" {
+		return 3
+	}
+	for idx := 0; idx+3 < len(segments); idx++ {
+		if segments[idx] == "o" && segments[idx+2] == "w" {
+			return idx + 4
+		}
+	}
+	return 0
+}
+
 func parseResourceLocator(raw string) (resourceLocator, bool, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || !strings.Contains(raw, "://") {
@@ -84,7 +99,9 @@ func parseResourceLocator(raw string) (resourceLocator, bool, error) {
 		return resourceLocator{}, false, errnorm.Usage("invalid_request", fmt.Sprintf("invalid ANX URL %q", raw))
 	}
 	segments := normalizedPathSegments(parsed.Path)
-	for idx, segment := range segments {
+	scanFrom := resourceLocatorScanStart(segments)
+	for idx := scanFrom; idx < len(segments); idx++ {
+		segment := segments[idx]
 		switch segment {
 		case "boards":
 			if idx+1 >= len(segments) {

--- a/cli/internal/app/resource_topics_cards.go
+++ b/cli/internal/app/resource_topics_cards.go
@@ -91,7 +91,7 @@ func (a *App) runTopicsCommand(ctx context.Context, args []string, cfg config.Re
 		}
 		return result, "topics list", nil
 	case "get":
-		id, err := parseIDArg(args[1:], "topic-id", "topic id")
+		id, err := parseResourceIDArg(args[1:], "topic-id", "topic id", "topic")
 		if err != nil {
 			return nil, "topics get", err
 		}
@@ -109,7 +109,7 @@ func (a *App) runTopicsCommand(ctx context.Context, args []string, cfg config.Re
 			return dryRunResult("topics create", "topics.create", nil, nil, body), "topics create", nil
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "topics create", "topics.create", nil, nil, body)
-		return result, "topics create", callErr
+		return addResourceURLToResult(cfg, "topics.create", result), "topics create", callErr
 	case "patch":
 		id, body, dryRun, err := a.parseIDAndBodyInputWithOptions(args[1:], "topic-id", "topic id", "topics patch", jsonBodyInputOptions{allowDryRun: true})
 		if err != nil {
@@ -150,14 +150,14 @@ func (a *App) runTopicsCommand(ctx context.Context, args []string, cfg config.Re
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "topics reply", "events.create", nil, nil, body)
 		return decorateThreadMessageWriteResult(result, callErr, cfg, "topics.reply", target), "topics reply", callErr
 	case "timeline":
-		id, err := parseIDArg(args[1:], "topic-id", "topic id")
+		id, err := parseResourceIDArg(args[1:], "topic-id", "topic id", "topic")
 		if err != nil {
 			return nil, "topics timeline", err
 		}
 		result, callErr := a.invokeTypedJSONWithIDResolution(ctx, cfg, "topics timeline", "topics.timeline", "topic_id", id, topicIDLookupSpec, nil, nil)
 		return result, "topics timeline", callErr
 	case "workspace":
-		id, err := parseIDArg(args[1:], "topic-id", "topic id")
+		id, err := parseResourceIDArg(args[1:], "topic-id", "topic id", "topic")
 		if err != nil {
 			return nil, "topics workspace", err
 		}
@@ -248,16 +248,16 @@ func (a *App) runCardsCommand(ctx context.Context, args []string, cfg config.Res
 			return dryRunResult("cards create", "cards.create", nil, nil, body), "cards create", nil
 		}
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "cards create", "cards.create", nil, nil, body)
-		return result, "cards create", callErr
+		return addResourceURLToResult(cfg, "cards.create", result), "cards create", callErr
 	case "get":
-		id, err := parseIDArg(args[1:], "card-id", "card id")
+		id, err := parseResourceIDArg(args[1:], "card-id", "card id", "card")
 		if err != nil {
 			return nil, "cards get", err
 		}
 		result, callErr := a.invokeTypedJSONWithIDResolution(ctx, cfg, "cards get", "cards.get", "card_id", id, cardIDLookupSpec, nil, nil)
 		return result, "cards get", callErr
 	case "timeline":
-		id, err := parseIDArg(args[1:], "card-id", "card id")
+		id, err := parseResourceIDArg(args[1:], "card-id", "card id", "card")
 		if err != nil {
 			return nil, "cards timeline", err
 		}
@@ -293,7 +293,7 @@ func (a *App) runCardsCommand(ctx context.Context, args []string, cfg config.Res
 		result, callErr := a.invokeTypedJSON(ctx, cfg, "cards reply", "events.create", nil, nil, body)
 		return a.decorateMessageWriteResult(result, callErr, cfg, "cards.reply", card), "cards reply", callErr
 	case "history":
-		id, err := parseIDArg(args[1:], "card-id", "card id")
+		id, err := parseResourceIDArg(args[1:], "card-id", "card id", "card")
 		if err != nil {
 			return nil, "cards history", err
 		}


### PR DESCRIPTION
## Summary

- Add URL/typed-ref normalization for CLI resource identifiers so read-oriented commands can accept ANX web URLs directly.
- Add local `anx read` and `anx url` helpers for deterministic resource inspection and shareable URL generation without a browser-opening affordance.
- Append shareable URLs to create command text output and expose the generated URL in JSON data for boards, cards, topics, docs, and artifacts.

## Why

Agents are often handed ANX web URLs from the UI or need to hand URLs back to humans. The CLI previously required callers to manually extract IDs from URLs and did not expose a deterministic way to print a shareable URL.

## Validation

- `go test ./internal/app`
- `make cli-check`

## ANX card

Resolves card `d0efb896-9a46-4a67-a9d7-64d8443b10d6`: CLI URL helpers, URL-as-input, and no `anx open` affordance.