### PR TITLE
Improve artifacts attachment CLI ergonomics

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -101,8 +101,8 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `inbox tail` (command): Stream inbox items (SSE)
 - `artifacts list` (command): List artifacts
 - `artifacts get` (command): Get artifact metadata
-- `artifacts create` (command): Create artifact
 - `artifacts content` (command): Download artifact bytes
+- `artifacts attachments` (group): Nested generated help topic.
 - `artifacts archive` (command): Archive artifact
 - `artifacts unarchive` (command): Unarchive artifact
 - `artifacts trash` (command): Move artifact to trash
@@ -139,6 +139,8 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `events list` (local-helper): Compose backing-thread timeline reads with client-side thread/type/actor filters and preview summaries.
 - `events validate` (local-helper): Validate an `events create` payload locally from stdin or `--from-file` without sending it.
 - `events explain` (local-helper): Explain known event-type conventions, required refs, and validation hints, including when `message_posted` targets a backing-thread message stream.
+- `artifacts create` (local-helper): Create an artifact; use --file/--ref for attachment uploads or JSON for advanced artifact bodies.
+- `artifacts attachments create` (local-helper): Upload a local file as an attachment artifact via multipart form.
 - `artifacts inspect` (local-helper): Fetch artifact metadata and resolved content in one command for operator inspection.
 - `threads inspect` (local-helper): Diagnostic backing-thread bundle: compose one view from read-only thread data and related `inbox list` items.
 - `threads workspace` (local-helper): Read-only backing-thread workspace projection: context, inbox, board membership, and related-thread signals in one command.
@@ -1654,7 +1656,17 @@ Commands:
   artifacts trash          Move artifact to trash
   artifacts unarchive      Unarchive artifact
 
-Local inspection helper:
+Common attachment flow:
+  artifacts create --file <path> --ref <typed-ref>
+                            Upload a file attachment with repeatable typed refs.
+  artifacts content <id> --output <path>
+                            Download raw artifact bytes to a file.
+  artifacts content <id> --output .
+                            Download using the server-provided filename.
+
+Lower-level helpers:
+  artifacts attachments create
+                            Explicit multipart attachment upload path.
   artifacts inspect        Fetch artifact metadata and content in one call.
 
 Global flags:
@@ -3615,38 +3627,6 @@ Global flags:
   Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
 ```
 
-## `artifacts create`
-
-Create artifact
-
-```text
-Generated Help: artifacts create
-
-- Command ID: `artifacts.create`
-- CLI path: `artifacts create`
-- HTTP: `POST /artifacts`
-- Stability: `beta`
-- Input mode: `json-body`
-- Why: Store content-addressed artifact metadata and payload (bytes, text, or structured JSON).
-- Output: Returns `{ artifact }`.
-- Error codes: `auth_required`, `invalid_request`, `invalid_token`, `conflict`
-- Concepts: `artifacts`, `write`
-- Adjacent commands: `artifacts archive`, `artifacts attachments create`, `artifacts content`, `artifacts get`, `artifacts list`, `artifacts purge`, `artifacts restore`, `artifacts trash`, `artifacts unarchive`
-
-Inputs:
-  Required:
-  - body `artifact` (object)
-  - body `content_type` (string)
-  Optional:
-  - body `actor_id` (string)
-  - body `content` (any)
-
-Global flags:
-  Global flags can appear before or after the command path.
-  Examples: anx artifacts create ... ; anx --json artifacts create ... ; anx artifacts create ... --json (last two: JSON envelope on stdout)
-  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
-```
-
 ## `artifacts content`
 
 Download artifact bytes
@@ -3673,6 +3653,24 @@ Global flags:
   Global flags can appear before or after the command path.
   Examples: anx artifacts content ... ; anx --json artifacts content ... ; anx artifacts content ... --json (last two: JSON envelope on stdout)
   Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
+```
+
+## `artifacts attachments`
+
+Nested generated help topic.
+
+```text
+Generated Help: artifacts attachments
+
+Commands:
+  artifacts attachments create Upload a file attachment
+
+Global flags:
+  Global flags can appear before or after the command path.
+  Examples: anx artifacts attachments ... ; anx --json artifacts attachments ... ; anx artifacts attachments ... --json (last two: JSON envelope on stdout)
+  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
+
+Tip: `anx help <command path>` for full command-level generated details.
 ```
 
 ## `artifacts archive`
@@ -4749,6 +4747,67 @@ Flags:
 Global flags:
   Global flags can appear before or after the command path.
   Examples: anx events explain ... ; anx --json events explain ... ; anx events explain ... --json (last two: JSON envelope on stdout)
+  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
+```
+
+## `artifacts create`
+
+Create an artifact; use --file/--ref for attachment uploads or JSON for advanced artifact bodies.
+
+```text
+Local Help: artifacts create
+
+- Kind: `local helper`
+- Summary: Create an artifact; use --file/--ref for attachment uploads or JSON for advanced artifact bodies.
+- Composition: Routes the common file attachment path through the multipart attachment endpoint while preserving the contract-level JSON create path for text, structured, or binary artifact bodies.
+- JSON body: With --file, posts multipart attachment data to `artifacts.attachments.create`; without --file, sends advanced JSON `{ artifact, content_type, content }` to `artifacts.create`.
+- Examples:
+  - `anx artifacts create --file ./photo.jpg --ref topic:<topic-id>`
+  - `anx artifacts create --file ./evidence.pdf --ref card:<card-id> --summary "Evidence"`
+  - `cat artifact.json | anx artifacts create`
+
+Flags:
+  --file <path>                Upload a local file as kind=attachment via multipart form.
+  --ref <typed-ref>            Typed ref to attach to, repeatable.
+  --refs <json>                Compatibility form: JSON array of typed refs.
+  --summary <text>             Optional attachment summary.
+  --artifact <json>            Optional JSON object merged into attachment metadata; refs and kind are ignored by the server.
+  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
+
+
+Global flags:
+  Global flags can appear before or after the command path.
+  Examples: anx artifacts create ... ; anx --json artifacts create ... ; anx artifacts create ... --json (last two: JSON envelope on stdout)
+  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
+```
+
+## `artifacts attachments create`
+
+Upload a local file as an attachment artifact via multipart form.
+
+```text
+Local Help: artifacts attachments create
+
+- Kind: `local helper`
+- Summary: Upload a local file as an attachment artifact via multipart form.
+- Composition: Posts to `POST /artifacts/attachments`, which stores the file bytes and creates kind=attachment artifact metadata.
+- JSON body: Multipart form fields: `refs`, `file`, optional `summary`, `artifact`, and `actor_id`.
+- Examples:
+  - `anx artifacts attachments create --file ./notes.md --ref thread:<thread-id>`
+  - `anx artifacts attachments create --file ./photo.jpg --refs '["topic:<topic-id>"]'`
+
+Flags:
+  --file <path>                Path to the file to upload.
+  --ref <typed-ref>            Typed ref to attach to, repeatable.
+  --refs <json>                Compatibility form: JSON array of typed refs.
+  --summary <text>             Optional attachment summary.
+  --artifact <json>            Optional JSON object merged into attachment metadata; refs and kind are ignored by the server.
+  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
+
+
+Global flags:
+  Global flags can appear before or after the command path.
+  Examples: anx artifacts attachments create ... ; anx --json artifacts attachments create ... ; anx artifacts attachments create ... --json (last two: JSON envelope on stdout)
   Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
 ```
 

--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -4773,6 +4773,7 @@ Flags:
   --summary <text>             Optional attachment summary.
   --artifact <json>            Optional JSON object merged into attachment metadata; refs and kind are ignored by the server.
   --actor-id <actor-id>        Actor id; defaults from the active profile when available.
+  --from-file <path>           Advanced JSON artifact create body from file; cannot be combined with --file.
 
 
 Global flags:

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -442,6 +442,7 @@ var localHelperTopics = []localHelperTopic{
 			{Name: "--summary <text>", Description: "Optional attachment summary."},
 			{Name: "--artifact <json>", Description: "Optional JSON object merged into attachment metadata; refs and kind are ignored by the server."},
 			{Name: "--actor-id <actor-id>", Description: "Actor id; defaults from the active profile when available."},
+			{Name: "--from-file <path>", Description: "Advanced JSON artifact create body from file; cannot be combined with --file."},
 		},
 	},
 	{

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -426,6 +426,43 @@ var localHelperTopics = []localHelperTopic{
 		},
 	},
 	{
+		Path:        "artifacts create",
+		Summary:     "Create an artifact; use --file/--ref for attachment uploads or JSON for advanced artifact bodies.",
+		JSONShape:   "With --file, posts multipart attachment data to `artifacts.attachments.create`; without --file, sends advanced JSON `{ artifact, content_type, content }` to `artifacts.create`.",
+		Composition: "Routes the common file attachment path through the multipart attachment endpoint while preserving the contract-level JSON create path for text, structured, or binary artifact bodies.",
+		Examples: []string{
+			`anx artifacts create --file ./photo.jpg --ref topic:<topic-id>`,
+			`anx artifacts create --file ./evidence.pdf --ref card:<card-id> --summary "Evidence"`,
+			`cat artifact.json | anx artifacts create`,
+		},
+		Flags: []localHelperFlag{
+			{Name: "--file <path>", Description: "Upload a local file as kind=attachment via multipart form."},
+			{Name: "--ref <typed-ref>", Description: "Typed ref to attach to, repeatable."},
+			{Name: "--refs <json>", Description: "Compatibility form: JSON array of typed refs."},
+			{Name: "--summary <text>", Description: "Optional attachment summary."},
+			{Name: "--artifact <json>", Description: "Optional JSON object merged into attachment metadata; refs and kind are ignored by the server."},
+			{Name: "--actor-id <actor-id>", Description: "Actor id; defaults from the active profile when available."},
+		},
+	},
+	{
+		Path:        "artifacts attachments create",
+		Summary:     "Upload a local file as an attachment artifact via multipart form.",
+		JSONShape:   "Multipart form fields: `refs`, `file`, optional `summary`, `artifact`, and `actor_id`.",
+		Composition: "Posts to `POST /artifacts/attachments`, which stores the file bytes and creates kind=attachment artifact metadata.",
+		Examples: []string{
+			`anx artifacts attachments create --file ./notes.md --ref thread:<thread-id>`,
+			`anx artifacts attachments create --file ./photo.jpg --refs '["topic:<topic-id>"]'`,
+		},
+		Flags: []localHelperFlag{
+			{Name: "--file <path>", Description: "Path to the file to upload."},
+			{Name: "--ref <typed-ref>", Description: "Typed ref to attach to, repeatable."},
+			{Name: "--refs <json>", Description: "Compatibility form: JSON array of typed refs."},
+			{Name: "--summary <text>", Description: "Optional attachment summary."},
+			{Name: "--artifact <json>", Description: "Optional JSON object merged into attachment metadata; refs and kind are ignored by the server."},
+			{Name: "--actor-id <actor-id>", Description: "Actor id; defaults from the active profile when available."},
+		},
+	},
+	{
 		Path:        "artifacts inspect",
 		Summary:     "Fetch artifact metadata and resolved content in one command for operator inspection.",
 		JSONShape:   "`artifact`, `content`, `content_headers`, `content_text`, `content_base64`",
@@ -942,7 +979,17 @@ func localGroupHelpSupplement(topic string) string {
   Raw ` + "`events create`" + ` is a contract escape hatch. For ordinary discussion, use ` + "`anx topics message <topic-id>`" + `, ` + "`anx docs message <document-id>`" + `, or ` + "`anx cards message <card-id>`" + ` instead of hand-authoring a ` + "`message_posted`" + ` event.
   For details: ` + "`anx events explain <event-type>`")
 	case "artifacts":
-		return strings.TrimSpace(`Local inspection helper:
+		return strings.TrimSpace(`Common attachment flow:
+  artifacts create --file <path> --ref <typed-ref>
+                            Upload a file attachment with repeatable typed refs.
+  artifacts content <id> --output <path>
+                            Download raw artifact bytes to a file.
+  artifacts content <id> --output .
+                            Download using the server-provided filename.
+
+Lower-level helpers:
+  artifacts attachments create
+                            Explicit multipart attachment upload path.
   artifacts inspect        Fetch artifact metadata and content in one call.`)
 	case "docs":
 		return strings.TrimSpace(`Local inspection helpers:

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -998,38 +998,63 @@ func (a *App) runArtifactsAttachmentsCommand(ctx context.Context, args []string,
 	sub := strings.TrimSpace(strings.ToLower(args[0]))
 	switch sub {
 	case "create":
-		fs := newSilentFlagSet("artifacts attachments create")
-		var refsJSON trackedString
-		var filePath trackedString
-		var summary trackedString
-		var artifactJSON trackedString
-		var actorIDFlag trackedString
-		fs.Var(&refsJSON, "refs", `JSON array of typed refs, e.g. ["thread:<uuid>"]`)
-		fs.Var(&filePath, "file", "Path to file to upload")
-		fs.Var(&summary, "summary", "Optional attachment summary")
-		fs.Var(&artifactJSON, "artifact", "Optional JSON object merged into artifact metadata")
-		fs.Var(&actorIDFlag, "actor-id", "Actor id")
-		if err := fs.Parse(args[1:]); err != nil {
-			return nil, "artifacts attachments create", errnorm.Usage("invalid_flags", err.Error())
-		}
-		if len(fs.Args()) > 0 {
-			return nil, "artifacts attachments create", errnorm.Usage("invalid_args", "unexpected positional arguments")
-		}
-		if strings.TrimSpace(refsJSON.value) == "" {
-			return nil, "artifacts attachments create", errnorm.Usage("invalid_request", "--refs is required")
-		}
-		if strings.TrimSpace(filePath.value) == "" {
-			return nil, "artifacts attachments create", errnorm.Usage("invalid_request", "--file is required")
-		}
-		actorID, err := resolveActorIDAlias(actorIDFlag.value, cfg)
-		if err != nil {
-			return nil, "artifacts attachments create", err
-		}
-		result, callErr := a.invokeArtifactAttachmentCreate(ctx, cfg, refsJSON.value, filePath.value, summary.value, artifactJSON.value, actorID)
+		result, callErr := a.runArtifactAttachmentCreateFlags(ctx, cfg, args[1:], "artifacts attachments create")
 		return result, "artifacts attachments create", callErr
 	default:
 		return nil, "artifacts attachments", errnorm.Usage("unknown_command", fmt.Sprintf("unknown artifacts attachments subcommand %q", args[0]))
 	}
+}
+
+func (a *App) runArtifactAttachmentCreateFlags(ctx context.Context, cfg config.Resolved, args []string, commandName string) (*commandResult, error) {
+	fs := newSilentFlagSet(commandName)
+	var refsJSON trackedString
+	var refs trackedStrings
+	var filePath trackedString
+	var summary trackedString
+	var artifactJSON trackedString
+	var actorIDFlag trackedString
+	fs.Var(&refsJSON, "refs", `JSON array of typed refs, e.g. ["thread:<uuid>"]`)
+	fs.Var(&refs, "ref", "Typed ref to attach to, repeatable")
+	fs.Var(&filePath, "file", "Path to file to upload")
+	fs.Var(&summary, "summary", "Optional attachment summary")
+	fs.Var(&artifactJSON, "artifact", "Optional JSON object merged into artifact metadata")
+	fs.Var(&actorIDFlag, "actor-id", "Actor id")
+	if err := fs.Parse(args); err != nil {
+		return nil, errnorm.Usage("invalid_flags", err.Error())
+	}
+	if len(fs.Args()) > 0 {
+		return nil, errnorm.Usage("invalid_args", fmt.Sprintf("unexpected positional arguments for `anx %s`", commandName))
+	}
+	if strings.TrimSpace(filePath.value) == "" {
+		return nil, errnorm.Usage("invalid_request", "--file is required")
+	}
+	resolvedRefsJSON, err := artifactAttachmentRefsJSON(refsJSON.value, refs.values)
+	if err != nil {
+		return nil, err
+	}
+	actorID, err := resolveActorIDAlias(actorIDFlag.value, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return a.invokeArtifactAttachmentCreate(ctx, cfg, resolvedRefsJSON, filePath.value, summary.value, artifactJSON.value, actorID)
+}
+
+func artifactAttachmentRefsJSON(refsJSON string, refs []string) (string, error) {
+	refsJSON = strings.TrimSpace(refsJSON)
+	if refsJSON != "" && len(refs) > 0 {
+		return "", errnorm.Usage("invalid_flags", "use either --ref or --refs, not both")
+	}
+	if len(refs) > 0 {
+		encoded, err := json.Marshal(refs)
+		if err != nil {
+			return "", errnorm.Wrap(errnorm.KindLocal, "refs_encode_failed", "failed to encode refs", err)
+		}
+		return string(encoded), nil
+	}
+	if refsJSON == "" {
+		return "", errnorm.Usage("invalid_request", "--ref is required (or pass --refs JSON)")
+	}
+	return refsJSON, nil
 }
 
 func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {
@@ -1109,6 +1134,10 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 		)
 		return result, "artifacts get", callErr
 	case "create":
+		if artifactCreateUsesFileFlags(args[1:]) {
+			result, callErr := a.runArtifactAttachmentCreateFlags(ctx, cfg, args[1:], "artifacts create")
+			return addResourceURLToResult(cfg, "artifacts.attachments.create", result), "artifacts create", callErr
+		}
 		body, err := a.parseJSONBodyInput(args[1:], "artifacts create")
 		if err != nil {
 			return nil, "artifacts create", err
@@ -1122,7 +1151,7 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 		fs.Var(&artifactIDFlag, "artifact-id", "Artifact id")
 		fs.StringVar(&outputPath, "o", "", "Write raw artifact bytes to file")
 		fs.StringVar(&outputPath, "output", "", "Write raw artifact bytes to file")
-		if err := fs.Parse(args[1:]); err != nil {
+		if err := fs.Parse(reorderArtifactContentFlags(args[1:])); err != nil {
 			return nil, "artifacts content", errnorm.Usage("invalid_flags", err.Error())
 		}
 		positionals := fs.Args()
@@ -1332,6 +1361,46 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 	default:
 		return nil, "artifacts", artifactsSubcommandSpec.unknownError(args[0])
 	}
+}
+
+func artifactCreateUsesFileFlags(args []string) bool {
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg == "--file" || strings.HasPrefix(arg, "--file=") || arg == "--ref" || strings.HasPrefix(arg, "--ref=") || arg == "--refs" || strings.HasPrefix(arg, "--refs=") {
+			return true
+		}
+	}
+	return false
+}
+
+func reorderArtifactContentFlags(args []string) []string {
+	knownValueFlags := map[string]struct{}{
+		"-o":            {},
+		"--output":      {},
+		"--artifact-id": {},
+	}
+	flags := make([]string, 0, len(args))
+	positionals := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		if arg == "" {
+			continue
+		}
+		if strings.HasPrefix(arg, "--output=") || strings.HasPrefix(arg, "--artifact-id=") || strings.HasPrefix(arg, "-o=") {
+			flags = append(flags, arg)
+			continue
+		}
+		if _, ok := knownValueFlags[arg]; ok {
+			flags = append(flags, arg)
+			if i+1 < len(args) {
+				i++
+				flags = append(flags, args[i])
+			}
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	return append(flags, positionals...)
 }
 
 func (a *App) runBoardsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {

--- a/cli/internal/app/resource_commands.go
+++ b/cli/internal/app/resource_commands.go
@@ -1151,7 +1151,11 @@ func (a *App) runArtifactsCommand(ctx context.Context, args []string, cfg config
 		fs.Var(&artifactIDFlag, "artifact-id", "Artifact id")
 		fs.StringVar(&outputPath, "o", "", "Write raw artifact bytes to file")
 		fs.StringVar(&outputPath, "output", "", "Write raw artifact bytes to file")
-		if err := fs.Parse(reorderArtifactContentFlags(args[1:])); err != nil {
+		contentArgs, reorderErr := reorderArtifactContentFlags(args[1:])
+		if reorderErr != nil {
+			return nil, "artifacts content", reorderErr
+		}
+		if err := fs.Parse(contentArgs); err != nil {
 			return nil, "artifacts content", errnorm.Usage("invalid_flags", err.Error())
 		}
 		positionals := fs.Args()
@@ -1373,7 +1377,7 @@ func artifactCreateUsesFileFlags(args []string) bool {
 	return false
 }
 
-func reorderArtifactContentFlags(args []string) []string {
+func reorderArtifactContentFlags(args []string) ([]string, error) {
 	knownValueFlags := map[string]struct{}{
 		"-o":            {},
 		"--output":      {},
@@ -1398,9 +1402,12 @@ func reorderArtifactContentFlags(args []string) []string {
 			}
 			continue
 		}
+		if strings.HasPrefix(arg, "-") {
+			return nil, errnorm.Usage("invalid_flags", fmt.Sprintf("flag provided but not defined: %s", arg))
+		}
 		positionals = append(positionals, arg)
 	}
-	return append(flags, positionals...)
+	return append(flags, positionals...), nil
 }
 
 func (a *App) runBoardsCommand(ctx context.Context, args []string, cfg config.Resolved) (*commandResult, string, error) {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -5404,6 +5404,59 @@ func TestArtifactsCreateFileRefUsesAttachmentEndpoint(t *testing.T) {
 	}
 }
 
+func TestArtifactsCreateFromFilePreservesAdvancedJSONPath(t *testing.T) {
+	t.Parallel()
+
+	bodyFile := filepath.Join(t.TempDir(), "artifact.json")
+	if err := os.WriteFile(bodyFile, []byte(`{"artifact":{"kind":"note","refs":["topic:topic_1"]},"content_type":"text","content":"hello"}`), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/artifacts" {
+			http.NotFound(w, r)
+			return
+		}
+		var got map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if got["content"] != "hello" {
+			t.Fatalf("expected JSON artifact body, got %#v", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"artifact":{"id":"artifact_json","kind":"note"}}`))
+	}))
+	defer server.Close()
+
+	raw := runCLIForTest(t, t.TempDir(), map[string]string{}, nil, []string{
+		"--json", "--base-url", server.URL,
+		"artifacts", "create", "--from-file", bodyFile,
+	})
+	assertEnvelopeOK(t, raw)
+}
+
+func TestArtifactsContentUnknownFlagFailsBeforeNetwork(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-a", `{"agent":"agent-a","actor_id":"actor_a","base_url":"http://127.0.0.1:1","access_token":"token","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+
+	raw := runCLIForTest(t, home, nil, nil, []string{
+		"--json",
+		"artifacts", "content", "--bogus",
+	})
+	payload := assertEnvelopeError(t, raw)
+	errObj, _ := payload["error"].(map[string]any)
+	if got := anyStringValue(errObj["code"]); got != "invalid_flags" {
+		t.Fatalf("expected invalid_flags, got %#v", payload)
+	}
+	if got := anyStringValue(errObj["message"]); !strings.Contains(got, "bogus") {
+		t.Fatalf("expected unknown flag in error message, got %#v", payload)
+	}
+}
+
 func TestArtifactsContentOutputDotUsesContentDispositionFilename(t *testing.T) {
 	expected := []byte("download body")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -5346,6 +5346,145 @@ func TestArtifactContentJSONOutputFile(t *testing.T) {
 	}
 }
 
+func TestArtifactsCreateFileRefUsesAttachmentEndpoint(t *testing.T) {
+	t.Parallel()
+
+	uploaded := []byte("menu bytes")
+	filePath := filepath.Join(t.TempDir(), "menu.txt")
+	if err := os.WriteFile(filePath, uploaded, 0o600); err != nil {
+		t.Fatalf("write upload file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/artifacts/attachments" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("refs"); got != `["topic:topic_1","card:card_1"]` {
+			t.Fatalf("unexpected refs field: %q", got)
+		}
+		if got := r.FormValue("summary"); got != "Menu" {
+			t.Fatalf("unexpected summary field: %q", got)
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		defer file.Close()
+		if header.Filename != "menu.txt" {
+			t.Fatalf("unexpected uploaded filename: %q", header.Filename)
+		}
+		got, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("read form file: %v", err)
+		}
+		if !bytes.Equal(got, uploaded) {
+			t.Fatalf("unexpected uploaded bytes: got=%q want=%q", got, uploaded)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"artifact":{"id":"artifact_menu","kind":"attachment","filename":"menu.txt"}}`))
+	}))
+	defer server.Close()
+
+	raw := runCLIForTest(t, t.TempDir(), map[string]string{}, nil, []string{
+		"--json", "--base-url", server.URL,
+		"artifacts", "create",
+		"--file", filePath,
+		"--ref", "topic:topic_1",
+		"--ref", "card:card_1",
+		"--summary", "Menu",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	if got := anyStringValue(payload["command"]); got != "artifacts create" {
+		t.Fatalf("unexpected command label: %#v", payload)
+	}
+}
+
+func TestArtifactsContentOutputDotUsesContentDispositionFilename(t *testing.T) {
+	expected := []byte("download body")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/artifacts/artifact-named/content" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Disposition", `attachment; filename="report.txt"`)
+		_, _ = w.Write(expected)
+	}))
+	defer server.Close()
+
+	cwd := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+
+	out := runCLIForTest(t, t.TempDir(), map[string]string{}, nil, []string{
+		"--base-url", server.URL,
+		"artifacts", "content", "artifact-named", "--output", ".",
+	})
+	if !strings.Contains(out, "wrote 13 bytes to report.txt") {
+		t.Fatalf("expected write summary, got %q", out)
+	}
+	got, err := os.ReadFile(filepath.Join(cwd, "report.txt"))
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("unexpected output bytes: got=%q want=%q", got, expected)
+	}
+}
+
+func TestArtifactsContentOutputDotFallsBackToMetadataFilename(t *testing.T) {
+	expected := []byte("metadata fallback")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/artifacts/artifact-meta/content":
+			_, _ = w.Write(expected)
+		case r.Method == http.MethodGet && r.URL.Path == "/artifacts/artifact-meta":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"artifact":{"id":"artifact-meta","filename":"fallback.bin"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cwd := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+
+	raw := runCLIForTest(t, t.TempDir(), map[string]string{}, nil, []string{
+		"--json", "--base-url", server.URL,
+		"artifacts", "content", "artifact-meta", "--output", ".",
+	})
+	payload := assertEnvelopeOK(t, raw)
+	data, _ := payload["data"].(map[string]any)
+	if got := anyStringValue(data["output_path"]); got != "fallback.bin" {
+		t.Fatalf("expected metadata fallback output path, got %#v", data)
+	}
+	got, err := os.ReadFile(filepath.Join(cwd, "fallback.bin"))
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("unexpected output bytes: got=%q want=%q", got, expected)
+	}
+}
+
 func TestArtifactsInspectCommand(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/resource_transport.go
+++ b/cli/internal/app/resource_transport.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -48,6 +49,13 @@ func (a *App) invokeArtifactContent(ctx context.Context, cfg config.Resolved, co
 	}
 
 	outPath := strings.TrimSpace(outputPath)
+	if outPath == "." {
+		resolved, resolveErr := a.resolveArtifactContentOutputPath(ctx, authCfg, strings.TrimSpace(pathParams["artifact_id"]), resp.Headers)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		outPath = resolved
+	}
 	if outPath != "" {
 		if err := os.WriteFile(outPath, body, 0o644); err != nil {
 			return nil, errnorm.Wrap(errnorm.KindLocal, "artifact_content_write_failed", fmt.Sprintf("failed to write %s", outPath), err)
@@ -84,6 +92,76 @@ func (a *App) invokeArtifactContent(ctx context.Context, cfg config.Resolved, co
 	}
 	text := fmt.Sprintf("%s status: %d\nbytes: %d", commandName, resp.StatusCode, len(body))
 	return &commandResult{Text: text, Data: data}, nil
+}
+
+func (a *App) resolveArtifactContentOutputPath(ctx context.Context, cfg config.Resolved, artifactID string, headers http.Header) (string, error) {
+	if filename := artifactContentDispositionFilename(headers); filename != "" {
+		return filename, nil
+	}
+	filename, err := a.artifactFilenameFromMetadata(ctx, cfg, artifactID)
+	if err != nil {
+		return "", err
+	}
+	if filename == "" {
+		return "", errnorm.Usage("artifact_filename_unavailable", "--output . requires Content-Disposition filename or artifact filename metadata")
+	}
+	return filename, nil
+}
+
+func artifactContentDispositionFilename(headers http.Header) string {
+	raw := strings.TrimSpace(headers.Get("Content-Disposition"))
+	if raw == "" {
+		return ""
+	}
+	_, params, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return ""
+	}
+	return cleanArtifactOutputFilename(firstNonEmpty(params["filename"], params["filename*"]))
+}
+
+func (a *App) artifactFilenameFromMetadata(ctx context.Context, cfg config.Resolved, artifactID string) (string, error) {
+	client, err := httpclient.New(cfg)
+	if err != nil {
+		return "", errnorm.Wrap(errnorm.KindLocal, "http_client_init_failed", "failed to initialize HTTP client", err)
+	}
+	callCtx, cancel := httpclient.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	resp, invokeErr := client.RawCall(callCtx, httpclient.RawRequest{
+		Method:  http.MethodGet,
+		Path:    "/artifacts/" + url.PathEscape(strings.TrimSpace(artifactID)),
+		Headers: generatedHeaders(cfg),
+	})
+	if invokeErr != nil {
+		return "", errnorm.Wrap(errnorm.KindNetwork, "request_failed", "artifact metadata request failed", invokeErr)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", errnorm.FromHTTPFailure(resp.StatusCode, resp.Body)
+	}
+	parsed := parseResponseBody(resp.Body)
+	body, _ := parsed.(map[string]any)
+	artifact := extractNestedMap(body, "artifact")
+	if artifact == nil {
+		artifact = body
+	}
+	for _, key := range []string{"filename", "original_filename", "name"} {
+		if filename := cleanArtifactOutputFilename(anyString(artifact[key])); filename != "" {
+			return filename, nil
+		}
+	}
+	return "", nil
+}
+
+func cleanArtifactOutputFilename(filename string) string {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return ""
+	}
+	filename = filepath.Base(filename)
+	if filename == "." || filename == string(filepath.Separator) {
+		return ""
+	}
+	return filename
 }
 
 func (a *App) invokeRawJSON(ctx context.Context, cfg config.Resolved, commandName string, method string, path string, body any) (*commandResult, error) {

--- a/cli/internal/app/subcommand_guidance.go
+++ b/cli/internal/app/subcommand_guidance.go
@@ -148,8 +148,8 @@ var threadsSubcommandSpec = subcommandSpec{
 
 var artifactsSubcommandSpec = subcommandSpec{
 	command:  "artifacts",
-	valid:    []string{"list", "get", "create", "content", "inspect", "archive", "unarchive", "trash", "restore", "purge"},
-	examples: []string{"anx artifacts list --kind attachment", "anx artifacts attachments create --refs '[\"thread:<id>\"]' --file ./notes.md", "anx artifacts content --artifact-id <id> --output ./out.bin"},
+	valid:    []string{"list", "get", "create", "content", "inspect", "attachments", "attachments create", "archive", "unarchive", "trash", "restore", "purge"},
+	examples: []string{"anx artifacts list --kind attachment", "anx artifacts create --file ./notes.md --ref thread:<id>", "anx artifacts attachments create --file ./notes.md --ref thread:<id>", "anx artifacts content --artifact-id <id> --output ./out.bin"},
 	aliases: map[string]string{
 		"ls":   "list",
 		"show": "inspect",


### PR DESCRIPTION
## Summary
- route `anx artifacts create --file ... --ref ...` through the existing multipart attachment upload endpoint
- make attachment upload help discoverable via `anx help artifacts`, `anx help artifacts create`, and `anx help artifacts attachments create`
- support `anx artifacts content <id> --output .` using Content-Disposition filename or artifact filename metadata

## Validation
- `go test ./internal/app -run 'TestArtifact|TestArtifacts|TestRunMetaDoc|TestRuntimeHelp'`
- `make cli-check`