### PR TITLE
Docs lifecycle: add --reason flag to trash, improve help text discovery

### DIFF
--- a/cli/docs/generated/runtime-help.md
+++ b/cli/docs/generated/runtime-help.md
@@ -65,7 +65,6 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `docs get` (command): Get document
 - `docs history` (command): List document revisions
 - `docs revision` (group): Nested generated help topic.
-- `docs trash` (command): Move document to trash
 - `docs archive` (command): Archive document
 - `docs unarchive` (command): Unarchive document
 - `docs restore` (command): Restore document from trash
@@ -149,6 +148,7 @@ This reference is bundled with the CLI. Print the full document with `anx meta d
 - `boards cards list` (local-helper): List all cards on a board in canonical column order without hydrating thread details.
 - `workspace summary` (local-helper): First-run workspace orientation: boards plus compact card/doc/inbox counts.
 - `docs revise` (local-helper): Revise a durable document from a local file or JSON body; stages a diff proposal by default.
+- `docs trash` (local-helper): Trash a document lineage with `--reason`, advanced JSON via `--from-file`, or both (flags overlay JSON).
 - `docs content` (local-helper): Show the current document content together with authoritative head revision metadata.
 - `docs messages` (local-helper): List messages from a Document conversation.
 - `docs message` (local-helper): Post a message to a Document conversation without hand-authoring event JSON.
@@ -2517,37 +2517,6 @@ Global flags:
 Tip: `anx help <command path>` for full command-level generated details.
 ```
 
-## `docs trash`
-
-Move document to trash
-
-```text
-Generated Help: docs trash
-
-- Command ID: `docs.trash`
-- CLI path: `docs trash`
-- HTTP: `POST /docs/{document_id}/trash`
-- Stability: `beta`
-- Input mode: `json-body`
-- Why: Move a document lineage to trash with an explicit operator reason.
-- Output: Returns `{ document, revision }`.
-- Error codes: `auth_required`, `invalid_request`, `invalid_token`, `not_found`, `conflict`
-- Concepts: `docs`, `write`
-- Adjacent commands: `docs archive`, `docs create`, `docs get`, `docs history`, `docs list`, `docs patch`, `docs purge`, `docs restore`, `docs revise`, `docs revision get`, `docs unarchive`
-
-Inputs:
-  Required:
-  - path `document_id`
-  - body `reason` (string)
-  Optional:
-  - body `actor_id` (string)
-
-Global flags:
-  Global flags can appear before or after the command path.
-  Examples: anx docs trash ... ; anx --json docs trash ... ; anx docs trash ... --json (last two: JSON envelope on stdout)
-  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
-```
-
 ## `docs archive`
 
 Archive document
@@ -4348,6 +4317,31 @@ Global flags:
 Create a durable document lineage, with a file-first text-doc path for agents.
 
 ```text
+Local Help: docs create
+
+- Kind: `local helper`
+- Summary: Create a durable document lineage, with a file-first text-doc path for agents.
+- Quick start: Flags: `--topic <topic-ref-or-handle> --title <text> --body-file <path>`; use `--body <text>` for short inline content or `--from-file <path>` for advanced JSON.
+- Composition: Builds the same `docs.create` request as the generated command. For ordinary text docs, prefer flags so agents can draft Markdown locally without hand-authoring JSON.
+- JSON body: Either flags plus `--body-file`, or advanced JSON body `{ document, content, content_type }` from stdin/--from-file.
+- Examples:
+  - `anx docs create --topic topic:<topic-handle> --title "Runbook" --body-file runbook.md`
+  - `anx docs create --topic topic:<topic-handle> --title "Note" --body "Short update"`
+  - `anx docs create --subject-ref topic:<topic-handle> --title "Runbook" --summary "Durable context" --body-file runbook.md`
+  - `cat doc-create.json | anx docs create`
+
+Flags:
+  --topic <topic-ref-or-handle> Anchor the document to a topic typed ref or handle.
+  --subject-ref <typed-ref>    Explicit document subject ref when not using --topic.
+  --title <text>               Document title for flag-built text docs.
+  --summary <text>             Optional document summary for list/detail headers.
+  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
+  --ref <typed-ref>            Additional typed ref (repeatable).
+  --body-file <path>           Load Markdown/text content from a local file, or stdin with `-`.
+  --body <text>                Inline document body text (Markdown/text) when not using --body-file.
+  --from-file <path>           Advanced JSON request body from file.
+  --dry-run                    Validate and render the request without sending it.
+
 Generated Help: docs create
 
 - Command ID: `docs.create`
@@ -4377,30 +4371,6 @@ Inputs:
   - body `refs` (list<any>)
   - body `request_key` (string)
   Enum values: content_type: binary, structured, text
-
-Local Help: docs create
-
-- Kind: `local helper`
-- Summary: Create a durable document lineage, with a file-first text-doc path for agents.
-- Composition: Builds the same `docs.create` request as the generated command. For ordinary text docs, prefer flags so agents can draft Markdown locally without hand-authoring JSON.
-- JSON body: Either flags plus `--body-file`, or advanced JSON body `{ document, content, content_type }` from stdin/--from-file.
-- Examples:
-  - `anx docs create --topic topic:<topic-handle> --title "Runbook" --body-file runbook.md`
-  - `anx docs create --topic topic:<topic-handle> --title "Note" --body "Short update"`
-  - `anx docs create --subject-ref topic:<topic-handle> --title "Runbook" --summary "Durable context" --body-file runbook.md`
-  - `cat doc-create.json | anx docs create`
-
-Flags:
-  --topic <topic-ref-or-handle> Anchor the document to a topic typed ref or handle.
-  --subject-ref <typed-ref>    Explicit document subject ref when not using --topic.
-  --title <text>               Document title for flag-built text docs.
-  --summary <text>             Optional document summary for list/detail headers.
-  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
-  --ref <typed-ref>            Additional typed ref (repeatable).
-  --body-file <path>           Load Markdown/text content from a local file, or stdin with `-`.
-  --body <text>                Inline document body text (Markdown/text) when not using --body-file.
-  --from-file <path>           Advanced JSON request body from file.
-  --dry-run                    Validate and render the request without sending it.
 
 Global flags:
   Global flags can appear before or after the command path.
@@ -5384,6 +5354,28 @@ Global flags:
 Revise a durable document from a local file or JSON body; stages a diff proposal by default.
 
 ```text
+Local Help: docs revise
+
+- Kind: `local helper`
+- Summary: Revise a durable document from a local file or JSON body; stages a diff proposal by default.
+- Quick start: Flags: `docs revise <doc-ref> --body-file <path>` stages a proposal; add `--apply` to write immediately.
+- Composition: Fetches the current document revision, discovers the base revision when omitted, computes a local diff, and stages a proposal. Add `--apply` to direct-write the revision; use `--apply --proposal-id <id>` to apply a staged proposal.
+- JSON body: Proposal mode returns `proposal_id`, `target_command_id`, `path`, `body`, `diff`, `apply_command`; `--apply` sends the revision immediately or applies a staged proposal.
+- Examples:
+  - `anx docs revise doc:runbook --body-file notes.md`
+  - `anx docs revise --apply --proposal-id <proposal-id>`
+  - `anx docs revise doc:runbook --apply --body-file notes.md`
+  - `cat revision.json | anx docs revise doc:runbook`
+
+Flags:
+  <ref>                        Document ref, alias, or id to revise.
+  --body-file <path>           Load revised Markdown/text content from a local file or stdin with `-`.
+  --from-file <path>           Advanced JSON revision body from a file.
+  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
+  --apply                      Apply immediately, or apply a staged proposal when combined with --proposal-id.
+  --proposal-id <proposal-id>  Staged proposal id to apply; must be combined with --apply.
+  --propose                    Stage a proposal (default; included for explicitness).
+
 Generated Help: docs revise
 
 - Command ID: `docs.revisions.create`
@@ -5412,30 +5404,58 @@ Inputs:
   - body `refs` (list<any>)
   Enum values: content_type: binary, structured, text
 
-Local Help: docs revise
-
-- Kind: `local helper`
-- Summary: Revise a durable document from a local file or JSON body; stages a diff proposal by default.
-- Composition: Fetches the current document revision, discovers the base revision when omitted, computes a local diff, and stages a proposal. Add `--apply` to direct-write the revision; use `--apply --proposal-id <id>` to apply a staged proposal.
-- JSON body: Proposal mode returns `proposal_id`, `target_command_id`, `path`, `body`, `diff`, `apply_command`; `--apply` sends the revision immediately or applies a staged proposal.
-- Examples:
-  - `anx docs revise doc:runbook --body-file notes.md`
-  - `anx docs revise --apply --proposal-id <proposal-id>`
-  - `anx docs revise doc:runbook --apply --body-file notes.md`
-  - `cat revision.json | anx docs revise doc:runbook`
-
-Flags:
-  <ref>                        Document ref, alias, or id to revise.
-  --body-file <path>           Load revised Markdown/text content from a local file or stdin with `-`.
-  --from-file <path>           Advanced JSON revision body from a file.
-  --actor-id <actor-id>        Actor id; defaults from the active profile when available.
-  --apply                      Apply immediately, or apply a staged proposal when combined with --proposal-id.
-  --proposal-id <proposal-id>  Staged proposal id to apply; must be combined with --apply.
-  --propose                    Stage a proposal (default; included for explicitness).
-
 Global flags:
   Global flags can appear before or after the command path.
   Examples: anx docs revise ... ; anx --json docs revise ... ; anx docs revise ... --json (last two: JSON envelope on stdout)
+  Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
+```
+
+## `docs trash`
+
+Trash a document lineage with `--reason`, advanced JSON via `--from-file`, or both (flags overlay JSON).
+
+```text
+Local Help: docs trash
+
+- Kind: `local helper`
+- Summary: Trash a document lineage with `--reason`, advanced JSON via `--from-file`, or both (flags overlay JSON).
+- Quick start: Flags: `docs trash <doc-ref> --reason <text>`; `--from-file <path>` remains the advanced JSON compatibility path.
+- Composition: Uses the shared lifecycle parser (`lifecycle_spec.go`). Routine trashing prefers `--reason`; JSON input remains supported for existing automation.
+- JSON body: `{ reason, actor_id?, ... }` from `--from-file`, merged with `--reason` / `--actor-id` flags.
+- Examples:
+  - `anx docs trash doc:runbook --reason "superseded"`
+  - `cat trash.json | anx docs trash doc:runbook --from-file=-`
+
+Flags:
+  <ref>                        Document ref, handle, or id to trash.
+  --reason <text>              Reason for trashing the document.
+  --from-file <path>           Advanced JSON request body from file or stdin (`-`).
+  --actor-id <actor-id>        Actor id; overlays JSON and defaults from profile when omitted.
+  --dry-run                    Validate and render the request without sending it.
+
+Generated Help: docs trash
+
+- Command ID: `docs.trash`
+- CLI path: `docs trash`
+- HTTP: `POST /docs/{document_id}/trash`
+- Stability: `beta`
+- Input mode: `json-body`
+- Why: Move a document lineage to trash with an explicit operator reason.
+- Output: Returns `{ document, revision }`.
+- Error codes: `auth_required`, `invalid_request`, `invalid_token`, `not_found`, `conflict`
+- Concepts: `docs`, `write`
+- Adjacent commands: `docs archive`, `docs create`, `docs get`, `docs history`, `docs list`, `docs patch`, `docs purge`, `docs restore`, `docs revise`, `docs revision get`, `docs unarchive`
+
+Inputs:
+  Required:
+  - path `document_id`
+  - body `reason` (string)
+  Optional:
+  - body `actor_id` (string)
+
+Global flags:
+  Global flags can appear before or after the command path.
+  Examples: anx docs trash ... ; anx --json docs trash ... ; anx docs trash ... --json (last two: JSON envelope on stdout)
   Available: --json, --base-url <url>, --agent <name>, --no-color, --verbose, --headers, --timeout <duration>
 ```
 
@@ -5505,6 +5525,7 @@ Local Help: docs message
 
 - Kind: `local helper`
 - Summary: Post a message to a Document conversation without hand-authoring event JSON.
+- Quick start: Flags: `docs message <doc-ref> --body-file <path>` or `--body <text>` for short updates.
 - Composition: Fetches the Document to discover its backing thread, then writes a visible `message_posted` event attached to that document.
 - JSON body: Builds an `events.create` body with `event.type=message_posted`, document/thread refs, profile actor, and payload text.
 - Examples:
@@ -5536,6 +5557,7 @@ Local Help: docs reply
 
 - Kind: `local helper`
 - Summary: Reply to an existing Document message.
+- Quick start: Flags: `docs reply <doc-ref> --to <message-id> --body-file <path>` or `--body <text>`.
 - Composition: Fetches the Document and validates the target message exists on its backing thread before posting the reply.
 - JSON body: Builds an `events.create` body like `docs message` and adds `payload.reply_to_event_id` plus an `event:launch-update` ref.
 - Examples:

--- a/cli/internal/app/help_generated.go
+++ b/cli/internal/app/help_generated.go
@@ -21,6 +21,7 @@ type localHelperFlag struct {
 type localHelperTopic struct {
 	Path        string
 	Summary     string
+	QuickStart  string
 	JSONShape   string
 	Composition string
 	Examples    []string
@@ -205,6 +206,7 @@ var localHelperTopics = []localHelperTopic{
 	{
 		Path:        "docs create",
 		Summary:     "Create a durable document lineage, with a file-first text-doc path for agents.",
+		QuickStart:  "Flags: `--topic <topic-ref-or-handle> --title <text> --body-file <path>`; use `--body <text>` for short inline content or `--from-file <path>` for advanced JSON.",
 		JSONShape:   "Either flags plus `--body-file`, or advanced JSON body `{ document, content, content_type }` from stdin/--from-file.",
 		Composition: "Builds the same `docs.create` request as the generated command. For ordinary text docs, prefer flags so agents can draft Markdown locally without hand-authoring JSON.",
 		Examples: []string{
@@ -653,6 +655,7 @@ var localHelperTopics = []localHelperTopic{
 	{
 		Path:        "docs revise",
 		Summary:     "Revise a durable document from a local file or JSON body; stages a diff proposal by default.",
+		QuickStart:  "Flags: `docs revise <doc-ref> --body-file <path>` stages a proposal; add `--apply` to write immediately.",
 		JSONShape:   "Proposal mode returns `proposal_id`, `target_command_id`, `path`, `body`, `diff`, `apply_command`; `--apply` sends the revision immediately or applies a staged proposal.",
 		Composition: "Fetches the current document revision, discovers the base revision when omitted, computes a local diff, and stages a proposal. Add `--apply` to direct-write the revision; use `--apply --proposal-id <id>` to apply a staged proposal.",
 		Examples: []string{
@@ -669,6 +672,24 @@ var localHelperTopics = []localHelperTopic{
 			{Name: "--apply", Description: "Apply immediately, or apply a staged proposal when combined with --proposal-id."},
 			{Name: "--proposal-id <proposal-id>", Description: "Staged proposal id to apply; must be combined with --apply."},
 			{Name: "--propose", Description: "Stage a proposal (default; included for explicitness)."},
+		},
+	},
+	{
+		Path:        "docs trash",
+		Summary:     "Trash a document lineage with `--reason`, advanced JSON via `--from-file`, or both (flags overlay JSON).",
+		QuickStart:  "Flags: `docs trash <doc-ref> --reason <text>`; `--from-file <path>` remains the advanced JSON compatibility path.",
+		JSONShape:   "`{ reason, actor_id?, ... }` from `--from-file`, merged with `--reason` / `--actor-id` flags.",
+		Composition: "Uses the shared lifecycle parser (`lifecycle_spec.go`). Routine trashing prefers `--reason`; JSON input remains supported for existing automation.",
+		Examples: []string{
+			"anx docs trash doc:runbook --reason \"superseded\"",
+			"cat trash.json | anx docs trash doc:runbook --from-file=-",
+		},
+		Flags: []localHelperFlag{
+			{Name: "<ref>", Description: "Document ref, handle, or id to trash."},
+			{Name: "--reason <text>", Description: "Reason for trashing the document."},
+			{Name: "--from-file <path>", Description: "Advanced JSON request body from file or stdin (`-`)."},
+			{Name: "--actor-id <actor-id>", Description: "Actor id; overlays JSON and defaults from profile when omitted."},
+			{Name: "--dry-run", Description: "Validate and render the request without sending it."},
 		},
 	},
 	{
@@ -707,6 +728,7 @@ var localHelperTopics = []localHelperTopic{
 	{
 		Path:        "docs message",
 		Summary:     "Post a message to a Document conversation without hand-authoring event JSON.",
+		QuickStart:  "Flags: `docs message <doc-ref> --body-file <path>` or `--body <text>` for short updates.",
 		JSONShape:   "Builds an `events.create` body with `event.type=message_posted`, document/thread refs, profile actor, and payload text.",
 		Composition: "Fetches the Document to discover its backing thread, then writes a visible `message_posted` event attached to that document.",
 		Examples: []string{
@@ -726,6 +748,7 @@ var localHelperTopics = []localHelperTopic{
 	{
 		Path:        "docs reply",
 		Summary:     "Reply to an existing Document message.",
+		QuickStart:  "Flags: `docs reply <doc-ref> --to <message-id> --body-file <path>` or `--body <text>`.",
 		JSONShape:   "Builds an `events.create` body like `docs message` and adds `payload.reply_to_event_id` plus an `event:launch-update` ref.",
 		Composition: "Fetches the Document and validates the target message exists on its backing thread before posting the reply.",
 		Examples: []string{
@@ -988,6 +1011,9 @@ func generatedHelpText(topic string) (string, bool) {
 		if exactOK && runtimeSupportsCommand(exact.CommandID) {
 			gen := formatGeneratedCommandHelp(topic, exact, false)
 			local := formatLocalHelperHelp(helper, false)
+			if strings.HasPrefix(topic, "docs ") {
+				return strings.TrimSpace(local + "\n\n" + gen + "\n\n" + formatGlobalFlagUsage(topic)), true
+			}
 			return strings.TrimSpace(gen + "\n\n" + local + "\n\n" + formatGlobalFlagUsage(topic)), true
 		}
 		return formatLocalHelperHelp(helper, true), true
@@ -1187,6 +1213,9 @@ func formatLocalHelperHelp(topic localHelperTopic, includeGlobalFlags bool) stri
 	b.WriteString(fmt.Sprintf("Local Help: %s\n\n", strings.TrimSpace(topic.Path)))
 	b.WriteString("- Kind: `local helper`\n")
 	b.WriteString(fmt.Sprintf("- Summary: %s\n", strings.TrimSpace(topic.Summary)))
+	if strings.TrimSpace(topic.QuickStart) != "" {
+		b.WriteString(fmt.Sprintf("- Quick start: %s\n", strings.TrimSpace(topic.QuickStart)))
+	}
 	if strings.TrimSpace(topic.Composition) != "" {
 		b.WriteString(fmt.Sprintf("- Composition: %s\n", strings.TrimSpace(topic.Composition)))
 	}

--- a/cli/internal/app/lifecycle_runtime.go
+++ b/cli/internal/app/lifecycle_runtime.go
@@ -165,5 +165,5 @@ func lifecycleTrashRequiresReasonOrJSON(resource, verb string) bool {
 	if verb != "trash" {
 		return false
 	}
-	return resource == "topics" || resource == "cards"
+	return resource == "topics" || resource == "cards" || resource == "docs"
 }

--- a/cli/internal/app/meta_help_test.go
+++ b/cli/internal/app/meta_help_test.go
@@ -574,11 +574,29 @@ func TestDocsCreateHelpUsesFileFirstLocalHelp(t *testing.T) {
 	if !strings.Contains(output, "Local Help: docs create") {
 		t.Fatalf("expected local docs create help, got output=%s", output)
 	}
+	if quickIdx, inputsIdx := strings.Index(output, "Quick start:"), strings.Index(output, "Inputs:"); quickIdx < 0 || inputsIdx < 0 || quickIdx > inputsIdx {
+		t.Fatalf("expected docs create quick start before generated JSON inputs output=%s", output)
+	}
 	if !strings.Contains(output, "--topic <topic-ref-or-handle>") || !strings.Contains(output, "--body-file <path>") {
 		t.Fatalf("expected file-first docs create flags output=%s", output)
 	}
 	if strings.Contains(output, "document.body_markdown") {
 		t.Fatalf("unexpected stale body_markdown help output=%s", output)
+	}
+}
+
+func TestDocsTrashHelpLeadsWithReasonFlag(t *testing.T) {
+	t.Parallel()
+
+	output := runHelpCommand(t, "help", "docs", "trash")
+	if !strings.Contains(output, "Local Help: docs trash") {
+		t.Fatalf("expected local docs trash help, got output=%s", output)
+	}
+	if quickIdx, inputsIdx := strings.Index(output, "Quick start:"), strings.Index(output, "Inputs:"); quickIdx < 0 || inputsIdx < 0 || quickIdx > inputsIdx {
+		t.Fatalf("expected docs trash quick start before generated JSON inputs output=%s", output)
+	}
+	if !strings.Contains(output, "docs trash <doc-ref> --reason <text>") || !strings.Contains(output, "--from-file <path>") {
+		t.Fatalf("expected docs trash reason/from-file flag guidance output=%s", output)
 	}
 }
 

--- a/cli/internal/app/resource_commands_test.go
+++ b/cli/internal/app/resource_commands_test.go
@@ -3369,6 +3369,37 @@ func TestLifecycleVerbDryRunUniformFlags(t *testing.T) {
 	}
 }
 
+func TestDocsTrashRequiresReasonFlagOrJSONBody(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeAgentProfile(t, home, "agent-docs-trash", `{"agent":"agent-docs-trash","actor_id":"actor_docs_trash","access_token":"token","access_token_expires_at":"2099-01-01T00:00:00Z"}`)
+	base := []string{"--json", "--base-url", "http://127.0.0.1:9", "--agent", "agent-docs-trash", "docs", "trash", "document_docs_trash_1"}
+
+	payload := assertEnvelopeOK(t, runCLIForTest(t, home, nil, nil, append(base, "--reason", "superseded", "--dry-run")))
+	data := asMap(payload["data"])
+	body := asMap(data["body"])
+	if got := anyStringValue(body["reason"]); got != "superseded" {
+		t.Fatalf("expected reason flag in dry-run body, got %#v", payload)
+	}
+
+	payload = assertEnvelopeOK(t, runCLIForTest(t, home, nil, strings.NewReader(`{"reason":"from-json"}`), append(base, "--from-file=-", "--dry-run")))
+	data = asMap(payload["data"])
+	body = asMap(data["body"])
+	if got := anyStringValue(body["reason"]); got != "from-json" {
+		t.Fatalf("expected JSON reason in dry-run body, got %#v", payload)
+	}
+
+	payload = assertEnvelopeError(t, runCLIForTest(t, home, nil, nil, append(base, "--dry-run")))
+	errPayload := asMap(payload["error"])
+	if got := anyStringValue(errPayload["code"]); got != "invalid_request" {
+		t.Fatalf("expected invalid_request for missing reason, got %#v", payload)
+	}
+	if msg := anyStringValue(errPayload["message"]); !strings.Contains(msg, "requires --reason or non-empty `--from-file` JSON body") {
+		t.Fatalf("expected missing reason guidance, got %#v", payload)
+	}
+}
+
 func TestTopicsMessageAcceptsBackingThreadAlias(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add first-class docs trash help for `--reason` while preserving `--from-file` JSON compatibility.
- Require docs trash dry-run/runtime validation to provide either `--reason` or a non-empty JSON body, matching the cards trash ergonomics.
- Put docs local helper guidance and quick-start flag summaries before generated JSON body requirements.

Closes ANX feature card: docs-lifecycle-trash-reason-flag-missing.

## Validation
- `cd cli && go build ./...`
- `cd cli && go test ./...`