### PR TITLE
[codex] Move mobile shell actions into bottom nav

### DIFF
--- a/web-ui/src/app.css
+++ b/web-ui/src/app.css
@@ -162,7 +162,6 @@
     .shell-search-trigger,
     .workspace-switcher-trigger,
     .workspace-switcher-option,
-    .shell-mobile-identity,
     .shell-bottom-nav-item,
     .shell-actor-panel button,
     .actor-gate-item,
@@ -921,111 +920,12 @@
     flex-direction: column;
   }
 
-  .shell-mobile-header {
-    position: sticky;
-    top: 0;
-    z-index: 25;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    justify-content: space-between;
-    border-bottom: 1px solid var(--line);
-    background: var(--bg-soft);
-    padding: 0.5rem 0.75rem;
-  }
-
-  .shell-mobile-header p {
-    margin: 0;
-    font-weight: 600;
-    font-size: 0.8125rem;
-  }
-
-  .shell-mobile-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-left: auto;
-  }
-
-  .shell-mobile-search {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 2.5rem;
-    min-height: 2.5rem;
-    padding: 0.45rem;
-    border: 1px solid var(--line);
-    background: var(--panel);
-    color: var(--fg-muted);
-    border-radius: var(--radius);
-    cursor: pointer;
-    transition:
-      background 0.1s,
-      color 0.1s;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  .shell-mobile-search:hover {
-    background: var(--bg-soft);
-    color: var(--fg);
-  }
-
-  .shell-mobile-search-icon {
-    width: 1.125rem;
-    height: 1.125rem;
-    flex-shrink: 0;
-  }
-
-  .shell-mobile-identity {
-    border: 1px solid var(--line);
-    background: var(--panel);
-    color: var(--fg);
-    border-radius: var(--radius);
-    min-height: 2.5rem;
-    padding: 0.45rem 0.5rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  .shell-mobile-identity span {
-    width: 1.125rem;
-    height: 1.125rem;
-    border-radius: 999px;
-    background: var(--line-strong);
-    color: white;
-    display: inline-grid;
-    place-items: center;
-    font-size: 0.625rem;
-    font-weight: 700;
-  }
-
   .shell-main-scroll {
     flex: 1;
     min-width: 0;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 1.25rem 1rem 5rem;
-  }
-
-  @media (max-width: 639px) {
-    .shell-mobile-header {
-      padding: 0.375rem 0.75rem;
-    }
-
-    .shell-mobile-search,
-    .shell-mobile-identity {
-      min-width: 2.25rem;
-      min-height: 2.25rem;
-      padding: 0.35rem 0.5rem;
-    }
-
-    .shell-main-scroll {
-      padding-top: 1rem;
-    }
   }
 
   .shell-content {
@@ -1860,6 +1760,13 @@
     -webkit-tap-highlight-color: transparent;
   }
 
+  .shell-bottom-nav-button {
+    border: 0;
+    background: transparent;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
   .shell-bottom-nav-item svg {
     width: 1.25rem;
     height: 1.25rem;
@@ -1925,10 +1832,6 @@
       flex: 0 0 auto;
       padding-top: 0.5rem;
       border-top: 1px solid var(--line);
-    }
-
-    .shell-mobile-header {
-      display: none;
     }
 
     .shell-main-scroll {

--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -1272,39 +1272,6 @@
       </aside>
 
       <div class="shell-main">
-        <header class="shell-mobile-header">
-          <p>ANX</p>
-          <div class="shell-mobile-header-actions">
-            <button
-              class="shell-mobile-search"
-              aria-label="Search workspace"
-              onclick={() => (commandPaletteOpen = true)}
-              type="button"
-            >
-              <svg
-                class="shell-mobile-search-icon"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </button>
-            <button
-              class="shell-mobile-identity"
-              onclick={switchIdentity}
-              type="button"
-            >
-              <span aria-hidden="true">{initials}</span>
-              {$authenticatedAgent ? "Sign out" : "Switch"}
-            </button>
-          </div>
-        </header>
-
         <main class="shell-main-scroll">
           <div
             class={`shell-content shell-content--${shellContentConfig.mode}`}
@@ -1344,6 +1311,21 @@
           <span>{item.label}</span>
         </a>
       {/each}
+      <button
+        class="shell-bottom-nav-item shell-bottom-nav-button"
+        aria-label="Search workspace"
+        onclick={() => (commandPaletteOpen = true)}
+        type="button"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path
+            fill-rule="evenodd"
+            d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span>Search</span>
+      </button>
       <a
         class="shell-bottom-nav-item {moreBottomNavActive
           ? 'shell-bottom-nav-item--active'

--- a/web-ui/tests/e2e/shell.spec.js
+++ b/web-ui/tests/e2e/shell.spec.js
@@ -2,6 +2,11 @@ import { expect, test } from "@playwright/test";
 
 const WS_HOME = "/o/local/w/local";
 
+async function unlockShellWithActor(page, name) {
+  await page.getByLabel("Display name").fill(name);
+  await page.getByRole("button", { name: "Create and continue" }).click();
+}
+
 test("blocks shell with actor gate when no actor is selected", async ({
   page,
 }) => {
@@ -57,11 +62,11 @@ test("renders Home on workspace root and routes into inbox", async ({
   page,
 }) => {
   await page.addInitScript(() => {
-    window.localStorage.setItem("anx_ui_actor_id:local", "actor-ops-ai");
     window.localStorage.setItem("workspaceTourSeen.local", "1");
   });
 
   await page.goto(WS_HOME);
+  await unlockShellWithActor(page, `Home User ${Date.now()}`);
 
   await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
   await expect(
@@ -79,7 +84,6 @@ test("renders Home on workspace root and routes into inbox", async ({
 
 test("shows error when Home unread feed is unavailable", async ({ page }) => {
   await page.addInitScript(() => {
-    window.localStorage.setItem("anx_ui_actor_id:local", "actor-ops-ai");
     window.localStorage.setItem("workspaceTourSeen.local", "1");
   });
 
@@ -97,6 +101,7 @@ test("shows error when Home unread feed is unavailable", async ({ page }) => {
   });
 
   await page.goto(WS_HOME);
+  await unlockShellWithActor(page, `Outage User ${Date.now()}`);
 
   await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
   await expect(page.getByRole("alert")).toBeVisible();
@@ -105,11 +110,11 @@ test("shows error when Home unread feed is unavailable", async ({ page }) => {
 test("mobile bottom navigation switches workspace routes", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.addInitScript(() => {
-    window.localStorage.setItem("anx_ui_actor_id:local", "actor-ops-ai");
     window.localStorage.setItem("workspaceTourSeen.local", "1");
   });
 
   await page.goto(`${WS_HOME}/inbox`);
+  await unlockShellWithActor(page, `Mobile User ${Date.now()}`);
 
   const bottomNav = page.getByRole("navigation", {
     name: "Primary navigation",
@@ -119,5 +124,10 @@ test("mobile bottom navigation switches workspace routes", async ({ page }) => {
   await expect(page).toHaveURL(/\/o\/local\/w\/local\/topics$/);
   await expect(
     page.getByRole("heading", { name: "Topics", exact: true }),
+  ).toBeVisible();
+
+  await bottomNav.getByRole("button", { name: "Search workspace" }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Command palette" }),
   ).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Remove the duplicate mobile shell top bar so content starts higher on small screens.
- Add a bottom navigation Search action that opens the command palette.
- Keep profile and identity controls in the existing More page identity section.
- Make shell e2e setup create actors through the gate instead of relying on seeded actor IDs.

## Validation

- `make -C web-ui check`
- `pnpm exec playwright test tests/e2e/shell.spec.js --project=default`
- Captured mobile screenshots in `.codex-autorunner/filebox/outbox/`.