### PR TITLE
Improve CLI slug ergonomics

### DIFF
--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -314,7 +314,9 @@ func TestURLCommandPrintsShareableURL(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cards/card:card_123"):
-			_, _ = w.Write([]byte(`{"card":{"id":"card_123","board_ref":"board:board_123","title":"Card URL"}}`))
+			_, _ = w.Write([]byte(`{"card":{"id":"98341768-646f-48e5-8b98-ddda78ff0fcd","ref":"card:cli-json-body-input","handle":"cli-json-body-input","board_ref":"board:869c2f55-1dd6-479f-9c10-57b1988472e9","title":"Card URL"}}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/boards/869c2f55-1dd6-479f-9c10-57b1988472e9"):
+			_, _ = w.Write([]byte(`{"board":{"id":"869c2f55-1dd6-479f-9c10-57b1988472e9","ref":"board:anx-features","handle":"anx-features","title":"ANX Features"}}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -324,9 +326,66 @@ func TestURLCommandPrintsShareableURL(t *testing.T) {
 	home := t.TempDir()
 	hostedBase := server.URL + "/ws/david-zhang/personal"
 	out := strings.TrimSpace(runCLIForTest(t, home, nil, nil, []string{"--base-url", hostedBase, "url", "card", "card:card_123"}))
-	expected := server.URL + "/o/david-zhang/w/personal/boards/board_123?card=card_123"
+	expected := server.URL + "/o/david-zhang/w/personal/boards/anx-features?card=cli-json-body-input"
 	if out != expected {
 		t.Fatalf("expected %q, got %q", expected, out)
+	}
+}
+
+func TestGetCommandResolvesUniqueSlugPrefixAfterNotFound(t *testing.T) {
+	t.Parallel()
+
+	seen := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		seen = append(seen, r.URL.EscapedPath())
+		switch r.URL.EscapedPath() {
+		case "/topics/anx-dog":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"topic not found"}}`))
+		case "/topics":
+			_, _ = w.Write([]byte(`{"topics":[{"id":"topic_internal_123","ref":"topic:anx-dogfooding","handle":"anx-dogfooding","title":"ANX Dogfooding"}]}`))
+		case "/topics/topic:anx-dogfooding":
+			_, _ = w.Write([]byte(`{"topic":{"id":"topic_internal_123","ref":"topic:anx-dogfooding","handle":"anx-dogfooding","title":"ANX Dogfooding"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", server.URL, "topics", "get", "anx-dog"}))
+	topic := asMap(asMap(payload["data"])["topic"])
+	if got := anyStringValue(topic["ref"]); got != "topic:anx-dogfooding" {
+		t.Fatalf("expected resolved topic ref, got %#v", payload)
+	}
+	want := []string{"/topics/anx-dog", "/topics", "/topics/topic:anx-dogfooding"}
+	if strings.Join(seen, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected request sequence:\n%v", seen)
+	}
+}
+
+func TestGetCommandRejectsAmbiguousSlugPrefix(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/cards/cli":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"card not found"}}`))
+		case "/cards":
+			_, _ = w.Write([]byte(`{"cards":[{"id":"c1","ref":"card:cli-json-body-input","handle":"cli-json-body-input"},{"id":"c2","ref":"card:cli-url-output","handle":"cli-url-output"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	payload := assertEnvelopeError(t, runCLIForTest(t, home, nil, nil, []string{"--json", "--base-url", server.URL, "cards", "get", "cli"}))
+	if got := anyStringValue(asMap(payload["error"])["code"]); got != "ambiguous_resource_prefix" {
+		t.Fatalf("expected ambiguous_resource_prefix, got %#v", payload)
 	}
 }
 

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -389,6 +389,36 @@ func TestGetCommandRejectsAmbiguousSlugPrefix(t *testing.T) {
 	}
 }
 
+func TestMutatingCommandDoesNotRetrySlugPrefixAfterNotFound(t *testing.T) {
+	t.Parallel()
+
+	seen := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		seen = append(seen, r.URL.EscapedPath())
+		switch r.URL.EscapedPath() {
+		case "/cards/cli/trash":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"card not found"}}`))
+		case "/cards":
+			t.Fatalf("mutating command must not list resources for prefix retry")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	payload := assertEnvelopeError(t, runCLIForTest(t, home, nil, strings.NewReader(`{"reason":"wrong id"}`), []string{"--json", "--base-url", server.URL, "cards", "trash", "cli"}))
+	if got := anyStringValue(asMap(payload["error"])["code"]); got != "not_found" {
+		t.Fatalf("expected original not_found error, got %#v", payload)
+	}
+	want := []string{"/cards/cli/trash"}
+	if strings.Join(seen, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected request sequence:\n%v", seen)
+	}
+}
+
 func TestCardsGetPassesTypedRefAndHandleToCore(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/app/resource_locator.go
+++ b/cli/internal/app/resource_locator.go
@@ -298,13 +298,29 @@ func (a *App) resolveLocatorForURL(ctx context.Context, cfg config.Resolved, loc
 				return loc, err
 			}
 			card := extractNestedMap(commandResultBody(result), "card")
-			if id := strings.TrimSpace(anyString(card["id"])); id != "" {
+			if id := publicLocatorID(card, "card"); id != "" {
 				loc.ID = id
 			}
-			loc.BoardID = refID(anyString(card["board_ref"]))
+			loc.BoardID = firstNonEmpty(refID(anyString(card["board_ref"])), strings.TrimSpace(anyString(card["board_handle"])))
+			if publicBoardID, err := a.resolvePublicBoardLocatorID(ctx, cfg, loc.BoardID); err == nil && publicBoardID != "" {
+				loc.BoardID = publicBoardID
+			}
 		}
 	}
 	return loc, nil
+}
+
+func (a *App) resolvePublicBoardLocatorID(ctx context.Context, cfg config.Resolved, boardID string) (string, error) {
+	boardID = strings.TrimSpace(boardID)
+	if boardID == "" {
+		return "", nil
+	}
+	result, err := a.invokeTypedJSONWithIDResolution(ctx, cfg, "boards get", "boards.get", "board_id", boardID, boardIDLookupSpec, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	board := extractNestedMap(commandResultBody(result), "board")
+	return publicLocatorID(board, "board"), nil
 }
 
 func addResourceURLToResult(cfg config.Resolved, commandID string, result *commandResult) *commandResult {
@@ -339,32 +355,57 @@ func locatorFromCommandBody(commandID string, body map[string]any) (resourceLoca
 	switch strings.TrimSpace(commandID) {
 	case "boards.create":
 		board := extractNestedMap(body, "board")
-		id := strings.TrimSpace(anyString(board["id"]))
+		id := publicLocatorID(board, "board")
 		return resourceLocator{Kind: "board", ID: id}, id != ""
 	case "topics.create":
 		topic := extractNestedMap(body, "topic")
-		id := strings.TrimSpace(anyString(topic["id"]))
+		id := publicLocatorID(topic, "topic")
 		return resourceLocator{Kind: "topic", ID: id}, id != ""
 	case "docs.create":
 		document := extractNestedMap(body, "document")
-		id := strings.TrimSpace(anyString(document["id"]))
+		id := publicLocatorID(document, "document")
 		return resourceLocator{Kind: "document", ID: id}, id != ""
 	case "artifacts.create":
 		artifact := extractNestedMap(body, "artifact")
-		id := strings.TrimSpace(anyString(artifact["id"]))
+		id := publicLocatorID(artifact, "artifact")
 		return resourceLocator{Kind: "artifact", ID: id}, id != ""
 	case "cards.create", "boards.cards.create":
 		card := extractNestedMap(body, "card")
-		id := strings.TrimSpace(anyString(card["id"]))
-		boardID := refID(anyString(card["board_ref"]))
+		id := publicLocatorID(card, "card")
+		boardID := firstNonEmpty(refID(anyString(card["board_ref"])), strings.TrimSpace(anyString(card["board_handle"])))
 		if boardID == "" {
 			board := extractNestedMap(body, "board")
-			boardID = strings.TrimSpace(anyString(board["id"]))
+			boardID = publicLocatorID(board, "board")
 		}
 		return resourceLocator{Kind: "card", ID: id, BoardID: boardID}, id != "" && boardID != ""
 	default:
 		return resourceLocator{}, false
 	}
+}
+
+func publicLocatorID(obj map[string]any, kind string) string {
+	if obj == nil {
+		return ""
+	}
+	kind = canonicalResourceKind(kind)
+	if kind == "" {
+		return strings.TrimSpace(anyString(obj["id"]))
+	}
+	if ref := refID(anyString(obj["ref"])); ref != "" {
+		return ref
+	}
+	if handle := strings.TrimSpace(anyString(obj["handle"])); handle != "" {
+		return handle
+	}
+	refKey := kind + "_ref"
+	if ref := refID(anyString(obj[refKey])); ref != "" {
+		return ref
+	}
+	handleKey := kind + "_handle"
+	if handle := strings.TrimSpace(anyString(obj[handleKey])); handle != "" {
+		return handle
+	}
+	return strings.TrimSpace(anyString(obj["id"]))
 }
 
 func resourceURL(cfg config.Resolved, loc resourceLocator) (string, error) {

--- a/cli/internal/app/resource_transport.go
+++ b/cli/internal/app/resource_transport.go
@@ -308,7 +308,7 @@ func (a *App) invokeTypedJSONWithIDResolution(
 ) (*commandResult, error) {
 	pathParams := map[string]string{pathParamName: rawID}
 	result, err := a.invokeTypedJSON(ctx, cfg, commandName, commandID, pathParams, query, body)
-	if err == nil || !isRemoteNotFound(err) || strings.TrimSpace(rawID) == "" {
+	if err == nil || !commandAllowsPrefixRetry(commandID) || !isRemoteNotFound(err) || strings.TrimSpace(rawID) == "" {
 		return result, err
 	}
 	resolvedID, resolveErr := a.resolveUniqueResourcePrefix(ctx, cfg, lookupSpec, rawID, pathParams)
@@ -364,6 +364,10 @@ func isRemoteNotFound(err error) bool {
 	default:
 		return false
 	}
+}
+
+func commandAllowsPrefixRetry(commandID string) bool {
+	return strings.EqualFold(resolveCommandMethod(commandID), http.MethodGet)
 }
 
 func (a *App) resolveUniqueResourcePrefix(ctx context.Context, cfg config.Resolved, spec resourceIDLookupSpec, rawID string, originalPathParams map[string]string) (string, error) {

--- a/cli/internal/app/resource_transport.go
+++ b/cli/internal/app/resource_transport.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -305,8 +306,20 @@ func (a *App) invokeTypedJSONWithIDResolution(
 	query []queryParam,
 	body any,
 ) (*commandResult, error) {
-	_ = lookupSpec
-	return a.invokeTypedJSON(ctx, cfg, commandName, commandID, map[string]string{pathParamName: rawID}, query, body)
+	pathParams := map[string]string{pathParamName: rawID}
+	result, err := a.invokeTypedJSON(ctx, cfg, commandName, commandID, pathParams, query, body)
+	if err == nil || !isRemoteNotFound(err) || strings.TrimSpace(rawID) == "" {
+		return result, err
+	}
+	resolvedID, resolveErr := a.resolveUniqueResourcePrefix(ctx, cfg, lookupSpec, rawID, pathParams)
+	if resolveErr != nil {
+		return nil, resolveErr
+	}
+	if strings.TrimSpace(resolvedID) == "" || resolvedID == rawID {
+		return result, err
+	}
+	pathParams[pathParamName] = resolvedID
+	return a.invokeTypedJSON(ctx, cfg, commandName, commandID, pathParams, query, body)
 }
 
 func (a *App) invokeArtifactContentWithIDResolution(
@@ -318,8 +331,189 @@ func (a *App) invokeArtifactContentWithIDResolution(
 	lookupSpec resourceIDLookupSpec,
 	outputPath string,
 ) (*commandResult, error) {
-	_ = lookupSpec
-	return a.invokeArtifactContent(ctx, cfg, commandName, map[string]string{pathParamName: rawID}, outputPath)
+	pathParams := map[string]string{pathParamName: rawID}
+	result, err := a.invokeArtifactContent(ctx, cfg, commandName, pathParams, outputPath)
+	if err == nil || !isRemoteNotFound(err) || strings.TrimSpace(rawID) == "" {
+		return result, err
+	}
+	resolvedID, resolveErr := a.resolveUniqueResourcePrefix(ctx, cfg, lookupSpec, rawID, pathParams)
+	if resolveErr != nil {
+		return nil, resolveErr
+	}
+	if strings.TrimSpace(resolvedID) == "" || resolvedID == rawID {
+		return result, err
+	}
+	pathParams[pathParamName] = resolvedID
+	return a.invokeArtifactContent(ctx, cfg, commandName, pathParams, outputPath)
+}
+
+func isRemoteNotFound(err error) bool {
+	var normalized *errnorm.Error
+	if !errors.As(err, &normalized) || normalized == nil {
+		return false
+	}
+	if normalized.Code == "not_found" {
+		return true
+	}
+	details, _ := normalized.Details.(map[string]any)
+	switch status := details["status"].(type) {
+	case int:
+		return status == http.StatusNotFound
+	case float64:
+		return int(status) == http.StatusNotFound
+	default:
+		return false
+	}
+}
+
+func (a *App) resolveUniqueResourcePrefix(ctx context.Context, cfg config.Resolved, spec resourceIDLookupSpec, rawID string, originalPathParams map[string]string) (string, error) {
+	rawID = strings.TrimSpace(rawID)
+	if rawID == "" || strings.TrimSpace(spec.listCommandID) == "" || strings.TrimSpace(spec.listField) == "" {
+		return "", nil
+	}
+	listPathParams := map[string]string{}
+	if commandSpec, ok := commandSpecByID(spec.listCommandID); ok {
+		for _, param := range commandSpec.PathParams {
+			if value := strings.TrimSpace(originalPathParams[param]); value != "" {
+				listPathParams[param] = value
+			}
+		}
+	}
+	listResult, err := a.invokeTypedJSON(ctx, cfg, spec.listCommand, spec.listCommandID, listPathParams, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	matches := uniqueResourcePrefixMatches(commandResultBody(listResult), spec, rawID)
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0].resolvedID, nil
+	default:
+		labels := make([]string, 0, len(matches))
+		for _, match := range matches {
+			labels = append(labels, match.label)
+		}
+		sort.Strings(labels)
+		return "", errnorm.Usage(
+			"ambiguous_resource_prefix",
+			fmt.Sprintf("%s prefix %q matched multiple %s: %s", spec.idLabel, rawID, spec.resourcePlural, strings.Join(labels, ", ")),
+		)
+	}
+}
+
+type resourcePrefixMatch struct {
+	resolvedID string
+	label      string
+}
+
+func uniqueResourcePrefixMatches(body map[string]any, spec resourceIDLookupSpec, rawID string) []resourcePrefixMatch {
+	items, _ := body[spec.listField].([]any)
+	if len(items) == 0 {
+		return nil
+	}
+	rawKind, rawValue, _, typedErr := parseTypedRef(rawID)
+	if typedErr == nil && canonicalResourceKind(rawKind) == canonicalResourceKind(spec.resource) {
+		rawID = rawValue
+	}
+	rawID = strings.TrimSpace(rawID)
+	if rawID == "" {
+		return nil
+	}
+	matchesByID := map[string]resourcePrefixMatch{}
+	for _, rawItem := range items {
+		item, _ := rawItem.(map[string]any)
+		target := resourceLookupTarget(item, spec)
+		if target == nil {
+			continue
+		}
+		candidates := resourceLookupCandidates(target, spec.resource)
+		if !resourceLookupMatches(candidates, rawID) {
+			continue
+		}
+		resolvedID := preferredLookupID(target, spec.resource)
+		if resolvedID == "" {
+			continue
+		}
+		matchesByID[resolvedID] = resourcePrefixMatch{resolvedID: resolvedID, label: firstNonEmpty(preferredLookupLabel(target, spec.resource), resolvedID)}
+	}
+	matches := make([]resourcePrefixMatch, 0, len(matchesByID))
+	for _, match := range matchesByID {
+		matches = append(matches, match)
+	}
+	return matches
+}
+
+func resourceLookupTarget(item map[string]any, spec resourceIDLookupSpec) map[string]any {
+	if item == nil {
+		return nil
+	}
+	target := item
+	if len(spec.idFieldPath) > 1 {
+		for _, segment := range spec.idFieldPath[:len(spec.idFieldPath)-1] {
+			next, _ := target[segment].(map[string]any)
+			if next == nil {
+				return item
+			}
+			target = next
+		}
+	}
+	return target
+}
+
+func resourceLookupCandidates(item map[string]any, kind string) []string {
+	kind = canonicalResourceKind(kind)
+	values := []string{
+		anyString(item["ref"]),
+		refID(anyString(item["ref"])),
+		anyString(item["handle"]),
+		anyString(item[kind+"_ref"]),
+		refID(anyString(item[kind+"_ref"])),
+		anyString(item[kind+"_handle"]),
+		anyString(item["id"]),
+	}
+	return normalizeStringFilters(values)
+}
+
+func resourceLookupMatches(candidates []string, rawID string) bool {
+	rawID = strings.ToLower(strings.TrimSpace(rawID))
+	if rawID == "" {
+		return false
+	}
+	for _, candidate := range candidates {
+		candidate = strings.ToLower(strings.TrimSpace(candidate))
+		if candidate == rawID || strings.HasPrefix(candidate, rawID) {
+			return true
+		}
+	}
+	return false
+}
+
+func preferredLookupID(item map[string]any, kind string) string {
+	if ref := strings.TrimSpace(anyString(item["ref"])); ref != "" {
+		return ref
+	}
+	if handle := strings.TrimSpace(anyString(item["handle"])); handle != "" {
+		return handle
+	}
+	kind = canonicalResourceKind(kind)
+	if ref := strings.TrimSpace(anyString(item[kind+"_ref"])); ref != "" {
+		return ref
+	}
+	if handle := strings.TrimSpace(anyString(item[kind+"_handle"])); handle != "" {
+		return handle
+	}
+	return strings.TrimSpace(anyString(item["id"]))
+}
+
+func preferredLookupLabel(item map[string]any, kind string) string {
+	if ref := strings.TrimSpace(anyString(item["ref"])); ref != "" {
+		return ref
+	}
+	if handle := strings.TrimSpace(anyString(item["handle"])); handle != "" {
+		return canonicalResourceKind(kind) + ":" + handle
+	}
+	return publicRefFromID(kind, anyString(item["id"]))
 }
 
 func (a *App) invokeArtifactAttachmentCreate(ctx context.Context, cfg config.Resolved, refsJSON, filePath, summary, artifactJSON, actorID string) (*commandResult, error) {

--- a/cli/internal/app/text_output.go
+++ b/cli/internal/app/text_output.go
@@ -1892,7 +1892,11 @@ func formatBoardCardCreateResult(body any) string {
 	if subject == "" {
 		subject = "card"
 	}
-	lines = append(lines, "- "+subject)
+	if strings.HasPrefix(subject, "card:") {
+		lines = append(lines, "- "+subject)
+	} else {
+		lines = append(lines, "- card: "+subject)
+	}
 	if threadID := threadRefFromCard(card); threadID != "" && threadID != cardID {
 		lines = append(lines, "  "+threadID)
 	}

--- a/cli/internal/app/text_output.go
+++ b/cli/internal/app/text_output.go
@@ -1827,27 +1827,34 @@ func formatBoardCardBoardAndCardSummary(body any, headline string) string {
 		lines = appendScalar(lines, "board_updated_at", board, "updated_at")
 	}
 	if card != nil {
+		cardID := strings.TrimSpace(anyString(card["id"]))
+		title := strings.TrimSpace(anyString(card["title"]))
+		subject := displayPublicIdentity(card, "card")
+		if subject == "(unknown)" {
+			subject = cardID
+		}
+		if title != "" && title != subject {
+			if subject != "" {
+				subject = subject + " — " + title
+			} else {
+				subject = title
+			}
+		}
+		if subject == "" {
+			subject = "standalone card"
+		}
+		if strings.HasPrefix(subject, "card:") {
+			lines = append(lines, "- "+subject)
+		} else {
+			lines = append(lines, "- card: "+subject)
+		}
 		threadID := strings.TrimSpace(anyString(card["thread_id"]))
 		if threadID != "" {
-			lines = append(lines, "- thread: "+threadID)
-		} else {
-			cardID := strings.TrimSpace(anyString(card["id"]))
-			title := strings.TrimSpace(anyString(card["title"]))
-			subject := displayPublicIdentity(card, "card")
-			if subject == "(unknown)" {
-				subject = cardID
+			if strings.HasPrefix(threadID, "thread:") {
+				lines = append(lines, "  "+threadID)
+			} else {
+				lines = append(lines, "  thread: "+threadID)
 			}
-			if title != "" && title != subject {
-				if subject != "" {
-					subject = subject + " — " + title
-				} else {
-					subject = title
-				}
-			}
-			if subject == "" {
-				subject = "standalone card"
-			}
-			lines = append(lines, "- card: "+subject)
 		}
 		lines = append(lines, "  column: "+anyString(card["column_key"]))
 		lines = append(lines, "  rank: "+anyString(card["rank"]))
@@ -1885,9 +1892,9 @@ func formatBoardCardCreateResult(body any) string {
 	if subject == "" {
 		subject = "card"
 	}
-	lines = append(lines, "- card: "+subject)
+	lines = append(lines, "- "+subject)
 	if threadID := threadRefFromCard(card); threadID != "" && threadID != cardID {
-		lines = append(lines, "  thread: "+threadID)
+		lines = append(lines, "  "+threadID)
 	}
 	lines = append(lines, "  column: "+anyString(card["column_key"]))
 	lines = append(lines, "  rank: "+anyString(card["rank"]))

--- a/cli/internal/app/text_output_test.go
+++ b/cli/internal/app/text_output_test.go
@@ -19,7 +19,7 @@ func TestFormatBoardCardRemoveResult_WithCardThreadBacked(t *testing.T) {
 	if !strings.Contains(got, "Card removed:") {
 		t.Fatalf("expected headline, got %q", got)
 	}
-	if !strings.Contains(got, "- thread: thread_abc123") {
+	if !strings.Contains(got, "- card: standalone card") || !strings.Contains(got, "thread: thread_abc123") {
 		t.Fatalf("expected thread line, got %q", got)
 	}
 	if !strings.Contains(got, "column: ready") {
@@ -46,7 +46,7 @@ func TestFormatBoardCardCreateResult_IsConciseAndShowsCardRef(t *testing.T) {
 	if strings.Contains(got, `"card"`) || strings.Contains(got, "thread_1234567890abcdef") || strings.Contains(got, "card_12345") {
 		t.Fatalf("expected concise text create output, got:\n%s", got)
 	}
-	if !strings.Contains(got, "Card created:") || !strings.Contains(got, "- card: card:fix-cli-card-discovery — Fix CLI card discovery") || !strings.Contains(got, "thread: thread:cli-card-discovery") {
+	if !strings.Contains(got, "Card created:") || !strings.Contains(got, "- card:fix-cli-card-discovery — Fix CLI card discovery") || !strings.Contains(got, "thread:cli-card-discovery") {
 		t.Fatalf("expected card ref create output, got:\n%s", got)
 	}
 }
@@ -150,7 +150,7 @@ func TestFormatBoardCardRemoveResult_WithCardStandalone(t *testing.T) {
 	if strings.Contains(got, "card_xyz789") {
 		t.Fatalf("expected public card ref instead of internal id, got %q", got)
 	}
-	if !strings.Contains(got, "- card: card:standalone-task — Standalone task") {
+	if !strings.Contains(got, "- card:standalone-task — Standalone task") {
 		t.Fatalf("expected card line with ref and title, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- prefer public refs/handles when rendering shareable URLs, including card board segments
- add a conservative unique-prefix fallback after direct resource lookup returns not_found
- fix card create/move text readbacks so card identity leads without double prefixes

## Assessment
The real CLI ergonomics issues are URL/readback identity selection and long slug entry. Changing JSON `id` to mean slug would break the existing internal-id contract; JSON already carries `ref` and `handle`, so this PR leaves `id` intact. New-resource slug generation, artifact nanoid fallback, and emoji slug behavior are core-side concerns rather than CLI fixes.

## Verification
- make cli-check
- go run ./cmd/anx url card slug-v0-9-0-follow-up-url-gaps-json-consistency-and-edge-cases
