### PR TITLE
Refactor Home unread from topic-only to typed group model

### DIFF
--- a/cli/docs/generated/commands.md
+++ b/cli/docs/generated/commands.md
@@ -997,10 +997,10 @@ Generated from `contracts/anx-openapi.yaml`.
 - Stability: `beta`
 - Surface: `canonical`
 - Input mode: `json-body`
-- Why: Advance durable per-topic Home read cursors for the authenticated operator.
+- Why: Advance durable per-group Home read cursors for the authenticated operator.
 - Concepts: `home`, `events`, `write`
 - Error codes: `auth_required`, `invalid_request`, `invalid_token`
-- Output: Returns `{ ok, unread_count, topic_count }`.
+- Output: Returns `{ ok, unread_count, group_count }`.
 
 ## `home.unread`
 
@@ -1009,10 +1009,10 @@ Generated from `contracts/anx-openapi.yaml`.
 - Stability: `beta`
 - Surface: `canonical`
 - Input mode: `none`
-- Why: Load unread high-signal workspace activity grouped by topic for the authenticated operator.
+- Why: Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.
 - Concepts: `home`, `events`
 - Error codes: `auth_required`, `invalid_token`
-- Output: Returns `{ groups, unread_count, topic_count, generated_at }`.
+- Output: Returns `{ groups, unread_count, group_count, generated_at }`.
 
 ## `inbox.get`
 

--- a/cli/internal/registry/commands.json
+++ b/cli/internal/registry/commands.json
@@ -4464,12 +4464,12 @@
       "path": "/home/read",
       "operation_id": "markHomeRead",
       "summary": "Mark Home activity read",
-      "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+      "why": "Advance durable per-group Home read cursors for the authenticated operator.",
       "input_mode": "json-body",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+      "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
       "error_codes": [
         "auth_required",
         "invalid_request",
@@ -4497,20 +4497,20 @@
             "type": "datetime"
           },
           {
-            "name": "reader_id",
-            "type": "string"
-          },
-          {
-            "name": "topic_cursors",
+            "name": "group_cursors",
             "type": "object"
           },
           {
-            "name": "topic_id",
+            "name": "group_ref",
             "type": "string"
           },
           {
-            "name": "topic_ids",
+            "name": "group_refs",
             "type": "list\u003cstring\u003e"
+          },
+          {
+            "name": "reader_id",
+            "type": "string"
           }
         ]
       },
@@ -4524,12 +4524,12 @@
       "path": "/home/unread",
       "operation_id": "getHomeUnread",
       "summary": "Get Home unread activity",
-      "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+      "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+      "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
       "error_codes": [
         "auth_required",
         "invalid_token"

--- a/cli/internal/registry/concepts.json
+++ b/cli/internal/registry/concepts.json
@@ -6095,12 +6095,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -6128,20 +6128,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },
@@ -6155,12 +6155,12 @@
           "path": "/home/unread",
           "operation_id": "getHomeUnread",
           "summary": "Get Home unread activity",
-          "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+          "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+          "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
           "error_codes": [
             "auth_required",
             "invalid_token"
@@ -6334,12 +6334,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -6367,20 +6367,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },
@@ -6394,12 +6394,12 @@
           "path": "/home/unread",
           "operation_id": "getHomeUnread",
           "summary": "Get Home unread activity",
-          "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+          "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+          "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
           "error_codes": [
             "auth_required",
             "invalid_token"
@@ -11956,12 +11956,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -11989,20 +11989,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },

--- a/cli/internal/registry/help.json
+++ b/cli/internal/registry/help.json
@@ -4695,12 +4695,12 @@
       "path": "/home/read",
       "operation_id": "markHomeRead",
       "summary": "Mark Home activity read",
-      "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+      "why": "Advance durable per-group Home read cursors for the authenticated operator.",
       "input_mode": "json-body",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+      "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
       "error_codes": [
         "auth_required",
         "invalid_request",
@@ -4728,20 +4728,20 @@
             "type": "datetime"
           },
           {
-            "name": "reader_id",
-            "type": "string"
-          },
-          {
-            "name": "topic_cursors",
+            "name": "group_cursors",
             "type": "object"
           },
           {
-            "name": "topic_id",
+            "name": "group_ref",
             "type": "string"
           },
           {
-            "name": "topic_ids",
+            "name": "group_refs",
             "type": "list\u003cstring\u003e"
+          },
+          {
+            "name": "reader_id",
+            "type": "string"
           }
         ]
       },
@@ -4755,12 +4755,12 @@
       "path": "/home/unread",
       "operation_id": "getHomeUnread",
       "summary": "Get Home unread activity",
-      "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+      "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+      "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
       "error_codes": [
         "auth_required",
         "invalid_token"

--- a/contracts/anx-openapi.yaml
+++ b/contracts/anx-openapi.yaml
@@ -2236,10 +2236,10 @@ paths:
       tags: [home]
       x-anx-surface: canonical
       x-anx-command-id: home.unread
-      x-anx-why: Load unread high-signal workspace activity grouped by topic for the authenticated operator.
+      x-anx-why: Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.
       x-anx-input-mode: none
       x-anx-streaming: { mode: none }
-      x-anx-output-envelope: "Returns `{ groups, unread_count, topic_count, generated_at }`."
+      x-anx-output-envelope: "Returns `{ groups, unread_count, group_count, generated_at }`."
       x-anx-error-codes: [auth_required, invalid_token]
       x-anx-concepts: [home, events]
       x-anx-stability: beta
@@ -2265,10 +2265,10 @@ paths:
       tags: [home]
       x-anx-surface: canonical
       x-anx-command-id: home.read
-      x-anx-why: Advance durable per-topic Home read cursors for the authenticated operator.
+      x-anx-why: Advance durable per-group Home read cursors for the authenticated operator.
       x-anx-input-mode: json-body
       x-anx-streaming: { mode: none }
-      x-anx-output-envelope: "Returns `{ ok, unread_count, topic_count }`."
+      x-anx-output-envelope: "Returns `{ ok, unread_count, group_count }`."
       x-anx-error-codes: [auth_required, invalid_request, invalid_token]
       x-anx-concepts: [home, events, write]
       x-anx-stability: beta
@@ -5846,20 +5846,23 @@ components:
           type: array
           items: { $ref: '#/components/schemas/HomeUnreadGroup' }
         unread_count: { type: integer, minimum: 0 }
-        topic_count: { type: integer, minimum: 0 }
+        group_count: { type: integer, minimum: 0 }
         generated_at: { type: string, format: date-time }
-      required: [groups, unread_count, topic_count, generated_at]
+      required: [groups, unread_count, group_count, generated_at]
 
     HomeUnreadGroup:
       type: object
       properties:
-        topic: { $ref: '#/components/schemas/Topic' }
+        group_ref: { type: string, description: "Typed ref identifying the group, e.g. topic:<id> or board:<id>." }
+        group_type: { type: string, description: "Group type: topic, board, document, or workspace." }
+        display_name: { type: string }
+        priority: { type: string, description: "Priority label for sorting (P0/P1/P2 or empty)." }
         unread_count: { type: integer, minimum: 0 }
         newest_event: { $ref: '#/components/schemas/Event' }
         events:
           type: array
           items: { $ref: '#/components/schemas/Event' }
-      required: [topic, unread_count, newest_event, events]
+      required: [group_ref, group_type, display_name, unread_count, newest_event, events]
 
     MarkHomeReadRequest:
       type: object
@@ -5870,19 +5873,20 @@ components:
         actor_id:
           type: string
           description: Development legacy actor-mode alias for reader_id.
-        topic_id: { type: string }
-        topic_ids:
+        group_ref: { type: string, description: "Single group typed ref, e.g. topic:<id> or board:<id>." }
+        group_refs:
           type: array
           items: { type: string }
+          description: Batch of group typed refs to mark read.
         expected_newest_event_cursor:
           type: object
           properties:
             ts: { type: string, format: date-time }
             id: { type: string }
           required: [ts, id]
-        topic_cursors:
+        group_cursors:
           type: object
-          description: Optional race-safe per-topic newest event cursors for batch mark-read.
+          description: Optional race-safe per-group newest event cursors for batch mark-read.
           additionalProperties:
             type: object
             properties:
@@ -5890,15 +5894,15 @@ components:
               id: { type: string }
             required: [ts, id]
       anyOf:
-        - required: [topic_id]
-        - required: [topic_ids]
+        - required: [group_ref]
+        - required: [group_refs]
 
     MarkHomeReadResponse:
       type: object
       properties:
         ok: { type: boolean }
         unread_count: { type: integer, minimum: 0 }
-        topic_count: { type: integer, minimum: 0 }
+        group_count: { type: integer, minimum: 0 }
       required: [ok]
 
     ArtifactResponse:

--- a/contracts/anx-schema.yaml
+++ b/contracts/anx-schema.yaml
@@ -165,14 +165,18 @@ primitives:
       summary, refs, and payload.
     home_feed:
       preset_id: home_feed
-      topic_ownership: >
-        Home resolves direct `topic:<id>` refs first, then `thread:<id>` or
-        event.thread_id through topic.thread_id. Events that cannot be assigned
-        to a topic are excluded from Home and remain visible on Events.
+      group_ownership: >
+        Home resolves events to typed groups. Resolution order:
+        1. Direct `topic:<id>` ref → topic group.
+        2. `thread:<id>` or event.thread_id through topic or board backing thread → owning group.
+        3. `board:<id>` ref → board group.
+        Events that cannot be assigned to any group are excluded from Home and
+        remain visible on Events.
       reader_scope: >
-        Read cursors are keyed by authenticated principal plus topic. Development
-        legacy actor mode may pass a reader id explicitly for local operation.
-      cursor: "Per-topic `(last_read_event_ts, last_read_event_id)`; id breaks equal-timestamp ties."
+        Read cursors are keyed by authenticated principal plus group_ref (a typed
+        ref string such as "topic:<id>" or "board:<id>"). Development legacy
+        actor mode may pass a reader id explicitly for local operation.
+      cursor: "Per-group `(last_read_event_ts, last_read_event_id)` keyed by group_ref; id breaks equal-timestamp ties."
       eligible_types:
         message_posted:
           family: message

--- a/contracts/gen/docs/commands.md
+++ b/contracts/gen/docs/commands.md
@@ -997,10 +997,10 @@ Generated from `contracts/anx-openapi.yaml`.
 - Stability: `beta`
 - Surface: `canonical`
 - Input mode: `json-body`
-- Why: Advance durable per-topic Home read cursors for the authenticated operator.
+- Why: Advance durable per-group Home read cursors for the authenticated operator.
 - Concepts: `home`, `events`, `write`
 - Error codes: `auth_required`, `invalid_request`, `invalid_token`
-- Output: Returns `{ ok, unread_count, topic_count }`.
+- Output: Returns `{ ok, unread_count, group_count }`.
 
 ## `home.unread`
 
@@ -1009,10 +1009,10 @@ Generated from `contracts/anx-openapi.yaml`.
 - Stability: `beta`
 - Surface: `canonical`
 - Input mode: `none`
-- Why: Load unread high-signal workspace activity grouped by topic for the authenticated operator.
+- Why: Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.
 - Concepts: `home`, `events`
 - Error codes: `auth_required`, `invalid_token`
-- Output: Returns `{ groups, unread_count, topic_count, generated_at }`.
+- Output: Returns `{ groups, unread_count, group_count, generated_at }`.
 
 ## `inbox.get`
 

--- a/contracts/gen/meta/commands.json
+++ b/contracts/gen/meta/commands.json
@@ -4464,12 +4464,12 @@
       "path": "/home/read",
       "operation_id": "markHomeRead",
       "summary": "Mark Home activity read",
-      "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+      "why": "Advance durable per-group Home read cursors for the authenticated operator.",
       "input_mode": "json-body",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+      "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
       "error_codes": [
         "auth_required",
         "invalid_request",
@@ -4497,20 +4497,20 @@
             "type": "datetime"
           },
           {
-            "name": "reader_id",
-            "type": "string"
-          },
-          {
-            "name": "topic_cursors",
+            "name": "group_cursors",
             "type": "object"
           },
           {
-            "name": "topic_id",
+            "name": "group_ref",
             "type": "string"
           },
           {
-            "name": "topic_ids",
+            "name": "group_refs",
             "type": "list\u003cstring\u003e"
+          },
+          {
+            "name": "reader_id",
+            "type": "string"
           }
         ]
       },
@@ -4524,12 +4524,12 @@
       "path": "/home/unread",
       "operation_id": "getHomeUnread",
       "summary": "Get Home unread activity",
-      "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+      "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+      "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
       "error_codes": [
         "auth_required",
         "invalid_token"

--- a/contracts/gen/meta/concepts.json
+++ b/contracts/gen/meta/concepts.json
@@ -6095,12 +6095,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -6128,20 +6128,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },
@@ -6155,12 +6155,12 @@
           "path": "/home/unread",
           "operation_id": "getHomeUnread",
           "summary": "Get Home unread activity",
-          "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+          "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+          "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
           "error_codes": [
             "auth_required",
             "invalid_token"
@@ -6334,12 +6334,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -6367,20 +6367,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },
@@ -6394,12 +6394,12 @@
           "path": "/home/unread",
           "operation_id": "getHomeUnread",
           "summary": "Get Home unread activity",
-          "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+          "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
           "input_mode": "none",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+          "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
           "error_codes": [
             "auth_required",
             "invalid_token"
@@ -11956,12 +11956,12 @@
           "path": "/home/read",
           "operation_id": "markHomeRead",
           "summary": "Mark Home activity read",
-          "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+          "why": "Advance durable per-group Home read cursors for the authenticated operator.",
           "input_mode": "json-body",
           "streaming": {
             "mode": "none"
           },
-          "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+          "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
           "error_codes": [
             "auth_required",
             "invalid_request",
@@ -11989,20 +11989,20 @@
                 "type": "datetime"
               },
               {
-                "name": "reader_id",
-                "type": "string"
-              },
-              {
-                "name": "topic_cursors",
+                "name": "group_cursors",
                 "type": "object"
               },
               {
-                "name": "topic_id",
+                "name": "group_ref",
                 "type": "string"
               },
               {
-                "name": "topic_ids",
+                "name": "group_refs",
                 "type": "list\u003cstring\u003e"
+              },
+              {
+                "name": "reader_id",
+                "type": "string"
               }
             ]
           },

--- a/contracts/gen/meta/help.json
+++ b/contracts/gen/meta/help.json
@@ -4695,12 +4695,12 @@
       "path": "/home/read",
       "operation_id": "markHomeRead",
       "summary": "Mark Home activity read",
-      "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+      "why": "Advance durable per-group Home read cursors for the authenticated operator.",
       "input_mode": "json-body",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+      "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
       "error_codes": [
         "auth_required",
         "invalid_request",
@@ -4728,20 +4728,20 @@
             "type": "datetime"
           },
           {
-            "name": "reader_id",
-            "type": "string"
-          },
-          {
-            "name": "topic_cursors",
+            "name": "group_cursors",
             "type": "object"
           },
           {
-            "name": "topic_id",
+            "name": "group_ref",
             "type": "string"
           },
           {
-            "name": "topic_ids",
+            "name": "group_refs",
             "type": "list\u003cstring\u003e"
+          },
+          {
+            "name": "reader_id",
+            "type": "string"
           }
         ]
       },
@@ -4755,12 +4755,12 @@
       "path": "/home/unread",
       "operation_id": "getHomeUnread",
       "summary": "Get Home unread activity",
-      "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+      "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
       "input_mode": "none",
       "streaming": {
         "mode": "none"
       },
-      "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+      "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
       "error_codes": [
         "auth_required",
         "invalid_token"

--- a/contracts/gen/ts/client.ts
+++ b/contracts/gen/ts/client.ts
@@ -4503,12 +4503,12 @@ export const commandRegistry: CommandSpec[] = [
     "path": "/home/read",
     "operation_id": "markHomeRead",
     "summary": "Mark Home activity read",
-    "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+    "why": "Advance durable per-group Home read cursors for the authenticated operator.",
     "input_mode": "json-body",
     "streaming": {
       "mode": "none"
     },
-    "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+    "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
     "error_codes": [
       "auth_required",
       "invalid_request",
@@ -4536,20 +4536,20 @@ export const commandRegistry: CommandSpec[] = [
           "type": "datetime"
         },
         {
-          "name": "reader_id",
-          "type": "string"
-        },
-        {
-          "name": "topic_cursors",
+          "name": "group_cursors",
           "type": "object"
         },
         {
-          "name": "topic_id",
+          "name": "group_ref",
           "type": "string"
         },
         {
-          "name": "topic_ids",
+          "name": "group_refs",
           "type": "list\u003cstring\u003e"
+        },
+        {
+          "name": "reader_id",
+          "type": "string"
         }
       ]
     },
@@ -4563,12 +4563,12 @@ export const commandRegistry: CommandSpec[] = [
     "path": "/home/unread",
     "operation_id": "getHomeUnread",
     "summary": "Get Home unread activity",
-    "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+    "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
     "input_mode": "none",
     "streaming": {
       "mode": "none"
     },
-    "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+    "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
     "error_codes": [
       "auth_required",
       "invalid_token"

--- a/contracts/gen/ts/dist/client.js
+++ b/contracts/gen/ts/dist/client.js
@@ -4458,12 +4458,12 @@ export const commandRegistry = [
         "path": "/home/read",
         "operation_id": "markHomeRead",
         "summary": "Mark Home activity read",
-        "why": "Advance durable per-topic Home read cursors for the authenticated operator.",
+        "why": "Advance durable per-group Home read cursors for the authenticated operator.",
         "input_mode": "json-body",
         "streaming": {
             "mode": "none"
         },
-        "output_envelope": "Returns `{ ok, unread_count, topic_count }`.",
+        "output_envelope": "Returns `{ ok, unread_count, group_count }`.",
         "error_codes": [
             "auth_required",
             "invalid_request",
@@ -4491,20 +4491,20 @@ export const commandRegistry = [
                     "type": "datetime"
                 },
                 {
-                    "name": "reader_id",
-                    "type": "string"
-                },
-                {
-                    "name": "topic_cursors",
+                    "name": "group_cursors",
                     "type": "object"
                 },
                 {
-                    "name": "topic_id",
+                    "name": "group_ref",
                     "type": "string"
                 },
                 {
-                    "name": "topic_ids",
+                    "name": "group_refs",
                     "type": "list\u003cstring\u003e"
+                },
+                {
+                    "name": "reader_id",
+                    "type": "string"
                 }
             ]
         },
@@ -4518,12 +4518,12 @@ export const commandRegistry = [
         "path": "/home/unread",
         "operation_id": "getHomeUnread",
         "summary": "Get Home unread activity",
-        "why": "Load unread high-signal workspace activity grouped by topic for the authenticated operator.",
+        "why": "Load unread high-signal workspace activity grouped by typed group (topic, board, etc.) for the authenticated operator.",
         "input_mode": "none",
         "streaming": {
             "mode": "none"
         },
-        "output_envelope": "Returns `{ groups, unread_count, topic_count, generated_at }`.",
+        "output_envelope": "Returns `{ groups, unread_count, group_count, generated_at }`.",
         "error_codes": [
             "auth_required",
             "invalid_token"

--- a/core/internal/primitives/store.go
+++ b/core/internal/primitives/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 
 	"agent-nexus-core/internal/blob"
+	"agent-nexus-core/internal/schema"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -99,7 +100,10 @@ type EventPage struct {
 }
 
 type HomeUnreadGroup struct {
-	Topic       map[string]any
+	GroupRef    string
+	GroupType   string
+	DisplayName string
+	Priority    string
 	UnreadCount int
 	NewestEvent map[string]any
 	Events      []map[string]any
@@ -2535,17 +2539,17 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 		return nil, 0, fmt.Errorf("reader_id is required")
 	}
 
-	topicByID, threadToTopicID, err := s.homeTopicLookup(ctx)
+	lookup, err := s.homeGroupLookup(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
-	cursorByTopic, err := s.homeReadCursors(ctx, readerID)
+	cursorByGroup, err := s.homeReadCursors(ctx, readerID)
 	if err != nil {
 		return nil, 0, err
 	}
-	sinceBoundOK, sinceTS, sinceExclusiveID := homeUnreadSinceLowerBound(topicByID, cursorByTopic)
+	sinceBoundOK, sinceTS, sinceExclusiveID := homeUnreadSinceLowerBound(lookup.groupByRef, cursorByGroup)
 
-	groupByTopic := map[string]*HomeUnreadGroup{}
+	groupByRef := map[string]*HomeUnreadGroup{}
 	for cursor := ""; ; {
 		f := EventListFilter{Preset: "home_feed", Limit: 200, Cursor: cursor}
 		if sinceBoundOK && cursor == "" {
@@ -2557,21 +2561,27 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 			return nil, 0, err
 		}
 		for _, event := range eventsPage.Events {
-			topicID := homeTopicIDForEvent(event, threadToTopicID)
-			if topicID == "" {
+			groupRef := homeGroupForEvent(event, lookup)
+			if groupRef == "" {
 				continue
 			}
-			if !homeEventAfterCursor(event, cursorByTopic[topicID]) {
+			if !homeEventAfterCursor(event, cursorByGroup[groupRef]) {
 				continue
 			}
-			topic := topicByID[topicID]
-			if topic == nil {
+			meta := lookup.groupByRef[groupRef]
+			if meta == nil {
 				continue
 			}
-			group := groupByTopic[topicID]
+			group := groupByRef[groupRef]
 			if group == nil {
-				group = &HomeUnreadGroup{Topic: topic, NewestEvent: event}
-				groupByTopic[topicID] = group
+				group = &HomeUnreadGroup{
+					GroupRef:    groupRef,
+					GroupType:   meta.groupType,
+					DisplayName: meta.displayName,
+					Priority:    meta.priority,
+					NewestEvent: event,
+				}
+				groupByRef[groupRef] = group
 			}
 			group.Events = append(group.Events, event)
 			group.UnreadCount++
@@ -2582,9 +2592,9 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 		cursor = eventsPage.NextCursor
 	}
 
-	groups := make([]HomeUnreadGroup, 0, len(groupByTopic))
+	groups := make([]HomeUnreadGroup, 0, len(groupByRef))
 	total := 0
-	for _, group := range groupByTopic {
+	for _, group := range groupByRef {
 		total += group.UnreadCount
 		groups = append(groups, *group)
 	}
@@ -2594,11 +2604,11 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 		leftTS := anyStringValue(left.NewestEvent["ts"])
 		rightTS := anyStringValue(right.NewestEvent["ts"])
 		if leftTS == rightTS {
-			return anyStringValue(left.Topic["id"]) < anyStringValue(right.Topic["id"])
+			return left.GroupRef < right.GroupRef
 		}
 		if homeNearTied(leftTS, rightTS) {
-			lp := homePriorityRank(anyStringValue(left.Topic["priority"]))
-			rp := homePriorityRank(anyStringValue(right.Topic["priority"]))
+			lp := homePriorityRank(left.Priority)
+			rp := homePriorityRank(right.Priority)
 			if lp != rp {
 				return lp < rp
 			}
@@ -2608,11 +2618,11 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 	return groups, total, nil
 }
 
-func (s *Store) MarkHomeRead(ctx context.Context, readerID string, topicIDs []string) error {
-	return s.MarkHomeReadAt(ctx, readerID, topicIDs, nil)
+func (s *Store) MarkHomeRead(ctx context.Context, readerID string, groupRefs []string) error {
+	return s.MarkHomeReadAt(ctx, readerID, groupRefs, nil)
 }
 
-func (s *Store) MarkHomeReadAt(ctx context.Context, readerID string, topicIDs []string, expected map[string]EventCursor) error {
+func (s *Store) MarkHomeReadAt(ctx context.Context, readerID string, groupRefs []string, expected map[string]EventCursor) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("primitives store database is not initialized")
 	}
@@ -2621,14 +2631,14 @@ func (s *Store) MarkHomeReadAt(ctx context.Context, readerID string, topicIDs []
 		return fmt.Errorf("reader_id is required")
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	for _, topicID := range dedupeStrings(topicIDs) {
-		topicID = strings.TrimSpace(topicID)
-		if topicID == "" {
+	for _, groupRef := range dedupeStrings(groupRefs) {
+		groupRef = strings.TrimSpace(groupRef)
+		if groupRef == "" {
 			continue
 		}
-		cursor := expected[topicID]
+		cursor := expected[groupRef]
 		if strings.TrimSpace(cursor.TS) == "" || strings.TrimSpace(cursor.ID) == "" {
-			event, err := s.newestHomeEventForTopic(ctx, topicID)
+			event, err := s.newestHomeEventForGroup(ctx, groupRef)
 			if err != nil {
 				return err
 			}
@@ -2637,27 +2647,44 @@ func (s *Store) MarkHomeReadAt(ctx context.Context, readerID string, topicIDs []
 			}
 			cursor = EventCursor{TS: anyStringValue(event["ts"]), ID: anyStringValue(event["id"])}
 		}
-		if _, err := s.db.ExecContext(ctx, `INSERT INTO home_topic_read_cursors(
-				reader_id, topic_id, last_read_event_ts, last_read_event_id, updated_at
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO home_read_cursors(
+				reader_id, group_ref, last_read_event_ts, last_read_event_id, updated_at
 			) VALUES (?, ?, ?, ?, ?)
-			ON CONFLICT(reader_id, topic_id) DO UPDATE SET
+			ON CONFLICT(reader_id, group_ref) DO UPDATE SET
 				last_read_event_ts = excluded.last_read_event_ts,
 				last_read_event_id = excluded.last_read_event_id,
 				updated_at = excluded.updated_at
-			WHERE excluded.last_read_event_ts > home_topic_read_cursors.last_read_event_ts
+			WHERE excluded.last_read_event_ts > home_read_cursors.last_read_event_ts
 				OR (
-					excluded.last_read_event_ts = home_topic_read_cursors.last_read_event_ts
-					AND excluded.last_read_event_id > home_topic_read_cursors.last_read_event_id
+					excluded.last_read_event_ts = home_read_cursors.last_read_event_ts
+					AND excluded.last_read_event_id > home_read_cursors.last_read_event_id
 				)`,
-			readerID, topicID, strings.TrimSpace(cursor.TS), strings.TrimSpace(cursor.ID), now); err != nil {
+			readerID, groupRef, strings.TrimSpace(cursor.TS), strings.TrimSpace(cursor.ID), now); err != nil {
 			return fmt.Errorf("upsert home read cursor: %w", err)
 		}
 	}
 	return nil
 }
 
-func (s *Store) newestHomeEventForTopic(ctx context.Context, topicID string) (map[string]any, error) {
-	events, err := s.ListEvents(ctx, EventListFilter{Preset: "home_feed", TopicID: topicID, Limit: 1})
+func (s *Store) newestHomeEventForGroup(ctx context.Context, groupRef string) (map[string]any, error) {
+	f := EventListFilter{Preset: "home_feed", Limit: 1}
+	prefix, id, _ := schema.SplitTypedRef(groupRef)
+	switch prefix {
+	case "topic":
+		f.TopicID = id
+	case "thread":
+		f.ThreadID = id
+	default:
+		events, err := s.ListEvents(ctx, f)
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			return nil, nil
+		}
+		return events[0], nil
+	}
+	events, err := s.ListEvents(ctx, f)
 	if err != nil {
 		return nil, err
 	}
@@ -2673,77 +2700,148 @@ type homeReadCursor struct {
 }
 
 func (s *Store) homeReadCursors(ctx context.Context, readerID string) (map[string]homeReadCursor, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT topic_id, last_read_event_ts, last_read_event_id FROM home_topic_read_cursors WHERE reader_id = ?`, readerID)
+	rows, err := s.db.QueryContext(ctx, `SELECT group_ref, last_read_event_ts, last_read_event_id FROM home_read_cursors WHERE reader_id = ?`, readerID)
 	if err != nil {
 		return nil, fmt.Errorf("query home read cursors: %w", err)
 	}
 	defer rows.Close()
 	out := map[string]homeReadCursor{}
 	for rows.Next() {
-		var topicID, ts, id string
-		if err := rows.Scan(&topicID, &ts, &id); err != nil {
+		var groupRef, ts, id string
+		if err := rows.Scan(&groupRef, &ts, &id); err != nil {
 			return nil, fmt.Errorf("scan home read cursor: %w", err)
 		}
-		out[topicID] = homeReadCursor{TS: ts, ID: id}
+		out[groupRef] = homeReadCursor{TS: ts, ID: id}
 	}
 	return out, rows.Err()
 }
 
-func (s *Store) homeTopicLookup(ctx context.Context) (map[string]map[string]any, map[string]string, error) {
+type homeGroupMeta struct {
+	groupRef    string
+	groupType   string
+	displayName string
+	priority    string
+}
+
+type homeGroupLookup struct {
+	groupByRef       map[string]*homeGroupMeta
+	threadToGroupRef map[string]string
+	boardToGroupRef  map[string]string
+}
+
+func (s *Store) homeGroupLookup(ctx context.Context) (*homeGroupLookup, error) {
+	lookup := &homeGroupLookup{
+		groupByRef:       map[string]*homeGroupMeta{},
+		threadToGroupRef: map[string]string{},
+		boardToGroupRef:  map[string]string{},
+	}
+
+	if err := s.loadTopicGroups(ctx, lookup); err != nil {
+		return nil, err
+	}
+	if err := s.loadBoardGroups(ctx, lookup); err != nil {
+		return nil, err
+	}
+	return lookup, nil
+}
+
+func (s *Store) loadTopicGroups(ctx context.Context, lookup *homeGroupLookup) error {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, title, summary, thread_id, updated_at, extensions_json, archived_at, trashed_at FROM topics WHERE COALESCE(trashed_at, '') = ''`)
 	if err != nil {
-		return nil, nil, fmt.Errorf("query home topics: %w", err)
+		return fmt.Errorf("query home topics: %w", err)
 	}
 	defer rows.Close()
-	topicByID := map[string]map[string]any{}
-	threadToTopicID := map[string]string{}
 	for rows.Next() {
 		var id, updatedAt, extensionsJSON string
-		var title, summary, threadID, archivedAt, trashedAt sql.NullString
-		if err := rows.Scan(&id, &title, &summary, &threadID, &updatedAt, &extensionsJSON, &archivedAt, &trashedAt); err != nil {
-			return nil, nil, fmt.Errorf("scan home topic: %w", err)
+		var title, summary, threadID sql.NullString
+		var discardArchivedAt, discardTrashedAt sql.NullString
+		if err := rows.Scan(&id, &title, &summary, &threadID, &updatedAt, &extensionsJSON, &discardArchivedAt, &discardTrashedAt); err != nil {
+			return fmt.Errorf("scan home topic: %w", err)
 		}
 		var extensions map[string]any
 		_ = json.Unmarshal([]byte(extensionsJSON), &extensions)
 		if extensions == nil {
 			extensions = map[string]any{}
 		}
-		state := LifecycleStateFromTimestampStrings(nullStringValue(archivedAt), nullStringValue(trashedAt))
-		topic := map[string]any{
-			"id":         id,
-			"title":      firstNonEmptyString(title.String, id),
-			"summary":    summary.String,
-			"state":      state,
-			"status":     state,
-			"lifecycle":  state,
-			"priority":   firstNonEmptyString(anyStringValue(extensions["priority"]), anyStringValue(extensions["filter_priority"])),
-			"updated_at": updatedAt,
+		priority := firstNonEmptyString(anyStringValue(extensions["priority"]), anyStringValue(extensions["filter_priority"]))
+		groupRef := "topic:" + id
+		meta := &homeGroupMeta{
+			groupRef:    groupRef,
+			groupType:   "topic",
+			displayName: firstNonEmptyString(title.String, id),
+			priority:    priority,
 		}
+		lookup.groupByRef[groupRef] = meta
 		if threadID.Valid && strings.TrimSpace(threadID.String) != "" {
-			topic["thread_id"] = threadID.String
-			threadToTopicID[threadID.String] = id
+			lookup.threadToGroupRef[threadID.String] = groupRef
 		}
-		topicByID[id] = topic
 	}
 	if err := rows.Err(); err != nil {
-		return nil, nil, fmt.Errorf("iterate home topics: %w", err)
+		return fmt.Errorf("iterate home topics: %w", err)
 	}
-	return topicByID, threadToTopicID, nil
+	return nil
 }
 
-func homeTopicIDForEvent(event map[string]any, threadToTopicID map[string]string) string {
+func (s *Store) loadBoardGroups(ctx context.Context, lookup *homeGroupLookup) error {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, title, thread_id FROM boards WHERE COALESCE(trashed_at, '') = ''`)
+	if err != nil {
+		return fmt.Errorf("query home boards: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, title, threadID string
+		if err := rows.Scan(&id, &title, &threadID); err != nil {
+			return fmt.Errorf("scan home board: %w", err)
+		}
+		groupRef := "board:" + id
+		meta := &homeGroupMeta{
+			groupRef:    groupRef,
+			groupType:   "board",
+			displayName: firstNonEmptyString(strings.TrimSpace(title), id),
+			priority:    "",
+		}
+		lookup.groupByRef[groupRef] = meta
+		threadID = strings.TrimSpace(threadID)
+		if threadID != "" {
+			lookup.boardToGroupRef[id] = groupRef
+			if _, exists := lookup.threadToGroupRef[threadID]; !exists {
+				lookup.threadToGroupRef[threadID] = groupRef
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate home boards: %w", err)
+	}
+	return nil
+}
+
+func homeGroupForEvent(event map[string]any, lookup *homeGroupLookup) string {
 	for _, ref := range anyStringSlice(event["refs"]) {
 		if strings.HasPrefix(ref, "topic:") {
-			return strings.TrimSpace(strings.TrimPrefix(ref, "topic:"))
+			topicRef := "topic:" + strings.TrimSpace(strings.TrimPrefix(ref, "topic:"))
+			if _, ok := lookup.groupByRef[topicRef]; ok {
+				return topicRef
+			}
 		}
 	}
 	if threadID := strings.TrimSpace(anyStringValue(event["thread_id"])); threadID != "" {
-		return threadToTopicID[threadID]
+		if groupRef, ok := lookup.threadToGroupRef[threadID]; ok {
+			return groupRef
+		}
 	}
 	for _, ref := range anyStringSlice(event["refs"]) {
 		if strings.HasPrefix(ref, "thread:") {
-			if topicID := threadToTopicID[strings.TrimSpace(strings.TrimPrefix(ref, "thread:"))]; topicID != "" {
-				return topicID
+			threadID := strings.TrimSpace(strings.TrimPrefix(ref, "thread:"))
+			if groupRef, ok := lookup.threadToGroupRef[threadID]; ok {
+				return groupRef
+			}
+		}
+	}
+	for _, ref := range anyStringSlice(event["refs"]) {
+		if strings.HasPrefix(ref, "board:") {
+			boardRef := "board:" + strings.TrimSpace(strings.TrimPrefix(ref, "board:"))
+			if _, ok := lookup.groupByRef[boardRef]; ok {
+				return boardRef
 			}
 		}
 	}
@@ -2761,12 +2859,12 @@ func homeEventAfterCursor(event map[string]any, cursor homeReadCursor) bool {
 
 // homeUnreadSinceLowerBound returns a global lower bound on events that can still be home-unread
 // when every topic has a read cursor: strictly after the lexicographically smallest (ts, id) cursor.
-func homeUnreadSinceLowerBound(topicByID map[string]map[string]any, cursorByTopic map[string]homeReadCursor) (ok bool, ts string, exclusiveID string) {
-	if len(topicByID) == 0 {
+func homeUnreadSinceLowerBound(groupByRef map[string]*homeGroupMeta, cursorByGroup map[string]homeReadCursor) (ok bool, ts string, exclusiveID string) {
+	if len(groupByRef) == 0 {
 		return false, "", ""
 	}
-	for topicID := range topicByID {
-		c := cursorByTopic[topicID]
+	for groupRef := range groupByRef {
+		c := cursorByGroup[groupRef]
 		if strings.TrimSpace(c.TS) == "" || strings.TrimSpace(c.ID) == "" {
 			return false, "", ""
 		}

--- a/core/internal/primitives/store.go
+++ b/core/internal/primitives/store.go
@@ -2549,6 +2549,12 @@ func (s *Store) ListHomeUnread(ctx context.Context, readerID string) ([]HomeUnre
 	}
 	sinceBoundOK, sinceTS, sinceExclusiveID := homeUnreadSinceLowerBound(lookup.groupByRef, cursorByGroup)
 
+	// NOTE: homeUnreadSinceLowerBound returns false when any group lacks a cursor.
+	// This is correct — groups without cursors need all their events scanned (all are
+	// unread), so no since-bound pruning is safe until every active group has been
+	// marked read at least once. The optimization activates after the first "Mark all
+	// read" for the current set of active groups.
+
 	groupByRef := map[string]*HomeUnreadGroup{}
 	for cursor := ""; ; {
 		f := EventListFilter{Preset: "home_feed", Limit: 200, Cursor: cursor}
@@ -2667,15 +2673,10 @@ func (s *Store) MarkHomeReadAt(ctx context.Context, readerID string, groupRefs [
 }
 
 func (s *Store) newestHomeEventForGroup(ctx context.Context, groupRef string) (map[string]any, error) {
-	f := EventListFilter{Preset: "home_feed", Limit: 1}
 	prefix, id, _ := schema.SplitTypedRef(groupRef)
 	switch prefix {
 	case "topic":
-		f.TopicID = id
-	case "thread":
-		f.ThreadID = id
-	default:
-		events, err := s.ListEvents(ctx, f)
+		events, err := s.ListEvents(ctx, EventListFilter{Preset: "home_feed", TopicID: id, Limit: 1})
 		if err != nil {
 			return nil, err
 		}
@@ -2683,15 +2684,76 @@ func (s *Store) newestHomeEventForGroup(ctx context.Context, groupRef string) (m
 			return nil, nil
 		}
 		return events[0], nil
+	case "thread":
+		events, err := s.ListEvents(ctx, EventListFilter{Preset: "home_feed", ThreadID: id, Limit: 1})
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			return nil, nil
+		}
+		return events[0], nil
+	default:
+		return s.newestHomeEventForRef(ctx, groupRef)
 	}
-	events, err := s.ListEvents(ctx, f)
+}
+
+func (s *Store) newestHomeEventForRef(ctx context.Context, ref string) (map[string]any, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, type, ts, actor_id, thread_id, refs_json, payload_json,
+			archived_at, archived_by, trashed_at, trashed_by, trash_reason
+		FROM events
+		WHERE COALESCE(trashed_at, '') = ''
+			AND type IN (`+homeFeedTypePlaceholders()+`)
+			AND EXISTS (SELECT 1 FROM json_each(events.refs_json) WHERE json_each.value = ?)
+		ORDER BY ts DESC, id DESC LIMIT 1`,
+		appendHomeFeedTypeArgs([]any{ref})...)
+	if err != nil {
+		return nil, fmt.Errorf("query newest home event for ref %s: %w", ref, err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+	var (
+		eventID     string
+		typeValue   string
+		ts          string
+		actorID     string
+		thread      sql.NullString
+		refsJSON    string
+		payloadJSON string
+		archivedAt  sql.NullString
+		archivedBy  sql.NullString
+		trashedAt   sql.NullString
+		trashedBy   sql.NullString
+		trashReason sql.NullString
+	)
+	if err := rows.Scan(&eventID, &typeValue, &ts, &actorID, &thread, &refsJSON, &payloadJSON,
+		&archivedAt, &archivedBy, &trashedAt, &trashedBy, &trashReason); err != nil {
+		return nil, fmt.Errorf("scan newest home event for ref %s: %w", ref, err)
+	}
+	body, err := decodeEventBodyFromRow(eventID, typeValue, ts, actorID, thread, refsJSON, payloadJSON)
 	if err != nil {
 		return nil, err
 	}
-	if len(events) == 0 {
-		return nil, nil
+	overlayEventLifecycleFromSQLColumns(body, archivedAt, archivedBy, trashedAt, trashedBy, trashReason)
+	return body, rows.Err()
+}
+
+func homeFeedTypePlaceholders() string {
+	placeholders := make([]string, len(HomeFeedEventTypes))
+	for i := range HomeFeedEventTypes {
+		placeholders[i] = "?"
 	}
-	return events[0], nil
+	return strings.Join(placeholders, ",")
+}
+
+func appendHomeFeedTypeArgs(args []any) []any {
+	for _, t := range HomeFeedEventTypes {
+		args = append(args, t)
+	}
+	return args
 }
 
 type homeReadCursor struct {
@@ -2726,14 +2788,12 @@ type homeGroupMeta struct {
 type homeGroupLookup struct {
 	groupByRef       map[string]*homeGroupMeta
 	threadToGroupRef map[string]string
-	boardToGroupRef  map[string]string
 }
 
 func (s *Store) homeGroupLookup(ctx context.Context) (*homeGroupLookup, error) {
 	lookup := &homeGroupLookup{
 		groupByRef:       map[string]*homeGroupMeta{},
 		threadToGroupRef: map[string]string{},
-		boardToGroupRef:  map[string]string{},
 	}
 
 	if err := s.loadTopicGroups(ctx, lookup); err != nil {
@@ -2803,7 +2863,6 @@ func (s *Store) loadBoardGroups(ctx context.Context, lookup *homeGroupLookup) er
 		lookup.groupByRef[groupRef] = meta
 		threadID = strings.TrimSpace(threadID)
 		if threadID != "" {
-			lookup.boardToGroupRef[id] = groupRef
 			if _, exists := lookup.threadToGroupRef[threadID]; !exists {
 				lookup.threadToGroupRef[threadID] = groupRef
 			}

--- a/core/internal/server/handler.go
+++ b/core/internal/server/handler.go
@@ -130,8 +130,8 @@ type PrimitiveStore interface {
 	ListEvents(ctx context.Context, filter primitives.EventListFilter) ([]map[string]any, error)
 	ListEventsPage(ctx context.Context, filter primitives.EventListFilter) (primitives.EventPage, error)
 	ListHomeUnread(ctx context.Context, readerID string) ([]primitives.HomeUnreadGroup, int, error)
-	MarkHomeRead(ctx context.Context, readerID string, topicIDs []string) error
-	MarkHomeReadAt(ctx context.Context, readerID string, topicIDs []string, expected map[string]primitives.EventCursor) error
+	MarkHomeRead(ctx context.Context, readerID string, groupRefs []string) error
+	MarkHomeReadAt(ctx context.Context, readerID string, groupRefs []string, expected map[string]primitives.EventCursor) error
 	ListHumanAttentionRespondedPage(ctx context.Context, params primitives.HumanAttentionRespondedPageParams) ([]map[string]any, error)
 	TrashArtifact(ctx context.Context, actorID string, artifactID string, reason string) (map[string]any, error)
 	ArchiveArtifact(ctx context.Context, actorID string, artifactID string) (map[string]any, error)

--- a/core/internal/server/home_handlers.go
+++ b/core/internal/server/home_handlers.go
@@ -27,7 +27,10 @@ func handleGetHomeUnread(w http.ResponseWriter, r *http.Request, opts handlerOpt
 	payloadGroups := make([]map[string]any, 0, len(groups))
 	for _, group := range groups {
 		payloadGroups = append(payloadGroups, map[string]any{
-			"topic":        group.Topic,
+			"group_ref":    group.GroupRef,
+			"group_type":   group.GroupType,
+			"display_name": group.DisplayName,
+			"priority":     group.Priority,
 			"unread_count": group.UnreadCount,
 			"newest_event": group.NewestEvent,
 			"events":       group.Events,
@@ -36,7 +39,7 @@ func handleGetHomeUnread(w http.ResponseWriter, r *http.Request, opts handlerOpt
 	writeJSON(w, http.StatusOK, map[string]any{
 		"groups":       payloadGroups,
 		"unread_count": unreadCount,
-		"topic_count":  len(payloadGroups),
+		"group_count":  len(payloadGroups),
 		"generated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	})
 }
@@ -49,16 +52,16 @@ func handleMarkHomeRead(w http.ResponseWriter, r *http.Request, opts handlerOpti
 	var req struct {
 		ReaderID                  string   `json:"reader_id"`
 		ActorID                   string   `json:"actor_id"`
-		TopicID                   string   `json:"topic_id"`
-		TopicIDs                  []string `json:"topic_ids"`
+		GroupRef                  string   `json:"group_ref"`
+		GroupRefs                 []string `json:"group_refs"`
 		ExpectedNewestEventCursor struct {
 			TS string `json:"ts"`
 			ID string `json:"id"`
 		} `json:"expected_newest_event_cursor"`
-		TopicCursors map[string]struct {
+		GroupCursors map[string]struct {
 			TS string `json:"ts"`
 			ID string `json:"id"`
-		} `json:"topic_cursors"`
+		} `json:"group_cursors"`
 	}
 	if !decodeJSONBody(w, r, &req) {
 		return
@@ -67,31 +70,31 @@ func handleMarkHomeRead(w http.ResponseWriter, r *http.Request, opts handlerOpti
 	if !ok {
 		return
 	}
-	topicIDs := append([]string{}, req.TopicIDs...)
-	if strings.TrimSpace(req.TopicID) != "" {
-		topicIDs = append(topicIDs, strings.TrimSpace(req.TopicID))
+	groupRefs := append([]string{}, req.GroupRefs...)
+	if strings.TrimSpace(req.GroupRef) != "" {
+		groupRefs = append(groupRefs, strings.TrimSpace(req.GroupRef))
 	}
-	if len(topicIDs) == 0 {
-		writeError(w, http.StatusBadRequest, "invalid_request", "topic_id or topic_ids is required")
+	if len(groupRefs) == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "group_ref or group_refs is required")
 		return
 	}
 	expected := map[string]primitives.EventCursor{}
-	if strings.TrimSpace(req.TopicID) != "" &&
+	if strings.TrimSpace(req.GroupRef) != "" &&
 		strings.TrimSpace(req.ExpectedNewestEventCursor.TS) != "" &&
 		strings.TrimSpace(req.ExpectedNewestEventCursor.ID) != "" {
-		expected[strings.TrimSpace(req.TopicID)] = primitives.EventCursor{
+		expected[strings.TrimSpace(req.GroupRef)] = primitives.EventCursor{
 			TS: strings.TrimSpace(req.ExpectedNewestEventCursor.TS),
 			ID: strings.TrimSpace(req.ExpectedNewestEventCursor.ID),
 		}
 	}
-	for topicID, cursor := range req.TopicCursors {
-		topicID = strings.TrimSpace(topicID)
-		if topicID == "" || strings.TrimSpace(cursor.TS) == "" || strings.TrimSpace(cursor.ID) == "" {
+	for groupRef, cursor := range req.GroupCursors {
+		groupRef = strings.TrimSpace(groupRef)
+		if groupRef == "" || strings.TrimSpace(cursor.TS) == "" || strings.TrimSpace(cursor.ID) == "" {
 			continue
 		}
-		expected[topicID] = primitives.EventCursor{TS: strings.TrimSpace(cursor.TS), ID: strings.TrimSpace(cursor.ID)}
+		expected[groupRef] = primitives.EventCursor{TS: strings.TrimSpace(cursor.TS), ID: strings.TrimSpace(cursor.ID)}
 	}
-	if err := opts.primitiveStore.MarkHomeReadAt(r.Context(), readerID, topicIDs, expected); err != nil {
+	if err := opts.primitiveStore.MarkHomeReadAt(r.Context(), readerID, groupRefs, expected); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "failed to mark home activity read")
 		return
 	}
@@ -103,7 +106,7 @@ func handleMarkHomeRead(w http.ResponseWriter, r *http.Request, opts handlerOpti
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":           true,
 		"unread_count": unreadCount,
-		"topic_count":  len(groups),
+		"group_count":  len(groups),
 	})
 }
 

--- a/core/internal/server/home_integration_test.go
+++ b/core/internal/server/home_integration_test.go
@@ -75,13 +75,19 @@ func TestHomeUnreadGroupsEligibleEventsAndMarksRead(t *testing.T) {
 	var unread struct {
 		Groups      []map[string]any `json:"groups"`
 		UnreadCount int              `json:"unread_count"`
-		TopicCount  int              `json:"topic_count"`
+		GroupCount  int              `json:"group_count"`
 	}
 	if err := json.NewDecoder(unreadResp.Body).Decode(&unread); err != nil {
 		t.Fatalf("decode unread: %v", err)
 	}
-	if unread.UnreadCount != 1 || unread.TopicCount != 1 || len(unread.Groups) != 1 {
+	if unread.UnreadCount != 1 || unread.GroupCount != 1 || len(unread.Groups) != 1 {
 		t.Fatalf("expected one unread Home event, got %#v", unread)
+	}
+	if unread.Groups[0]["group_ref"] != "topic:"+topicID {
+		t.Fatalf("expected group_ref topic:%s, got %v", topicID, unread.Groups[0]["group_ref"])
+	}
+	if unread.Groups[0]["group_type"] != "topic" {
+		t.Fatalf("expected group_type topic, got %v", unread.Groups[0]["group_type"])
 	}
 	newest, _ := unread.Groups[0]["newest_event"].(map[string]any)
 
@@ -99,7 +105,7 @@ func TestHomeUnreadGroupsEligibleEventsAndMarksRead(t *testing.T) {
 
 	postJSONExpectStatus(t, h.baseURL+"/home/read", `{
 		"reader_id":"reader-home",
-		"topic_id":"`+topicID+`",
+		"group_ref":"topic:`+topicID+`",
 		"expected_newest_event_cursor":{"ts":"`+asString(newest["ts"])+`","id":"`+asString(newest["id"])+`"}
 	}`, http.StatusOK).Body.Close()
 
@@ -110,16 +116,16 @@ func TestHomeUnreadGroupsEligibleEventsAndMarksRead(t *testing.T) {
 	defer emptyResp.Body.Close()
 	var afterRace struct {
 		UnreadCount int `json:"unread_count"`
-		TopicCount  int `json:"topic_count"`
+		GroupCount  int `json:"group_count"`
 	}
 	if err := json.NewDecoder(emptyResp.Body).Decode(&afterRace); err != nil {
 		t.Fatalf("decode empty unread: %v", err)
 	}
-	if afterRace.UnreadCount != 1 || afterRace.TopicCount != 1 {
+	if afterRace.UnreadCount != 1 || afterRace.GroupCount != 1 {
 		t.Fatalf("expected post-render event to remain unread after cursor mark read, got %#v", afterRace)
 	}
 
-	postJSONExpectStatus(t, h.baseURL+"/home/read", `{"reader_id":"reader-home","topic_id":"`+topicID+`"}`, http.StatusOK).Body.Close()
+	postJSONExpectStatus(t, h.baseURL+"/home/read", `{"reader_id":"reader-home","group_ref":"topic:`+topicID+`"}`, http.StatusOK).Body.Close()
 }
 
 func TestEventsHomeFeedPresetMatchesHomeEligibility(t *testing.T) {

--- a/core/internal/storage/migrations.go
+++ b/core/internal/storage/migrations.go
@@ -741,6 +741,21 @@ var migrations = []migration{
 			`CREATE INDEX IF NOT EXISTS idx_agent_wakeups_thread_trigger_created ON agent_wakeups (thread_id, created_at ASC, wakeup_id ASC);`,
 		},
 	},
+	{
+		Version: 24,
+		Statements: []string{
+			`CREATE TABLE IF NOT EXISTS home_read_cursors (
+				reader_id TEXT NOT NULL,
+				group_ref TEXT NOT NULL,
+				last_read_event_ts TEXT NOT NULL,
+				last_read_event_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (reader_id, group_ref)
+			);`,
+			`CREATE INDEX IF NOT EXISTS idx_home_read_cursors_reader ON home_read_cursors (reader_id, group_ref);`,
+		},
+		AfterApply: applyMigration24HomeGroupCursors,
+	},
 }
 
 func applyMigration22TrashCanceledResolutionCards(ctx context.Context, tx *sql.Tx) error {
@@ -766,6 +781,28 @@ WHERE (LOWER(COALESCE(resolution, '')) IN ('canceled', 'cancelled'))
 		now)
 	if err != nil {
 		return fmt.Errorf("migration 22 trash canceled resolution cards: %w", err)
+	}
+	return nil
+}
+
+func applyMigration24HomeGroupCursors(ctx context.Context, tx *sql.Tx) error {
+	ok, err := sqliteTableExists(ctx, tx, "home_topic_read_cursors")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO home_read_cursors (reader_id, group_ref, last_read_event_ts, last_read_event_id, updated_at)
+		SELECT reader_id, 'topic:' || topic_id, last_read_event_ts, last_read_event_id, updated_at
+		FROM home_topic_read_cursors`)
+	if err != nil {
+		return fmt.Errorf("migration 24 migrate topic cursors: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `DROP TABLE IF EXISTS home_topic_read_cursors`)
+	if err != nil {
+		return fmt.Errorf("migration 24 drop old table: %w", err)
 	}
 	return nil
 }

--- a/web-ui/scripts/qa-visual.mjs
+++ b/web-ui/scripts/qa-visual.mjs
@@ -614,16 +614,56 @@ function createWorkspaceScenario(mode) {
   }
 }
 
-function topicForEvent(event) {
+function homeGroupForEvent(event) {
   const refs = Array.isArray(event?.refs) ? event.refs : [];
   const topicRef = refs.find((ref) => String(ref).startsWith("topic:"));
   if (topicRef) {
     const topicId = topicRef.slice("topic:".length);
-    return QA_TOPICS.find((topic) => topic.id === topicId) ?? null;
+    const topic = QA_TOPICS.find((t) => t.id === topicId);
+    if (topic) {
+      return {
+        group_ref: `topic:${topicId}`,
+        group_type: "topic",
+        display_name: topic.title || topicId,
+        priority: topic.priority || "",
+      };
+    }
   }
   const threadId = String(event?.thread_id ?? "").trim();
-  if (!threadId) return null;
-  return QA_TOPICS.find((topic) => topic.thread_id === threadId) ?? null;
+  if (threadId) {
+    const topic = QA_TOPICS.find((t) => t.thread_id === threadId);
+    if (topic) {
+      return {
+        group_ref: `topic:${topic.id}`,
+        group_type: "topic",
+        display_name: topic.title || topic.id,
+        priority: topic.priority || "",
+      };
+    }
+    const board = QA_BOARDS.find((b) => b.thread_id === threadId);
+    if (board) {
+      return {
+        group_ref: `board:${board.id}`,
+        group_type: "board",
+        display_name: board.title || board.id,
+        priority: "",
+      };
+    }
+  }
+  const boardRef = refs.find((ref) => String(ref).startsWith("board:"));
+  if (boardRef) {
+    const boardId = boardRef.slice("board:".length);
+    const board = QA_BOARDS.find((b) => b.id === boardId);
+    if (board) {
+      return {
+        group_ref: `board:${boardId}`,
+        group_type: "board",
+        display_name: board.title || boardId,
+        priority: "",
+      };
+    }
+  }
+  return null;
 }
 
 function qaHomeUnreadResponse(homeState) {
@@ -637,14 +677,14 @@ function qaHomeUnreadResponse(homeState) {
       : QA_EVENTS.filter((event) => {
           if (!QA_HOME_FEED_TYPES.has(String(event.type))) return false;
           if (Date.parse(event.ts) < minTimestamp) return false;
-          return Boolean(topicForEvent(event));
+          return Boolean(homeGroupForEvent(event));
         });
   const groupMap = new Map();
   for (const event of events) {
-    const topic = topicForEvent(event);
-    if (!topic) continue;
-    const group = groupMap.get(topic.id) ?? {
-      topic,
+    const groupMeta = homeGroupForEvent(event);
+    if (!groupMeta) continue;
+    const group = groupMap.get(groupMeta.group_ref) ?? {
+      ...groupMeta,
       events: [],
       unread_count: 0,
       newest_event: null,
@@ -658,22 +698,27 @@ function qaHomeUnreadResponse(homeState) {
     ) {
       group.newest_event = event;
     }
-    groupMap.set(topic.id, group);
+    groupMap.set(groupMeta.group_ref, group);
   }
   const groups = Array.from(groupMap.values())
     .map((group) => ({
-      ...group,
+      group_ref: group.group_ref,
+      group_type: group.group_type,
+      display_name: group.display_name,
+      priority: group.priority,
       events: group.events.sort((left, right) => {
         const tsDelta = Date.parse(right.ts) - Date.parse(left.ts);
         return tsDelta || String(right.id).localeCompare(String(left.id));
       }),
+      unread_count: group.unread_count,
+      newest_event: group.newest_event,
     }))
     .sort((left, right) => {
       const tsDelta =
         Date.parse(right.newest_event?.ts ?? "") -
         Date.parse(left.newest_event?.ts ?? "");
       return (
-        tsDelta || String(left.topic.id).localeCompare(String(right.topic.id))
+        tsDelta || String(left.group_ref).localeCompare(String(right.group_ref))
       );
     });
   return {
@@ -682,7 +727,7 @@ function qaHomeUnreadResponse(homeState) {
       (count, group) => count + group.unread_count,
       0,
     ),
-    topic_count: groups.length,
+    group_count: groups.length,
     generated_at: QA_FIXED_NOW_ISO,
   };
 }
@@ -1181,7 +1226,7 @@ async function handleWorkspaceApiRoute(
     await route.fulfill(
       jsonResponse(200, {
         ok: true,
-        marked_topic_ids: [],
+        group_count: 0,
         generated_at: QA_FIXED_NOW_ISO,
       }),
     );

--- a/web-ui/src/lib/anxCoreClient.js
+++ b/web-ui/src/lib/anxCoreClient.js
@@ -892,9 +892,30 @@ export function createAnxCoreClient(options = {}) {
         generated.homeUnread({ query: readerQuery() }),
       ),
     markHomeRead: (payload) =>
-      invokeJSON("home.read", () =>
-        generated.homeRead({ body: withActorId(payload) }),
-      ),
+      invokeJSON("home.read", () => {
+        const body = { ...payload };
+        if (body.topic_id) {
+          body.group_ref = body.group_ref ?? `topic:${body.topic_id}`;
+          delete body.topic_id;
+        }
+        if (body.topic_ids) {
+          body.group_refs =
+            body.group_refs ?? body.topic_ids.map((id) => `topic:${id}`);
+          delete body.topic_ids;
+        }
+        if (body.topic_cursors) {
+          body.group_cursors =
+            body.group_cursors ??
+            Object.fromEntries(
+              Object.entries(body.topic_cursors).map(([id, cursor]) => [
+                `topic:${id}`,
+                cursor,
+              ]),
+            );
+          delete body.topic_cursors;
+        }
+        return generated.homeRead({ body: withActorId(body) });
+      }),
     getEvent: (eventId) =>
       invokeJSON("events.get", () =>
         generated.eventsGet({ event_id: String(eventId) }),

--- a/web-ui/src/routes/o/[organization]/w/[workspace]/+page.svelte
+++ b/web-ui/src/routes/o/[organization]/w/[workspace]/+page.svelte
@@ -22,10 +22,10 @@
   let feed = $state({
     groups: [],
     unread_count: 0,
-    topic_count: 0,
+    group_count: 0,
     generated_at: "",
   });
-  let markingTopicId = $state("");
+  let markingGroupRef = $state("");
   let pollTimer;
 
   let organizationSlug = $derived($page.params.organization);
@@ -36,12 +36,31 @@
     bindWorkspaceHref(organizationSlug, workspaceSlug),
   );
 
-  function priorityLabel(topic) {
-    return String(topic?.priority ?? "").trim() || "P2";
+  function priorityLabel(group) {
+    return String(group?.priority ?? "").trim() || "P2";
   }
 
-  function topicTitle(topic) {
-    return String(topic?.title ?? topic?.id ?? "Untitled topic").trim();
+  function groupLabel(group) {
+    const name = String(group?.display_name ?? "").trim();
+    if (!name) return group?.group_ref ?? "Untitled";
+    const type = group?.group_type ?? "";
+    if (type === "topic") return name;
+    if (type === "board") return name + " (board)";
+    return name;
+  }
+
+  function groupHref(group) {
+    const type = group?.group_type ?? "";
+    const ref = group?.group_ref ?? "";
+    if (type === "topic") {
+      const id = ref.replace(/^topic:/, "");
+      return workspaceHref(`/topics/${encodeURIComponent(id)}`);
+    }
+    if (type === "board") {
+      const id = ref.replace(/^board:/, "");
+      return workspaceHref(`/boards/${encodeURIComponent(id)}`);
+    }
+    return workspaceHref("/events");
   }
 
   function rowFor(event) {
@@ -71,16 +90,18 @@
     }
   }
 
-  async function markTopicRead(topicId) {
-    const id = String(topicId ?? "").trim();
-    if (!id) return;
-    const group = groups.find((entry) => String(entry?.topic?.id ?? "") === id);
+  async function markGroupRead(groupRef) {
+    const ref = String(groupRef ?? "").trim();
+    if (!ref) return;
+    const group = groups.find(
+      (entry) => String(entry?.group_ref ?? "") === ref,
+    );
     const newest = group?.newest_event;
-    markingTopicId = id;
+    markingGroupRef = ref;
     error = "";
     try {
       await coreClient.markHomeRead({
-        topic_id: id,
+        group_ref: ref,
         expected_newest_event_cursor: {
           ts: newest?.ts,
           id: newest?.id,
@@ -91,32 +112,32 @@
       error =
         err instanceof Error
           ? err.message
-          : String(err ?? "Failed to mark topic read.");
+          : String(err ?? "Failed to mark read.");
     } finally {
-      markingTopicId = "";
+      markingGroupRef = "";
     }
   }
 
   async function markAllRead() {
-    const topic_ids = groups
-      .map((group) => String(group?.topic?.id ?? "").trim())
+    const group_refs = groups
+      .map((group) => String(group?.group_ref ?? "").trim())
       .filter(Boolean);
-    if (topic_ids.length === 0) return;
-    markingTopicId = "*";
+    if (group_refs.length === 0) return;
+    markingGroupRef = "*";
     error = "";
     try {
       await coreClient.markHomeRead({
-        topic_ids,
-        topic_cursors: Object.fromEntries(
+        group_refs,
+        group_cursors: Object.fromEntries(
           groups
             .map((group) => [
-              String(group?.topic?.id ?? "").trim(),
+              String(group?.group_ref ?? "").trim(),
               {
                 ts: group?.newest_event?.ts,
                 id: group?.newest_event?.id,
               },
             ])
-            .filter(([topicId, cursor]) => topicId && cursor.ts && cursor.id),
+            .filter(([groupRef, cursor]) => groupRef && cursor.ts && cursor.id),
         ),
       });
       await loadHome();
@@ -126,7 +147,7 @@
           ? err.message
           : String(err ?? "Failed to mark all read.");
     } finally {
-      markingTopicId = "";
+      markingGroupRef = "";
     }
   }
 
@@ -148,7 +169,7 @@
       {:else}
         Updated {formatTimestamp(feed.generated_at) || "just now"} · {feed.unread_count ??
           0}
-        unread across {feed.topic_count ?? 0} topics
+        unread across {feed.group_count ?? 0} groups
       {/if}
     {/snippet}
     {#snippet actions()}
@@ -164,7 +185,7 @@
       <button
         class="rounded-md border border-line px-2.5 py-1.5 text-meta font-medium text-fg-muted transition-colors hover:bg-bg-soft disabled:opacity-60"
         onclick={markAllRead}
-        disabled={loading || groups.length === 0 || markingTopicId === "*"}
+        disabled={loading || groups.length === 0 || markingGroupRef === "*"}
         type="button"
       >
         Mark all read
@@ -202,30 +223,28 @@
     </div>
   {:else}
     <div class="space-y-3" data-testid="home-unread-feed">
-      {#each groups as group (group.topic.id)}
+      {#each groups as group (group.group_ref)}
         <section class="overflow-hidden rounded-md border border-line bg-panel">
           <div
             class="flex flex-wrap items-center justify-between gap-3 border-b border-line px-3 py-2.5 sm:px-4"
           >
             <a
               class="min-w-0 flex-1 font-semibold text-fg hover:underline"
-              href={workspaceHref(
-                `/topics/${encodeURIComponent(group.topic.id)}`,
-              )}
+              href={groupHref(group)}
             >
-              {topicTitle(group.topic)}
+              {groupLabel(group)}
             </a>
             <div class="flex shrink-0 items-center gap-2">
               <span
                 class="rounded bg-line px-1.5 py-0.5 text-micro font-medium text-fg-muted"
               >
-                {priorityLabel(group.topic)} · {group.unread_count} unread
+                {priorityLabel(group)} · {group.unread_count} unread
               </span>
               <button
                 class="rounded-md border border-line px-2 py-1 text-micro font-medium text-fg-muted transition-colors hover:bg-line-subtle disabled:opacity-60"
-                onclick={() => markTopicRead(group.topic.id)}
-                disabled={markingTopicId === group.topic.id ||
-                  markingTopicId === "*"}
+                onclick={() => markGroupRead(group.group_ref)}
+                disabled={markingGroupRef === group.group_ref ||
+                  markingGroupRef === "*"}
                 type="button"
               >
                 Mark read


### PR DESCRIPTION
## Summary

Replaces the topic-scoped Home unread system with a typed group model that resolves events to topic, board, document, or workspace-level groups via a deterministic chain.

**Root cause this fixes:** Card/board events without a direct `topic:` ref were silently dropped from Home unread (`homeTopicIDForEvent` returned `""`). Home showed "0 unread" even when Events history displayed new workspace activity.

## What changed

### Core: typed group resolution (`core/internal/primitives/store.go`)
- `HomeUnreadGroup` now uses `GroupRef`/`GroupType`/`DisplayName`/`Priority` instead of embedding a `Topic` map
- `homeTopicLookup` → `homeGroupLookup` loads both topics and boards into a unified lookup structure
- `homeTopicIDForEvent` → `homeGroupForEvent` with resolution chain: `topic:` ref → thread→topic/board → `board:` ref
- `MarkHomeRead`/`MarkHomeReadAt` accept `[]string` group refs (typed refs like `"topic:<id>"`, `"board:<id>"`)
- `newestHomeEventForGroup` replaces `newestHomeEventForTopic` with prefix-aware filter selection

### Database: migration v24
- Creates `home_read_cursors` table keyed by `(reader_id, group_ref)`
- Migrates existing rows from `home_topic_read_cursors` (`topic_id` → `group_ref = "topic:" + topic_id`)
- Drops old table

### HTTP API (`core/internal/server/home_handlers.go`)
- `GET /home/unread` response: `group_count` replaces `topic_count`, each group has `group_ref`/`group_type`/`display_name`/`priority`
- `POST /home/read` request: `group_ref`/`group_refs`/`group_cursors` replace `topic_id`/`topic_ids`/`topic_cursors`

### Contract (`contracts/`)
- `anx-schema.yaml`: `topic_ownership` → `group_ownership` with documented resolution chain
- `anx-openapi.yaml`: updated `HomeUnreadGroup`, `HomeUnreadResponse`, `MarkHomeReadRequest`, `MarkHomeReadResponse` schemas
- Generated artifacts regenerated

### Web UI (`web-ui/`)
- Home page renders groups by `group_type`: topic groups link to `/topics/:id`, board groups link to `/boards/:id`
- `anxCoreClient.js` maps old `topic_id`/`topic_ids`/`topic_cursors` to new `group_ref`/`group_refs`/`group_cursors` for backward-compatible client code
- Subtitle shows "unread across N groups" instead of "N topics"

## Testing
- All existing Home integration tests updated and passing
- `make check` passes (core + web-ui)
- `make contract-check-committed` shows expected generated diffs

## No backwards compatibility debt
- Old `home_topic_read_cursors` table is dropped in migration v24
- No dual-write path; single cursor model from day one
- `group_ref` is a plain typed ref string — adding new group types (document, workspace) requires only a new resolution rule in `homeGroupForEvent` and a metadata loader