### PR TITLE
[codex] Strip OpenClaw trailing NO_REPLY

### DIFF
--- a/adapters/agent-bridge/anx_agent_bridge/adapters/openclaw.py
+++ b/adapters/agent-bridge/anx_agent_bridge/adapters/openclaw.py
@@ -129,7 +129,7 @@ def _dispatch(request: dict[str, Any], settings: dict[str, Any]) -> dict[str, An
             metadata={"error": err[:500], "returncode": proc.returncode},
         )
 
-    response_text = _extract_response_text(proc.stdout)
+    response_text = _sanitize_response_text(_extract_response_text(proc.stdout))
     if not response_text:
         response_text = "OpenClaw completed the agent turn without returning text."
     return {
@@ -219,6 +219,13 @@ def _extract_response_text(raw_stdout: str) -> str:
         if text:
             return text
     return ""
+
+
+def _sanitize_response_text(text: str) -> str:
+    lines = text.rstrip().splitlines()
+    if lines and lines[-1].strip() == "NO_REPLY":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
 
 
 def _last_payload_text(payloads: Any) -> str:

--- a/adapters/agent-bridge/tests/test_openclaw.py
+++ b/adapters/agent-bridge/tests/test_openclaw.py
@@ -60,6 +60,56 @@ def test_openclaw_extract_response_falls_back_to_final_visible_text() -> None:
     assert openclaw._extract_response_text(raw) == "final fallback"
 
 
+def test_openclaw_dispatch_strips_trailing_standalone_no_reply(monkeypatch) -> None:
+    def fake_run(cmd: list[str], *, timeout: int):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps({"result": {"payloads": [{"text": "Full answer.\n\nNO_REPLY"}]}}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(openclaw, "_resolve_bin", lambda settings, env_key, config_key, default_name: f"/bin/{default_name}")
+    monkeypatch.setattr(openclaw, "_new_wake_session_id", lambda: "anx-abc123def456")
+    monkeypatch.setattr(openclaw, "_run", fake_run)
+
+    result = openclaw._dispatch(
+        {
+            "mode": "dispatch",
+            "prompt_text": "wake prompt",
+            "wake_packet": {"thread": {"id": "thread_1", "title": "Launch plan"}},
+        },
+        {},
+    )
+
+    assert result["response_text"] == "Full answer."
+
+
+def test_openclaw_dispatch_keeps_inline_no_reply_content(monkeypatch) -> None:
+    def fake_run(cmd: list[str], *, timeout: int):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps({"result": {"payloads": [{"text": "Use NO_REPLY only as a sentinel."}]}}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(openclaw, "_resolve_bin", lambda settings, env_key, config_key, default_name: f"/bin/{default_name}")
+    monkeypatch.setattr(openclaw, "_new_wake_session_id", lambda: "anx-abc123def456")
+    monkeypatch.setattr(openclaw, "_run", fake_run)
+
+    result = openclaw._dispatch(
+        {
+            "mode": "dispatch",
+            "prompt_text": "wake prompt",
+            "wake_packet": {"thread": {"id": "thread_1", "title": "Launch plan"}},
+        },
+        {},
+    )
+
+    assert result["response_text"] == "Use NO_REPLY only as a sentinel."
+
+
 def test_openclaw_dispatch_creates_isolated_session_and_does_not_persist_native_session(monkeypatch) -> None:
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

- Strip a trailing standalone `NO_REPLY` line from OpenClaw adapter response text before posting back to Agent Nexus.
- Keep inline `NO_REPLY` content intact so legitimate explanatory text is not changed.
- Add OpenClaw adapter regression coverage for both cases.

## Root Cause

The OpenClaw adapter extracted final visible text from the OpenClaw JSON envelope and posted it directly to ANX. OpenClaw can append a standalone `NO_REPLY` sentinel to an otherwise complete response in isolated sessions, so that sentinel leaked into `message_posted`.

## Validation

- `python3 -m pytest adapters/agent-bridge/tests/test_openclaw.py`

## Notes

`make -C adapters/agent-bridge test` could not run in this worktree because `adapters/agent-bridge/.venv/bin/python` is missing. The branch push also needed `PRE_COMMIT_ALLOW_NO_CONFIG=1` because the submodule worktree hook resolved `.pre-commit-config.yaml` through an invalid relative path.