### PR TITLE
Improve CLI profile docs discovery

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -7,6 +7,8 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `onboarding` (manual): Offline quick-start mental model and first command flow.
 - `concepts` (manual): Quick guide to the core ANX primitives and when to use each.
 - `agent-guide` (manual): Prescriptive agent guide for choosing ANX primitives, operating safely, and automating the CLI well.
+- `profiles` (manual): CLI profile resolution, same-machine multi-agent setup, and active profile inspection.
+- `env` (manual): Supported ANX_* environment variables and precedence.
 - `agent-bridge` (manual): Install, configure, and operate the preferred per-agent `anx-agent-bridge` runtime (local adapter + check-in); workspace wake routing still lives in `anx-core`.
 - `wake-routing` (manual): How `@handle` wake routing works, including self-registration, verification, and troubleshooting.
 - `draft` (manual): Local draft staging, listing, commit, and discard workflow.
@@ -15,7 +17,7 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `auth list` (manual): List local CLI profiles and the active profile.
 - `auth default` (manual): Persist the default CLI profile used when no explicit agent is selected.
 - `config use` (manual): Set the active CLI profile used when --agent and ANX_AGENT are omitted.
-- `config show` (manual): Print effective CLI settings and per-field sources (tokens redacted).
+- `config show` (manual): Print effective CLI profile settings, per-field sources, precedence, and env var hints (tokens redacted).
 - `config unset` (manual): Clear the persisted default profile marker (~/.config/anx/default-profile).
 - `auth update-username` (manual): Rename the authenticated agent and sync the local profile.
 - `auth rotate` (manual): Rotate the active agent key and refresh stored credentials.
@@ -273,6 +275,11 @@ Inbox categories:
 - `risk_exception`: Exceptions or at-risk work items that need follow-up.
 - `attention`: Review or lighter operator focus (for example document attention).
 
+Configuration and profiles:
+- Use profiles for local CLI identity and auth material; use `ANX_AGENT` as a per-process default for multi-agent machines.
+- Precedence is command flags > environment variables > profile/default marker/autodiscovery > built-in defaults.
+- Read next: anx meta doc profiles ; anx meta doc env ; anx config show
+
 For the fuller operating model, read `anx meta doc agent-guide`.
 ```
 
@@ -344,10 +351,9 @@ Configuration
 - On a durable workstation, set the active profile once with `anx config use <profile>` (equivalent to `anx auth default <profile>`). Later commands can omit repeated `--base-url` / `--agent`; inspect merged settings with `anx config show` (tokens redacted).
 - Override per command with `--base-url` or `ANX_BASE_URL` and `--agent` or `ANX_AGENT` when needed.
 - Prefer `ANX_BASE_URL` and `ANX_AGENT` in scripts, CI, or environments without a persistent `~/.config/anx`.
+- Config precedence is command flags > environment variables > profile/default marker/autodiscovery > built-in defaults. Read `anx meta doc profiles` and `anx meta doc env` for details.
 - If available, run `anx doctor` when config or connectivity is unclear.
 - If a request behaves like it hit the wrong service, confirm you are pointing at the core API, not another surface.
-
-Config precedence is typically: flags -> environment -> profile -> defaults.
 
 
 Discovery first
@@ -406,6 +412,93 @@ Maintenance rule
 - Describe roles and decision rules, not exhaustive command inventories.
 - Prefer `anx help` and `anx meta docs` over embedding fragile schemas.
 - Mention examples of primitives and abstractions, but avoid implying the list is closed.
+```
+
+## `profiles`
+
+CLI profile resolution, same-machine multi-agent setup, and active profile inspection.
+
+```text
+ANX CLI profiles
+
+A profile is a local identity file with the base URL, token material, key metadata, and agent identity used by the CLI. Profiles normally live under:
+
+  ~/.config/anx/profiles/<profile>.json
+
+Active profile resolution:
+
+  1. --agent <profile>       Explicit command flag for one invocation
+  2. ANX_AGENT=<profile>     Per-process default for shells, scripts, services
+  3. default-profile marker  ~/.config/anx/default-profile written by config use/auth default
+  4. single profile          Auto-selected only when exactly one profile exists
+  5. none                    Multiple profiles without selection fail config resolution
+
+Precedence:
+
+  command flags > environment variables > profile/default marker/autodiscovery > built-in defaults
+
+Use anx config use <profile> for a durable workstation default. It writes ~/.config/anx/default-profile.
+
+Use ANX_AGENT=<profile> for multi-agent machines, launchd/systemd services, CI jobs, or any process that should not mutate a shared default marker:
+
+  ANX_AGENT=engineering anx auth whoami
+  ANX_AGENT=reviewer anx cards list
+
+Use --agent <profile> for a one-off command that should override both the process environment and the persisted default:
+
+  ANX_AGENT=engineering anx --agent reviewer auth whoami
+
+Inspect the effective profile, base URL, token redaction status, and per-field sources with:
+
+  anx config show
+
+Switch or clear the persisted default with:
+
+  anx config use <profile>
+  anx config unset
+  anx auth list
+
+Bridge isolation:
+
+Bridge configs are agent-isolated by their own handle/config path and imported auth material. Multiple bridges can coexist on one machine; prefer explicit bridge configs plus ANX_AGENT or --agent during setup so the CLI default profile does not become hidden shared state.
+
+Related docs:
+  anx meta doc env
+  anx help config
+  anx auth list
+```
+
+## `env`
+
+Supported ANX_* environment variables and precedence.
+
+```text
+ANX environment variables
+
+Use environment variables as per-process defaults for shells, scripts, services, and same-machine multi-agent setups. Explicit command flags still win for one command.
+
+Precedence:
+  command flags > environment variables > profile/default marker/autodiscovery > built-in defaults
+
+Supported variables:
+
+Variable          Overrides                 Example
+--------          ---------                 -------
+ANX_AGENT         active profile selection  ANX_AGENT=engineering
+ANX_BASE_URL      core API base URL         ANX_BASE_URL=https://anx.example.com/ws/org/workspace
+ANX_TIMEOUT       request timeout           ANX_TIMEOUT=30s
+ANX_NO_COLOR      color output              ANX_NO_COLOR=1
+ANX_JSON          JSON output mode          ANX_JSON=true
+ANX_PROFILE_PATH  profile file path         ANX_PROFILE_PATH=/path/to/profile.json
+ANX_ACCESS_TOKEN  bearer access token       ANX_ACCESS_TOKEN=<token>
+
+Notes:
+- Prefer `ANX_AGENT` in long-running agent services so each process has its own identity without rewriting `~/.config/anx/default-profile`.
+- Prefer `ANX_BASE_URL` in CI and scripts when the target workspace is known outside the profile file.
+- Use `ANX_PROFILE_PATH` for isolated launch contexts that should not read the normal profile directory.
+- Treat `ANX_ACCESS_TOKEN` as secret material. Profile-backed auth is usually easier to refresh and audit.
+
+Inspect effective values and sources with `anx config show`.
 ```
 
 ## `agent-bridge`
@@ -997,7 +1090,7 @@ Global flags:
 
 ## `config show`
 
-Print effective CLI settings and per-field sources (tokens redacted).
+Print effective CLI profile settings, per-field sources, precedence, and env var hints (tokens redacted).
 
 ```text
 Local Help: config show

--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -9,6 +9,7 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `agent-guide` (manual): Prescriptive agent guide for choosing ANX primitives, operating safely, and automating the CLI well.
 - `profiles` (manual): CLI profile resolution, same-machine multi-agent setup, and active profile inspection.
 - `env` (manual): Supported ANX_* environment variables and precedence.
+- `config` (manual): CLI config surface: default profile selection, effective settings, and clearing the persisted marker.
 - `agent-bridge` (manual): Install, configure, and operate the preferred per-agent `anx-agent-bridge` runtime (local adapter + check-in); workspace wake routing still lives in `anx-core`.
 - `wake-routing` (manual): How `@handle` wake routing works, including self-registration, verification, and troubleshooting.
 - `draft` (manual): Local draft staging, listing, commit, and discard workflow.
@@ -499,6 +500,29 @@ Notes:
 - Treat `ANX_ACCESS_TOKEN` as secret material. Profile-backed auth is usually easier to refresh and audit.
 
 Inspect effective values and sources with `anx config show`.
+```
+
+## `config`
+
+CLI config surface: default profile selection, effective settings, and clearing the persisted marker.
+
+```text
+Config surface for the active CLI profile
+
+Use this group to set or inspect which local profile supplies base URL and auth when you omit --agent / --base-url.
+
+Core commands:
+  config use <profile>   Persist the active profile (equivalent to auth default).
+  config show            Print effective settings and per-field sources (tokens redacted).
+  config unset           Remove the default profile marker (~/.config/anx/default-profile).
+
+Related:
+  auth list              List profiles and which is active.
+  auth default <profile> Same selection as config use.
+
+Docs:
+  anx meta doc profiles
+  anx meta doc env
 ```
 
 ## `agent-bridge`

--- a/cli/internal/app/agent_guide.go
+++ b/cli/internal/app/agent_guide.go
@@ -86,10 +86,9 @@ func agentGuideSections() []guideSection {
 				"- On a durable workstation, set the active profile once with `anx config use <profile>` (equivalent to `anx auth default <profile>`). Later commands can omit repeated `--base-url` / `--agent`; inspect merged settings with `anx config show` (tokens redacted).",
 				"- Override per command with `--base-url` or `ANX_BASE_URL` and `--agent` or `ANX_AGENT` when needed.",
 				"- Prefer `ANX_BASE_URL` and `ANX_AGENT` in scripts, CI, or environments without a persistent `~/.config/anx`.",
+				"- Config precedence is command flags > environment variables > profile/default marker/autodiscovery > built-in defaults. Read `anx meta doc profiles` and `anx meta doc env` for details.",
 				"- If available, run `anx doctor` when config or connectivity is unclear.",
 				"- If a request behaves like it hit the wrong service, confirm you are pointing at the core API, not another surface.",
-				"",
-				"Config precedence is typically: flags -> environment -> profile -> defaults.",
 			},
 		},
 		{

--- a/cli/internal/app/concepts_guide.go
+++ b/cli/internal/app/concepts_guide.go
@@ -119,7 +119,7 @@ func conceptsGuideData() map[string]any {
 		"primitives":        primitives,
 		"selection_rules":   conceptsSelectionRules(),
 		"inbox_categories":  inboxCategoryReferenceMap(),
-		"recommended_reads": []string{"anx help", "anx meta doc concepts", "anx meta doc agent-guide"},
+		"recommended_reads": []string{"anx help", "anx meta doc concepts", "anx meta doc agent-guide", "anx meta doc profiles", "anx meta doc env"},
 	}
 }
 
@@ -175,6 +175,10 @@ func conceptsGuideText() string {
 		b.WriteString(entry.Description)
 		b.WriteString("\n")
 	}
+	b.WriteString("\nConfiguration and profiles:\n")
+	b.WriteString("- Use profiles for local CLI identity and auth material; use `ANX_AGENT` as a per-process default for multi-agent machines.\n")
+	b.WriteString("- Precedence is command flags > environment variables > profile/default marker/autodiscovery > built-in defaults.\n")
+	b.WriteString("- Read next: anx meta doc profiles ; anx meta doc env ; anx config show\n")
 	b.WriteString("\nFor the fuller operating model, read `anx meta doc agent-guide`.\n")
 	return strings.TrimSpace(b.String())
 }

--- a/cli/internal/app/config_commands.go
+++ b/cli/internal/app/config_commands.go
@@ -51,9 +51,9 @@ func (a *App) runConfigUse(args []string) (*commandResult, error) {
 		}
 		return nil, errnorm.Wrap(errnorm.KindLocal, "profile_read_failed", "failed to read profile", err)
 	}
-	agents, err := profile.ListAgents(homeDir)
-	if err != nil {
-		return nil, errnorm.Wrap(errnorm.KindLocal, "profile_list_failed", "failed to inspect local profiles", err)
+	var agents []string
+	if listed, err := profile.ListAgents(homeDir); err == nil {
+		agents = listed
 	}
 	otherProfiles := make([]string, 0, len(agents))
 	for _, agent := range agents {

--- a/cli/internal/app/config_commands.go
+++ b/cli/internal/app/config_commands.go
@@ -51,14 +51,38 @@ func (a *App) runConfigUse(args []string) (*commandResult, error) {
 		}
 		return nil, errnorm.Wrap(errnorm.KindLocal, "profile_read_failed", "failed to read profile", err)
 	}
+	agents, err := profile.ListAgents(homeDir)
+	if err != nil {
+		return nil, errnorm.Wrap(errnorm.KindLocal, "profile_list_failed", "failed to inspect local profiles", err)
+	}
+	otherProfiles := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		if agent != agentName {
+			otherProfiles = append(otherProfiles, agent)
+		}
+	}
+	lines := []string{"Active profile: " + agentName}
+	warnings := []string{}
+	if len(otherProfiles) > 0 {
+		lines = append(lines, "Other profiles on this machine: "+strings.Join(otherProfiles, ", "))
+		warning := "For agent services or multi-agent shells, prefer ANX_AGENT=<profile> over config use so you do not change the shared default profile."
+		lines = append(lines, warning)
+		lines = append(lines, "Docs: anx meta doc profiles ; anx meta doc env")
+		warnings = append(warnings, warning)
+	}
+	data := map[string]any{
+		"agent":             agentName,
+		"active_profile":    agentName,
+		"default_file_path": profile.DefaultAgentPath(homeDir),
+		"profile_path":      profilePath,
+	}
+	if len(otherProfiles) > 0 {
+		data["other_profiles"] = otherProfiles
+		data["warnings"] = warnings
+	}
 	return &commandResult{
-		Text: "Active profile: " + agentName,
-		Data: map[string]any{
-			"agent":             agentName,
-			"active_profile":    agentName,
-			"default_file_path": profile.DefaultAgentPath(homeDir),
-			"profile_path":      profilePath,
-		},
+		Text: strings.Join(lines, "\n"),
+		Data: data,
 	}, nil
 }
 
@@ -110,6 +134,16 @@ func (a *App) runConfigShow(cfg config.Resolved) *commandResult {
 	for _, k := range keys {
 		lines = append(lines, fmt.Sprintf("  Source %s: %s", k, cfg.Sources[k]))
 	}
+	lines = append(lines, "")
+	lines = append(lines, "Precedence:")
+	lines = append(lines, "  command flags > environment variables > profile/default marker/autodiscovery > built-in defaults")
+	lines = append(lines, "")
+	lines = append(lines, "Environment overrides available:")
+	for _, envVar := range cliEnvironmentVariables() {
+		lines = append(lines, fmt.Sprintf("  %-16s %s", envVar.Name, envVar.Summary))
+	}
+	lines = append(lines, "")
+	lines = append(lines, "Docs: anx meta doc profiles ; anx meta doc env")
 	return &commandResult{
 		Text: strings.Join(lines, "\n"),
 		Data: data,
@@ -166,6 +200,17 @@ func redactedConfigShowData(cfg config.Resolved) map[string]any {
 		out["private_key_path"] = cfg.PrivateKeyPath
 	}
 	out["revoked"] = cfg.Revoked
+	envVars := make([]map[string]any, 0, len(cliEnvironmentVariables()))
+	for _, envVar := range cliEnvironmentVariables() {
+		envVars = append(envVars, map[string]any{
+			"name":      envVar.Name,
+			"summary":   envVar.Summary,
+			"overrides": envVar.Overrides,
+			"example":   envVar.Example,
+		})
+	}
+	out["precedence"] = []string{"flags", "environment", "profile/default/autodiscovery", "built-in defaults"}
+	out["environment_overrides_available"] = envVars
 	if strings.TrimSpace(cfg.CoreInstanceID) != "" {
 		out["core_instance_id"] = cfg.CoreInstanceID
 	}

--- a/cli/internal/app/config_commands_test.go
+++ b/cli/internal/app/config_commands_test.go
@@ -59,6 +59,32 @@ func TestConfigUseOmitsMultiProfileWarningForSingleProfile(t *testing.T) {
 	}
 }
 
+func TestConfigUseStillSucceedsWhenProfileListAdvisoryFails(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := profile.Save(profile.ProfilePath(home, "solo"), profile.Profile{Agent: "solo", BaseURL: "http://solo:8000"}); err != nil {
+		t.Fatalf("save solo profile: %v", err)
+	}
+	profilesDir := profile.ProfilesDir(home)
+	if err := os.Chmod(profilesDir, 0o111); err != nil {
+		t.Fatalf("chmod profiles dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(profilesDir, 0o700)
+	})
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "config", "use", "solo"})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	if strings.TrimSpace(anyStr(data["active_profile"])) != "solo" {
+		t.Fatalf("unexpected config use payload: %#v", payload)
+	}
+	if _, exists := data["warnings"]; exists {
+		t.Fatalf("did not expect warning when advisory profile listing fails: %#v", payload)
+	}
+}
+
 func TestConfigUseNormalizedSubcommandIsConfigLenient(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/config_commands_test.go
+++ b/cli/internal/app/config_commands_test.go
@@ -28,6 +28,9 @@ func TestConfigUseSetsActiveProfile(t *testing.T) {
 	if strings.TrimSpace(anyStr(data["active_profile"])) != "beta" {
 		t.Fatalf("unexpected config use payload: %#v", payload)
 	}
+	if warnings, _ := data["warnings"].([]any); len(warnings) == 0 {
+		t.Fatalf("expected multi-profile warning: %#v", payload)
+	}
 
 	versionRaw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "version"})
 	versionPayload := assertEnvelopeOK(t, versionRaw)
@@ -37,6 +40,22 @@ func TestConfigUseSetsActiveProfile(t *testing.T) {
 	}
 	if strings.TrimSpace(anyStr(versionData["base_url"])) != "http://beta:8000" {
 		t.Fatalf("unexpected version base url: %#v", versionPayload)
+	}
+}
+
+func TestConfigUseOmitsMultiProfileWarningForSingleProfile(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := profile.Save(profile.ProfilePath(home, "solo"), profile.Profile{Agent: "solo", BaseURL: "http://solo:8000"}); err != nil {
+		t.Fatalf("save solo profile: %v", err)
+	}
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--json", "config", "use", "solo"})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	if _, exists := data["warnings"]; exists {
+		t.Fatalf("did not expect warning for one profile: %#v", payload)
 	}
 }
 
@@ -134,6 +153,33 @@ func TestConfigShowRedactsTokens(t *testing.T) {
 	rawJSON, _ := json.Marshal(data)
 	if strings.Contains(string(rawJSON), "super-secret") {
 		t.Fatalf("secret leaked in JSON: %s", rawJSON)
+	}
+	envVars, _ := data["environment_overrides_available"].([]any)
+	if len(envVars) == 0 {
+		t.Fatalf("expected env var discovery data: %#v", data)
+	}
+	if !strings.Contains(string(rawJSON), "ANX_AGENT") || !strings.Contains(string(rawJSON), "ANX_JSON") {
+		t.Fatalf("expected supported env vars in config show data: %s", rawJSON)
+	}
+}
+
+func TestConfigShowTextIncludesPrecedenceAndEnvHints(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := profile.Save(profile.ProfilePath(home, "sec"), profile.Profile{
+		Agent:   "sec",
+		BaseURL: "http://sec:8000",
+	}); err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+
+	raw := runCLIForTest(t, home, map[string]string{}, nil, []string{"--agent", "sec", "config", "show"})
+	if !strings.Contains(raw, "command flags > environment variables > profile/default marker/autodiscovery > built-in defaults") {
+		t.Fatalf("expected precedence in text output: %s", raw)
+	}
+	if !strings.Contains(raw, "ANX_AGENT") || !strings.Contains(raw, "anx meta doc profiles") {
+		t.Fatalf("expected env hints and docs links in text output: %s", raw)
 	}
 }
 

--- a/cli/internal/app/config_docs.go
+++ b/cli/internal/app/config_docs.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+type cliEnvironmentVariable struct {
+	Name      string
+	Overrides string
+	Summary   string
+	Example   string
+}
+
+func cliEnvironmentVariables() []cliEnvironmentVariable {
+	return []cliEnvironmentVariable{
+		{Name: "ANX_AGENT", Overrides: "active profile selection", Summary: "Select the active profile for this process.", Example: "ANX_AGENT=engineering"},
+		{Name: "ANX_BASE_URL", Overrides: "core API base URL", Summary: "Point commands at a core API origin.", Example: "ANX_BASE_URL=https://anx.example.com/ws/org/workspace"},
+		{Name: "ANX_TIMEOUT", Overrides: "request timeout", Summary: "Set request timeout as a Go duration.", Example: "ANX_TIMEOUT=30s"},
+		{Name: "ANX_NO_COLOR", Overrides: "color output", Summary: "Disable colored text output when true.", Example: "ANX_NO_COLOR=1"},
+		{Name: "ANX_JSON", Overrides: "JSON output mode", Summary: "Emit JSON envelopes when true.", Example: "ANX_JSON=true"},
+		{Name: "ANX_PROFILE_PATH", Overrides: "profile file path", Summary: "Read profile data from an explicit file.", Example: "ANX_PROFILE_PATH=/path/to/profile.json"},
+		{Name: "ANX_ACCESS_TOKEN", Overrides: "bearer access token", Summary: "Use an explicit bearer token for this process.", Example: "ANX_ACCESS_TOKEN=<token>"},
+	}
+}
+
+func envDocText() string {
+	var b strings.Builder
+	b.WriteString("ANX environment variables\n\n")
+	b.WriteString("Use environment variables as per-process defaults for shells, scripts, services, and same-machine multi-agent setups. Explicit command flags still win for one command.\n\n")
+	b.WriteString("Precedence:\n")
+	b.WriteString("  command flags > environment variables > profile/default marker/autodiscovery > built-in defaults\n\n")
+	b.WriteString("Supported variables:\n\n")
+	b.WriteString("Variable          Overrides                 Example\n")
+	b.WriteString("--------          ---------                 -------\n")
+	for _, envVar := range cliEnvironmentVariables() {
+		b.WriteString(fmt.Sprintf("%-16s  %-24s  %s\n", envVar.Name, envVar.Overrides, envVar.Example))
+	}
+	b.WriteString("\nNotes:\n")
+	b.WriteString("- Prefer `ANX_AGENT` in long-running agent services so each process has its own identity without rewriting `~/.config/anx/default-profile`.\n")
+	b.WriteString("- Prefer `ANX_BASE_URL` in CI and scripts when the target workspace is known outside the profile file.\n")
+	b.WriteString("- Use `ANX_PROFILE_PATH` for isolated launch contexts that should not read the normal profile directory.\n")
+	b.WriteString("- Treat `ANX_ACCESS_TOKEN` as secret material. Profile-backed auth is usually easier to refresh and audit.\n\n")
+	b.WriteString("Inspect effective values and sources with `anx config show`.\n")
+	return strings.TrimSpace(b.String())
+}
+
+func profilesDocText() string {
+	return strings.TrimSpace(`ANX CLI profiles
+
+A profile is a local identity file with the base URL, token material, key metadata, and agent identity used by the CLI. Profiles normally live under:
+
+  ~/.config/anx/profiles/<profile>.json
+
+Active profile resolution:
+
+  1. --agent <profile>       Explicit command flag for one invocation
+  2. ANX_AGENT=<profile>     Per-process default for shells, scripts, services
+  3. default-profile marker  ~/.config/anx/default-profile written by config use/auth default
+  4. single profile          Auto-selected only when exactly one profile exists
+  5. none                    Multiple profiles without selection fail config resolution
+
+Precedence:
+
+  command flags > environment variables > profile/default marker/autodiscovery > built-in defaults
+
+Use anx config use <profile> for a durable workstation default. It writes ~/.config/anx/default-profile.
+
+Use ANX_AGENT=<profile> for multi-agent machines, launchd/systemd services, CI jobs, or any process that should not mutate a shared default marker:
+
+  ANX_AGENT=engineering anx auth whoami
+  ANX_AGENT=reviewer anx cards list
+
+Use --agent <profile> for a one-off command that should override both the process environment and the persisted default:
+
+  ANX_AGENT=engineering anx --agent reviewer auth whoami
+
+Inspect the effective profile, base URL, token redaction status, and per-field sources with:
+
+  anx config show
+
+Switch or clear the persisted default with:
+
+  anx config use <profile>
+  anx config unset
+  anx auth list
+
+Bridge isolation:
+
+Bridge configs are agent-isolated by their own handle/config path and imported auth material. Multiple bridges can coexist on one machine; prefer explicit bridge configs plus ANX_AGENT or --agent during setup so the CLI default profile does not become hidden shared state.
+
+Related docs:
+  anx meta doc env
+  anx help config
+  anx auth list`)
+}

--- a/cli/internal/app/help_catalog.go
+++ b/cli/internal/app/help_catalog.go
@@ -37,6 +37,8 @@ var runtimeHelpManualDocTopics = []runtimeHelpDocTopic{
 	{Path: "onboarding", Kind: "manual", Summary: "Offline quick-start mental model and first command flow."},
 	{Path: "concepts", Kind: "manual", Summary: "Quick guide to the core ANX primitives and when to use each."},
 	{Path: "agent-guide", Kind: "manual", Summary: "Prescriptive agent guide for choosing ANX primitives, operating safely, and automating the CLI well."},
+	{Path: "profiles", Kind: "manual", Summary: "CLI profile resolution, same-machine multi-agent setup, and active profile inspection."},
+	{Path: "env", Kind: "manual", Summary: "Supported ANX_* environment variables and precedence."},
 	{Path: "agent-bridge", Kind: "manual", Summary: "Install, configure, and operate the preferred per-agent `anx-agent-bridge` runtime (local adapter + check-in); workspace wake routing still lives in `anx-core`."},
 	{Path: "wake-routing", Kind: "manual", Summary: "How `@handle` wake routing works, including self-registration, verification, and troubleshooting."},
 	{Path: "draft", Kind: "manual", Summary: "Local draft staging, listing, commit, and discard workflow."},
@@ -45,7 +47,7 @@ var runtimeHelpManualDocTopics = []runtimeHelpDocTopic{
 	{Path: "auth list", Kind: "manual", Summary: "List local CLI profiles and the active profile."},
 	{Path: "auth default", Kind: "manual", Summary: "Persist the default CLI profile used when no explicit agent is selected."},
 	{Path: "config use", Kind: "manual", Summary: "Set the active CLI profile used when --agent and ANX_AGENT are omitted."},
-	{Path: "config show", Kind: "manual", Summary: "Print effective CLI settings and per-field sources (tokens redacted)."},
+	{Path: "config show", Kind: "manual", Summary: "Print effective CLI profile settings, per-field sources, precedence, and env var hints (tokens redacted)."},
 	{Path: "config unset", Kind: "manual", Summary: "Clear the persisted default profile marker (~/.config/anx/default-profile)."},
 	{Path: "auth update-username", Kind: "manual", Summary: "Rename the authenticated agent and sync the local profile."},
 	{Path: "auth rotate", Kind: "manual", Summary: "Rotate the active agent key and refresh stored credentials."},
@@ -191,12 +193,26 @@ func runtimeHelpDocTopics() []runtimeHelpDocTopic {
 
 func runtimeHelpDocTopicByPath(path string) (runtimeHelpDocTopic, bool) {
 	path = strings.Join(strings.Fields(strings.TrimSpace(path)), " ")
+	path = canonicalRuntimeHelpDocTopic(path)
 	for _, topic := range runtimeHelpDocTopics() {
 		if strings.Join(strings.Fields(strings.TrimSpace(topic.Path)), " ") == path {
 			return topic, true
 		}
 	}
 	return runtimeHelpDocTopic{}, false
+}
+
+func canonicalRuntimeHelpDocTopic(path string) string {
+	switch strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(path)), " ")) {
+	case "environment", "environments", "environment variables", "env vars", "env var":
+		return "env"
+	case "profile", "profiles", "config profiles", "configuration profiles":
+		return "profiles"
+	case "configuration":
+		return "config"
+	default:
+		return strings.Join(strings.Fields(strings.TrimSpace(path)), " ")
+	}
 }
 
 func RuntimeHelpDocMarkdown(topic string) (string, error) {
@@ -225,6 +241,44 @@ func RuntimeHelpDocsMarkdown() (string, error) {
 		b.WriteString(section)
 	}
 	return strings.TrimSpace(b.String()) + "\n", nil
+}
+
+func RuntimeHelpDocsIndexMarkdown(topics []runtimeHelpDocTopic) string {
+	if topics == nil {
+		topics = runtimeHelpDocTopics()
+	}
+	var b strings.Builder
+	b.WriteString("# ANX Runtime Help Topics\n\n")
+	for _, topic := range topics {
+		b.WriteString(fmt.Sprintf("- `%s` (%s): %s\n", topic.Path, topic.Kind, topic.Summary))
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func SearchRuntimeHelpDocTopics(query string) []runtimeHelpDocTopic {
+	terms := strings.Fields(strings.ToLower(strings.TrimSpace(query)))
+	if len(terms) == 0 {
+		return nil
+	}
+	matches := []runtimeHelpDocTopic{}
+	for _, topic := range runtimeHelpDocTopics() {
+		haystackParts := []string{topic.Path, topic.Kind, topic.Summary}
+		if text, ok := helpTopicText(topic.Path); ok {
+			haystackParts = append(haystackParts, text)
+		}
+		haystack := strings.ToLower(strings.Join(haystackParts, "\n"))
+		matched := true
+		for _, term := range terms {
+			if !strings.Contains(haystack, term) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			matches = append(matches, topic)
+		}
+	}
+	return matches
 }
 
 func WriteRuntimeHelpDocs(dir string) (string, error) {

--- a/cli/internal/app/help_catalog.go
+++ b/cli/internal/app/help_catalog.go
@@ -39,6 +39,7 @@ var runtimeHelpManualDocTopics = []runtimeHelpDocTopic{
 	{Path: "agent-guide", Kind: "manual", Summary: "Prescriptive agent guide for choosing ANX primitives, operating safely, and automating the CLI well."},
 	{Path: "profiles", Kind: "manual", Summary: "CLI profile resolution, same-machine multi-agent setup, and active profile inspection."},
 	{Path: "env", Kind: "manual", Summary: "Supported ANX_* environment variables and precedence."},
+	{Path: "config", Kind: "manual", Summary: "CLI config surface: default profile selection, effective settings, and clearing the persisted marker."},
 	{Path: "agent-bridge", Kind: "manual", Summary: "Install, configure, and operate the preferred per-agent `anx-agent-bridge` runtime (local adapter + check-in); workspace wake routing still lives in `anx-core`."},
 	{Path: "wake-routing", Kind: "manual", Summary: "How `@handle` wake routing works, including self-registration, verification, and troubleshooting."},
 	{Path: "draft", Kind: "manual", Summary: "Local draft staging, listing, commit, and discard workflow."},

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -706,6 +706,12 @@ func helpTopicText(topic string) (string, bool) {
 	if topic == "concepts" || topic == "primitives" || topic == "primitives guide" {
 		return conceptsGuideText() + "\n", true
 	}
+	if topic == "profiles" {
+		return profilesDocText() + "\n", true
+	}
+	if topic == "env" {
+		return envDocText() + "\n", true
+	}
 	if topic == "config" {
 		return strings.TrimSpace(`Config surface for the active CLI profile
 
@@ -718,7 +724,11 @@ Core commands:
 
 Related:
   auth list              List profiles and which is active.
-  auth default <profile> Same selection as config use.`) + "\n", true
+  auth default <profile> Same selection as config use.
+
+Docs:
+  anx meta doc profiles
+  anx meta doc env`) + "\n", true
 	}
 	if topic == "auth" {
 		return strings.TrimSpace(`Auth lifecycle and registration surface

--- a/cli/internal/app/meta_commands.go
+++ b/cli/internal/app/meta_commands.go
@@ -274,6 +274,9 @@ func (a *App) runMetaDocs(args []string) (*commandResult, error) {
 	if listFlag.value && strings.TrimSpace(searchFlag.value) != "" {
 		return nil, errnorm.Usage("invalid_flags", "use either --list or --search, not both")
 	}
+	if strings.TrimSpace(writeDir.value) != "" && (listFlag.value || strings.TrimSpace(searchFlag.value) != "") {
+		return nil, errnorm.Usage("invalid_flags", "use --write-dir only with full `anx meta docs` output, not --list or --search")
+	}
 	if listFlag.value {
 		topics := runtimeHelpDocTopics()
 		return &commandResult{Text: RuntimeHelpDocsIndexMarkdown(topics), Data: map[string]any{

--- a/cli/internal/app/meta_commands.go
+++ b/cli/internal/app/meta_commands.go
@@ -260,12 +260,40 @@ func (a *App) runMetaDocs(args []string) (*commandResult, error) {
 
 	fs := newSilentFlagSet("meta docs")
 	var writeDir trackedString
+	var listFlag trackedBool
+	var searchFlag trackedString
 	fs.Var(&writeDir, "write-dir", "Write bundled runtime help docs to the target directory")
+	fs.Var(&listFlag, "list", "List bundled runtime help topics")
+	fs.Var(&searchFlag, "search", "Search bundled runtime help topics")
 	if err := fs.Parse(args); err != nil {
 		return nil, errnorm.Usage("invalid_flags", err.Error())
 	}
 	if len(fs.Args()) > 0 {
 		return nil, errnorm.Usage("invalid_args", "unexpected positional arguments for `anx meta docs`")
+	}
+	if listFlag.value && strings.TrimSpace(searchFlag.value) != "" {
+		return nil, errnorm.Usage("invalid_flags", "use either --list or --search, not both")
+	}
+	if listFlag.value {
+		topics := runtimeHelpDocTopics()
+		return &commandResult{Text: RuntimeHelpDocsIndexMarkdown(topics), Data: map[string]any{
+			"topics": topics,
+			"source": "runtime-help-catalog",
+			"count":  len(topics),
+		}}, nil
+	}
+	if strings.TrimSpace(searchFlag.value) != "" {
+		matches := SearchRuntimeHelpDocTopics(searchFlag.value)
+		text := RuntimeHelpDocsIndexMarkdown(matches)
+		if len(matches) == 0 {
+			text = "No runtime help topics matched: " + strings.TrimSpace(searchFlag.value)
+		}
+		return &commandResult{Text: text, Data: map[string]any{
+			"query":   strings.TrimSpace(searchFlag.value),
+			"topics":  matches,
+			"source":  "runtime-help-catalog",
+			"matches": len(matches),
+		}}, nil
 	}
 
 	markdown, err := RuntimeHelpDocsMarkdown()
@@ -397,14 +425,20 @@ func metaDocsUsageText() string {
 
 Usage:
   anx meta docs [--write-dir <dir>]
+  anx meta docs --list
+  anx meta docs --search <query>
 
 Print the bundled Markdown reference built from the same runtime help catalog used by ` + "`anx help`" + `.
 
 Options:
   --write-dir <dir>   Write ` + "`runtime-help.md`" + ` into the target directory.
+  --list              List available topic names with summaries.
+  --search <query>    Search topic names, summaries, and bundled help text.
 
 Examples:
   anx meta docs
+  anx meta docs --list
+  anx meta docs --search profile
   anx meta docs --write-dir ./docs/generated`)
 }
 
@@ -419,6 +453,8 @@ Print one bundled Markdown topic from the runtime help catalog.
 
 Examples:
   anx meta doc agent-guide
+  anx meta doc profiles
+  anx meta doc env
   anx meta doc "docs trash"`)
 }
 

--- a/cli/internal/app/meta_docs_test.go
+++ b/cli/internal/app/meta_docs_test.go
@@ -103,6 +103,11 @@ func TestRunMetaDocPrintsProfileAndEnvDocs(t *testing.T) {
 	if !strings.Contains(env, "## `env`") || !strings.Contains(env, "ANX_PROFILE_PATH") || !strings.Contains(env, "ANX_JSON") {
 		t.Fatalf("expected env docs via alias output=%s", env)
 	}
+
+	config := runHelpCommand(t, "meta", "doc", "configuration")
+	if !strings.Contains(config, "## `config`") || !strings.Contains(config, "Config surface for the active CLI profile") {
+		t.Fatalf("expected config docs via alias output=%s", config)
+	}
 }
 
 func TestRunMetaDocsListAndSearch(t *testing.T) {
@@ -119,6 +124,20 @@ func TestRunMetaDocsListAndSearch(t *testing.T) {
 	}
 	if strings.Contains(searchOutput, "## `threads`") {
 		t.Fatalf("expected search index, not full docs output=%s", searchOutput)
+	}
+}
+
+func TestRunMetaDocsRejectsWriteDirWithListOrSearch(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"--json", "meta", "docs", "--list", "--write-dir", t.TempDir()},
+		{"--json", "meta", "docs", "--search", "profile", "--write-dir", t.TempDir()},
+	} {
+		stdout := runCLIForTestJSONError(t, t.TempDir(), map[string]string{}, args)
+		if !strings.Contains(stdout, "use --write-dir only with full") {
+			t.Fatalf("expected write-dir conflict error for %v, got %s", args, stdout)
+		}
 	}
 }
 

--- a/cli/internal/app/meta_docs_test.go
+++ b/cli/internal/app/meta_docs_test.go
@@ -88,6 +88,40 @@ func TestRunMetaDocPrintsAgentGuideMarkdown(t *testing.T) {
 	}
 }
 
+func TestRunMetaDocPrintsProfileAndEnvDocs(t *testing.T) {
+	t.Parallel()
+
+	profiles := runHelpCommand(t, "meta", "doc", "profiles")
+	if !strings.Contains(profiles, "## `profiles`") || !strings.Contains(profiles, "Active profile resolution") {
+		t.Fatalf("expected profiles docs output=%s", profiles)
+	}
+	if !strings.Contains(profiles, "command flags > environment variables") {
+		t.Fatalf("expected precedence guidance output=%s", profiles)
+	}
+
+	env := runHelpCommand(t, "meta", "doc", "environment")
+	if !strings.Contains(env, "## `env`") || !strings.Contains(env, "ANX_PROFILE_PATH") || !strings.Contains(env, "ANX_JSON") {
+		t.Fatalf("expected env docs via alias output=%s", env)
+	}
+}
+
+func TestRunMetaDocsListAndSearch(t *testing.T) {
+	t.Parallel()
+
+	listOutput := runHelpCommand(t, "meta", "docs", "--list")
+	if !strings.Contains(listOutput, "# ANX Runtime Help Topics") || !strings.Contains(listOutput, "`profiles`") {
+		t.Fatalf("expected topic list output=%s", listOutput)
+	}
+
+	searchOutput := runHelpCommand(t, "meta", "docs", "--search", "profile")
+	if !strings.Contains(searchOutput, "`profiles`") || !strings.Contains(searchOutput, "`config show`") {
+		t.Fatalf("expected profile search output=%s", searchOutput)
+	}
+	if strings.Contains(searchOutput, "## `threads`") {
+		t.Fatalf("expected search index, not full docs output=%s", searchOutput)
+	}
+}
+
 func TestRunMetaDocPrintsAgentBridgeMarkdown(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add searchable `anx meta docs --list` and `--search <query>` paths
- add `anx meta doc profiles` and `anx meta doc env`, with aliases like `environment`
- make `config show` expose precedence/env hints and warn from `config use` when multiple profiles exist

## Validation
- `go test ./internal/app -run 'Test(Config|RunMetaDoc|RunMetaDocs|RuntimeHelp)'`
- `make cli-check`